### PR TITLE
configure maven-jar-plugin to install test-jar so it can be used by r…

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -175,6 +175,18 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-jar-plugin</artifactId>
+               <version>3.2.0</version>
+               <executions>
+                   <execution>
+                       <goals>
+                           <goal>test-jar</goal>
+                       </goals>
+                   </execution>
+               </executions>
+           </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
…untimes as source of examples to run

**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

To be able to use examples used to test api to also test the runtimes that takes advantage of Java SDK of Serverless workflow 