### PR TITLE
Removing dependency from JitPack repository

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -39,8 +39,8 @@
             <artifactId>json</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.everit-org.json-schema</groupId>
-            <artifactId>org.everit.json.schema</artifactId>
+            <groupId>com.github.erosb</groupId>
+            <artifactId>everit-json-schema</artifactId>
         </dependency>
 
         <!-- test -->

--- a/pom.xml
+++ b/pom.xml
@@ -97,8 +97,8 @@
                 <version>${commons.lang.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.everit-org.json-schema</groupId>
-                <artifactId>org.everit.json.schema</artifactId>
+                <groupId>com.github.erosb</groupId>
+                <artifactId>everit-json-schema</artifactId>
                 <version>${json.schema.validation.version}</version>
             </dependency>
             <dependency>
@@ -265,11 +265,4 @@
             </snapshots>
         </pluginRepository>
     </pluginRepositories>
-
-    <repositories>
-        <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </repository>
-    </repositories>
 </project>

--- a/validation/pom.xml
+++ b/validation/pom.xml
@@ -31,8 +31,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.everit-org.json-schema</groupId>
-            <artifactId>org.everit.json.schema</artifactId>
+            <groupId>com.github.erosb</groupId>
+            <artifactId>everit-json-schema</artifactId>
         </dependency>
 
         <!-- test -->


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
In this PR, we remove the need to have the JitPack repository declared in our POM. Some companies do not allow adding or using libraries that are not uploaded to Maven Central. It can be a problem for our community. More Info: https://github.com/everit-org/json-schema/issues/360 

**Additional information (if needed):**
The JSON Schema library is exclusively distributed via JitPack, but they also upload to Maven Central under a different artifact and group id. Although it can take some time after the initial release, it's worth not to depend on third-party repositories.

```xml
        <dependency>
            <groupId>com.github.erosb</groupId>
            <artifactId>everit-json-schema</artifactId>
            <version>1.12.1</version>
        </dependency>
```