### PR TITLE
Auth Workflow attribute supposed to be an array

### DIFF
--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/AuthDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/AuthDeserializer.java
@@ -84,17 +84,17 @@ public class AuthDeserializer extends StdDeserializer<Auth> {
           authRefNode = jsonWriter.readTree(new JSONObject(authFileSrc).toString());
         }
 
-        JsonNode refAuth = authRefNode.get("retries");
+        JsonNode refAuth = authRefNode.get("auth");
         if (refAuth != null) {
           for (final JsonNode nodeEle : refAuth) {
             authDefinitions.add(mapper.treeToValue(nodeEle, AuthDefinition.class));
           }
         } else {
-          logger.error("Unable to find retries definitions in reference file: {}", authFileSrc);
+          logger.error("Unable to find auth definitions in reference file: {}", authFileSrc);
         }
 
       } else {
-        logger.error("Unable to load retries defs reference file: {}", authFileSrc);
+        logger.error("Unable to load auth defs reference file: {}", authFileSrc);
       }
     }
     auth.setAuthDefs(authDefinitions);

--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/AuthDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/AuthDeserializer.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.api.deserializers;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.serverlessworkflow.api.auth.AuthDefinition;
+import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
+import io.serverlessworkflow.api.utils.Utils;
+import io.serverlessworkflow.api.workflow.Auth;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AuthDeserializer extends StdDeserializer<Auth> {
+
+  private static final long serialVersionUID = 520L;
+  private static Logger logger = LoggerFactory.getLogger(AuthDeserializer.class);
+
+  @SuppressWarnings("unused")
+  private WorkflowPropertySource context;
+
+  public AuthDeserializer() {
+    this(Auth.class);
+  }
+
+  public AuthDeserializer(Class<?> vc) {
+    super(vc);
+  }
+
+  public AuthDeserializer(WorkflowPropertySource context) {
+    this(Auth.class);
+    this.context = context;
+  }
+
+  @Override
+  public Auth deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+
+    ObjectMapper mapper = (ObjectMapper) jp.getCodec();
+    JsonNode node = jp.getCodec().readTree(jp);
+
+    Auth auth = new Auth();
+    List<AuthDefinition> authDefinitions = new ArrayList<>();
+
+    if (node.isArray()) {
+      for (final JsonNode nodeEle : node) {
+        authDefinitions.add(mapper.treeToValue(nodeEle, AuthDefinition.class));
+      }
+    } else {
+      String authFileDef = node.asText();
+      String authFileSrc = Utils.getResourceFileAsString(authFileDef);
+      JsonNode authRefNode;
+      ObjectMapper jsonWriter = new ObjectMapper();
+      if (authFileSrc != null && authFileSrc.trim().length() > 0) {
+        // if its a yaml def convert to json first
+        if (!authFileSrc.trim().startsWith("{")) {
+          // convert yaml to json to validate
+          ObjectMapper yamlReader = new ObjectMapper(new YAMLFactory());
+          Object obj = yamlReader.readValue(authFileSrc, Object.class);
+
+          authRefNode =
+              jsonWriter.readTree(new JSONObject(jsonWriter.writeValueAsString(obj)).toString());
+        } else {
+          authRefNode = jsonWriter.readTree(new JSONObject(authFileSrc).toString());
+        }
+
+        JsonNode refAuth = authRefNode.get("retries");
+        if (refAuth != null) {
+          for (final JsonNode nodeEle : refAuth) {
+            authDefinitions.add(mapper.treeToValue(nodeEle, AuthDefinition.class));
+          }
+        } else {
+          logger.error("Unable to find retries definitions in reference file: {}", authFileSrc);
+        }
+
+      } else {
+        logger.error("Unable to load retries defs reference file: {}", authFileSrc);
+      }
+    }
+    auth.setAuthDefs(authDefinitions);
+    return auth;
+  }
+}

