### PR TITLE
(bugsbash)fixes strings should not be compared with '=='

### DIFF
--- a/diagram/src/main/java/io/serverlessworkflow/diagram/model/ModelConnection.java
+++ b/diagram/src/main/java/io/serverlessworkflow/diagram/model/ModelConnection.java
@@ -33,9 +33,9 @@ public class ModelConnection {
     public String toString() {
         StringBuffer retBuff = new StringBuffer();
         retBuff.append(System.lineSeparator());
-        retBuff.append(left == WorkflowDiagramUtils.wfStart ? WorkflowDiagramUtils.startEnd : left);
+        retBuff.append(left.equals(WorkflowDiagramUtils.wfStart ? WorkflowDiagramUtils.startEnd : left));
         retBuff.append(WorkflowDiagramUtils.connection);
-        retBuff.append(right == WorkflowDiagramUtils.wfEnd ? WorkflowDiagramUtils.startEnd : right);
+        retBuff.append(right.equlas(WorkflowDiagramUtils.wfEnd ? WorkflowDiagramUtils.startEnd : right));
         if (desc != null && desc.trim().length() > 0) {
             retBuff.append(WorkflowDiagramUtils.description).append(desc);
         }

--- a/diagram/src/main/java/io/serverlessworkflow/diagram/model/ModelConnection.java
+++ b/diagram/src/main/java/io/serverlessworkflow/diagram/model/ModelConnection.java
@@ -33,9 +33,9 @@ public class ModelConnection {
     public String toString() {
         StringBuffer retBuff = new StringBuffer();
         retBuff.append(System.lineSeparator());
-        retBuff.append(left.equals(WorkflowDiagramUtils.wfStart ? WorkflowDiagramUtils.startEnd : left));
+        retBuff.append(left.equals(WorkflowDiagramUtils.wfStart) ? WorkflowDiagramUtils.startEnd : left);
         retBuff.append(WorkflowDiagramUtils.connection);
-        retBuff.append(right.equlas(WorkflowDiagramUtils.wfEnd ? WorkflowDiagramUtils.startEnd : right));
+        retBuff.append(right.equals(WorkflowDiagramUtils.wfEnd) ? WorkflowDiagramUtils.startEnd : right);
         if (desc != null && desc.trim().length() > 0) {
             retBuff.append(WorkflowDiagramUtils.description).append(desc);
         }


### PR DESCRIPTION
Signed-off-by: aSquare14 <atibhi.a@gmail.com>

**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
Fixes opt.semgrep.java.lang.correctness.no-string-eqeq.no-string-eqeq : Strings should not be compared with '=='. This is a reference comparison operator. Use '.equals()' instead.

**Special notes for reviewers**:

**Additional information (if needed):**