### PR TITLE
Replacing commons-logging with slf4j in transitive dependencies

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -19,6 +19,10 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,11 @@
                 <version>${version.org.slf4j}</version>
             </dependency>
             <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jcl-over-slf4j</artifactId>
+                <version>${version.org.slf4j}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
                 <version>${version.com.fasterxml.jackson}</version>
@@ -100,6 +105,12 @@
                 <groupId>com.github.erosb</groupId>
                 <artifactId>everit-json-schema</artifactId>
                 <version>${json.schema.validation.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.json</groupId>

--- a/validation/pom.xml
+++ b/validation/pom.xml
@@ -18,6 +18,10 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.serverlessworkflow</groupId>


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
Since the most used log framework is slf4j, and we are using it in our project, it doesn't make sense to bring another logging framework to our dependency list. One of our dependencies uses `commons-logging`. I just replaced it with a bridge to slf4j. So now, everything is logged using the same framework.