--- a/api/src/main/java/io/serverlessworkflow/api/mapper/WorkflowModule.java
+++ b/api/src/main/java/io/serverlessworkflow/api/mapper/WorkflowModule.java
@@ -121,6 +121,7 @@ public class WorkflowModule extends SimpleModule {
         StateExecTimeout.class, new StateExecTimeoutDeserializer(workflowPropertySource));
     addDeserializer(Errors.class, new ErrorsDeserializer(workflowPropertySource));
     addDeserializer(ContinueAs.class, new ContinueAsDeserializer(workflowPropertySource));
+    addDeserializer(Auth.class, new AuthDeserializer(workflowPropertySource));
   }
 
   public ExtensionSerializer getExtensionSerializer() {

--- a/api/src/main/java/io/serverlessworkflow/api/serializers/WorkflowSerializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/serializers/WorkflowSerializer.java
@@ -167,8 +167,8 @@ public class WorkflowSerializer extends StdSerializer<Workflow> {
       gen.writeObjectField("timeouts", workflow.getTimeouts());
     }
 
-    if (workflow.getAuth() != null) {
-      gen.writeObjectField("auth", workflow.getAuth());
+    if (workflow.getAuth() != null && !workflow.getAuth().getAuthDefs().isEmpty()) {
+      gen.writeObjectField("auth", workflow.getAuth().getAuthDefs());
     }
 
     if (workflow.getStates() != null && !workflow.getStates().isEmpty()) {

--- a/api/src/main/java/io/serverlessworkflow/api/workflow/Auth.java
+++ b/api/src/main/java/io/serverlessworkflow/api/workflow/Auth.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.serverlessworkflow.api.workflow;
+
+import io.serverlessworkflow.api.auth.AuthDefinition;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Auth {
+  private String refValue;
+  private List<AuthDefinition> authDefs;
+
+  public Auth() {}
+
+  public Auth(AuthDefinition authDef) {
+    this.authDefs = new ArrayList<>();
+    this.authDefs.add(authDef);
+  }
+
+  public Auth(List<AuthDefinition> authDefs) {
+    this.authDefs = authDefs;
+  }
+
+  public Auth(String refValue) {
+    this.refValue = refValue;
+  }
+
+  public String getRefValue() {
+    return refValue;
+  }
+
+  public void setRefValue(String refValue) {
+    this.refValue = refValue;
+  }
+
+  public List<AuthDefinition> getAuthDefs() {
+    return authDefs;
+  }
+
+  public void setAuthDefs(List<AuthDefinition> authDefs) {
+    this.authDefs = authDefs;
+  }
+}

--- a/api/src/main/resources/schema/workflow.json
+++ b/api/src/main/resources/schema/workflow.json
@@ -100,7 +100,9 @@
       "$ref": "timeouts/timeoutsdef.json"
     },
     "auth": {
-      "$ref": "auth/auth.json"
+      "type": "object",
+      "existingJavaType": "io.serverlessworkflow.api.workflow.Auth",
+      "description": "Workflow Auth definitions"
     },
     "states": {
       "type": "array",

--- a/api/src/test/java/io/serverlessworkflow/api/test/MarkupToWorkflowTest.java
+++ b/api/src/test/java/io/serverlessworkflow/api/test/MarkupToWorkflowTest.java
@@ -627,7 +627,7 @@ public class MarkupToWorkflowTest {
     assertNotNull(workflow.getName());
 
     assertNotNull(workflow.getAuth());
-    AuthDefinition auth = workflow.getAuth();
+    AuthDefinition auth = workflow.getAuth().getAuthDefs().get(0);
     assertNotNull(auth.getName());
     assertEquals("authname", auth.getName());
     assertNotNull(auth.getScheme());
@@ -647,7 +647,7 @@ public class MarkupToWorkflowTest {
     assertNotNull(workflow.getName());
 
     assertNotNull(workflow.getAuth());
-    AuthDefinition auth = workflow.getAuth();
+    AuthDefinition auth = workflow.getAuth().getAuthDefs().get(0);
     assertNotNull(auth.getName());
     assertEquals("authname", auth.getName());
     assertNotNull(auth.getScheme());
@@ -666,7 +666,7 @@ public class MarkupToWorkflowTest {
     assertNotNull(workflow.getName());
 
     assertNotNull(workflow.getAuth());
-    AuthDefinition auth = workflow.getAuth();
+    AuthDefinition auth = workflow.getAuth().getAuthDefs().get(0);
     assertNotNull(auth.getName());
     assertEquals("authname", auth.getName());
     assertNotNull(auth.getScheme());

--- a/api/src/test/java/io/serverlessworkflow/api/test/WorkflowToMarkupTest.java
+++ b/api/src/test/java/io/serverlessworkflow/api/test/WorkflowToMarkupTest.java
@@ -16,7 +16,9 @@
 package io.serverlessworkflow.api.test;
 
 import static io.serverlessworkflow.api.states.DefaultState.Type.SLEEP;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.serverlessworkflow.api.Workflow;
 import io.serverlessworkflow.api.auth.AuthDefinition;
@@ -29,6 +31,7 @@ import io.serverlessworkflow.api.produce.ProduceEvent;
 import io.serverlessworkflow.api.schedule.Schedule;
 import io.serverlessworkflow.api.start.Start;
 import io.serverlessworkflow.api.states.SleepState;
+import io.serverlessworkflow.api.workflow.Auth;
 import io.serverlessworkflow.api.workflow.Events;
 import io.serverlessworkflow.api.workflow.Functions;
 import java.util.Arrays;
@@ -162,22 +165,24 @@ public class WorkflowToMarkupTest {
             .withVersion("1.0")
             .withStart(new Start())
             .withAuth(
-                new AuthDefinition()
-                    .withName("authname")
-                    .withScheme(AuthDefinition.Scheme.BASIC)
-                    .withBasicauth(
-                        new BasicAuthDefinition()
-                            .withUsername("testuser")
-                            .withPassword("testPassword")));
+                new Auth(
+                    new AuthDefinition()
+                        .withName("authname")
+                        .withScheme(AuthDefinition.Scheme.BASIC)
+                        .withBasicauth(
+                            new BasicAuthDefinition()
+                                .withUsername("testuser")
+                                .withPassword("testPassword"))));
 
     assertNotNull(workflow);
     assertNotNull(workflow.getAuth());
-    assertNotNull(workflow.getAuth().getName());
-    assertEquals("authname", workflow.getAuth().getName());
-    assertNotNull(workflow.getAuth().getScheme());
-    assertEquals("basic", workflow.getAuth().getScheme().value());
-    assertNotNull(workflow.getAuth().getBasicauth());
-    assertEquals("testuser", workflow.getAuth().getBasicauth().getUsername());
-    assertEquals("testPassword", workflow.getAuth().getBasicauth().getPassword());
+    assertNotNull(workflow.getAuth().getAuthDefs().get(0));
+    assertEquals("authname", workflow.getAuth().getAuthDefs().get(0).getName());
+    assertNotNull(workflow.getAuth().getAuthDefs().get(0).getScheme());
+    assertEquals("basic", workflow.getAuth().getAuthDefs().get(0).getScheme().value());
+    assertNotNull(workflow.getAuth().getAuthDefs().get(0).getBasicauth());
+    assertEquals("testuser", workflow.getAuth().getAuthDefs().get(0).getBasicauth().getUsername());
+    assertEquals(
+        "testPassword", workflow.getAuth().getAuthDefs().get(0).getBasicauth().getPassword());
   }
 }

--- a/api/src/test/resources/features/authbasic.json
+++ b/api/src/test/resources/features/authbasic.json
@@ -1,13 +1,15 @@
 {
-  "id" : "test-workflow",
-  "name" : "test-workflow-name",
-  "version" : "1.0",
-  "auth" : {
-    "name" : "authname",
-    "scheme" : "basic",
-    "properties" : {
-      "username" : "testuser",
-      "password" : "testpassword"
+  "id": "test-workflow",
+  "name": "test-workflow-name",
+  "version": "1.0",
+  "auth": [
+    {
+      "name": "authname",
+      "scheme": "basic",
+      "properties": {
+        "username": "testuser",
+        "password": "testpassword"
+      }
     }
-  }
+  ]
 }

--- a/api/src/test/resources/features/authbasic.yml
+++ b/api/src/test/resources/features/authbasic.yml
@@ -2,8 +2,8 @@ id: test-workflow
 name: test-workflow-name
 version: '1.0'
 auth:
-  name: authname
-  scheme: basic
-  properties:
-    username: testuser
-    password: testpassword
+  - name: authname
+    scheme: basic
+    properties:
+      username: testuser
+      password: testpassword

--- a/api/src/test/resources/features/authbearer.json
+++ b/api/src/test/resources/features/authbearer.json
@@ -1,12 +1,14 @@
 {
-  "id" : "test-workflow",
-  "name" : "test-workflow-name",
-  "version" : "1.0",
-  "auth" : {
-    "name" : "authname",
-    "scheme" : "bearer",
-    "properties" : {
-      "token" : "testtoken"
+  "id": "test-workflow",
+  "name": "test-workflow-name",
+  "version": "1.0",
+  "auth": [
+    {
+      "name": "authname",
+      "scheme": "bearer",
+      "properties": {
+        "token": "testtoken"
+      }
     }
-  }
+  ]
 }

--- a/api/src/test/resources/features/authbearer.yml
+++ b/api/src/test/resources/features/authbearer.yml
@@ -2,7 +2,7 @@ id: test-workflow
 name: test-workflow-name
 version: '1.0'
 auth:
-  name: authname
-  scheme: bearer
-  properties:
-    token: testtoken
+  - name: authname
+    scheme: bearer
+    properties:
+      token: testtoken

--- a/api/src/test/resources/features/authoauth.json
+++ b/api/src/test/resources/features/authoauth.json
@@ -2,7 +2,7 @@
   "id" : "test-workflow",
   "name" : "test-workflow-name",
   "version" : "1.0",
-  "auth" : {
+  "auth" : [{
     "name" : "authname",
     "scheme" : "oauth2",
     "properties" : {
@@ -11,5 +11,5 @@
       "clientId": "${ $SECRETS.clientid }",
       "clientSecret": "${ $SECRETS.clientsecret }"
     }
-  }
+  }]
 }

--- a/api/src/test/resources/features/authoauth.yml
+++ b/api/src/test/resources/features/authoauth.yml
@@ -2,10 +2,10 @@ id: test-workflow
 name: test-workflow-name
 version: '1.0'
 auth:
-  name: authname
-  scheme: oauth2
-  properties:
-    authority: testauthority
-    grantType: clientCredentials
-    clientId: "${ $SECRETS.clientid }"
-    clientSecret: "${ $SECRETS.clientsecret }"
+  - name: authname
+    scheme: oauth2
+    properties:
+      authority: testauthority
+      grantType: clientCredentials
+      clientId: "${ $SECRETS.clientid }"
+      clientSecret: "${ $SECRETS.clientsecret }"


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
Per the spec, the [Auth](https://github.com/serverlessworkflow/specification/blob/main/schema/auth.json#L14) property is an array, not an object. This makes sense since a workflow could have multiple functions accessing different openapi spec files over other servers with varying auth schemes.
 
**Special notes for reviewers**:
The `*Deseralizer` classes look pretty much the same. I believe we can improve this one in the future.

**Additional information (if needed):**
Perhaps timeouts should be done the same thing, but I'll open a different PR.