### PR TITLE
Update to Java 11

### DIFF
--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Cache Maven packages
       uses: actions/cache@v2
       with:

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -103,7 +103,7 @@
                     <includeConstructors>true</includeConstructors>
                     <constructorsRequiredPropertiesOnly>true</constructorsRequiredPropertiesOnly>
                     <serializable>true</serializable>
-                    <targetVersion>1.8</targetVersion>
+                    <targetVersion>${java.version}</targetVersion>
                     <usePrimitives>true</usePrimitives>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -33,13 +33,13 @@
     </modules>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.maven>3.6.2</version.maven>
         <version.enforcer.plugin>3.0.0-M2</version.enforcer.plugin>
-        <version.jdk>8</version.jdk>
+        <version.jdk>${java.version}</version.jdk>
         <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <version.surefire.plugin>2.22.0</version.surefire.plugin>
         <version.failsafe.plugin>2.22.0</version.failsafe.plugin>


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Java **8** is quite old
- Let's update the project with **Java 11** version
- Updated all pom.xml to use placeholder
- Updated also github workflow

**Special notes for reviewers**:


**Additional information (if needed):**

Here is my output on my laptop


> [INFO] Serverless Workflow :: Parent ...................... SUCCESS [  0.277 s]
[INFO] Serverless Workflow :: API ......................... SUCCESS [ 11.516 s]
[INFO] Serverless Workflow :: SPI ......................... SUCCESS [  1.466 s]
[INFO] Serverless Workflow :: Validation .................. SUCCESS [  2.439 s]
[INFO] Serverless Workflow :: Diagram ..................... SUCCESS [ 11.380 s]
[INFO] Serverless Workflow :: Utils ....................... SUCCESS [  2.241 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  29.454 s
[INFO] Finished at: 2022-02-12T12:24:40+01:00
[INFO] ------------------------------------------------------------------------
➜  sdk-java git:(java11) java -version                          
openjdk version "11.0.12" 2021-07-20
OpenJDK Runtime Environment GraalVM CE 21.2.0 (build 11.0.12+6-jvmci-21.2-b08)
OpenJDK 64-Bit Server VM GraalVM CE 21.2.0 (build 11.0.12+6-jvmci-21.2-b08, mixed mode, sharing)
