### PR TITLE
Adding muse dev config to ignore generated 2 java files from json  - BugBash

### DIFF
--- a/.muse.toml
+++ b/.muse.toml
@@ -1,0 +1,5 @@
+# Ignore results from target directory
+ignoreFiles = """
+**/target/generated-sources/src/main/java/io/serverlessworkflow/api/states/DefaultState.java
+**/target/generated-sources/src/main/java/io/serverlessworkflow/api/error/Error.java
+"""


### PR DESCRIPTION
Signed-off-by: janaganh <janagan.h@gmail.com>

**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**: Adding muse dev config to ignore generated 2 java files from json

**Special notes for reviewers**: NA

**Additional information (if needed):** NA