### PR TITLE
Constanst.setRefValue() was always null

### DIFF
--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/ConstantsDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/ConstantsDeserializer.java
@@ -62,6 +62,7 @@ public class ConstantsDeserializer extends StdDeserializer<Constants> {
       constantsDefinition = node;
     } else {
       String constantsFileDef = node.asText();
+      constants.setRefValue(constantsFileDef);
       String constantsFileSrc = Utils.getResourceFileAsString(constantsFileDef);
       JsonNode constantsRefNode;
       ObjectMapper jsonWriter = new ObjectMapper();

--- a/api/src/main/java/io/serverlessworkflow/api/serializers/WorkflowSerializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/serializers/WorkflowSerializer.java
@@ -160,10 +160,11 @@ public class WorkflowSerializer extends StdSerializer<Workflow> {
     }
 
     if (workflow.getConstants() != null) {
-      if (!workflow.getConstants().getConstantsDef().isEmpty()) {  
-          gen.writeObjectField("constants", workflow.getConstants().getConstantsDef());
+      if (workflow.getConstants().getConstantsDef() != null
+          && !workflow.getConstants().getConstantsDef().isEmpty()) {
+        gen.writeObjectField("constants", workflow.getConstants().getConstantsDef());
       } else if (workflow.getConstants().getRefValue() != null) {
-          gen.writeStringField("constants", workflow.getConstants().getRefValue());
+        gen.writeStringField("constants", workflow.getConstants().getRefValue());
       }
     }
 

--- a/api/src/main/java/io/serverlessworkflow/api/serializers/WorkflowSerializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/serializers/WorkflowSerializer.java
@@ -159,8 +159,12 @@ public class WorkflowSerializer extends StdSerializer<Workflow> {
       gen.writeEndArray();
     }
 
-    if (workflow.getConstants() != null && !workflow.getConstants().getConstantsDef().isEmpty()) {
-      gen.writeObjectField("constants", workflow.getConstants().getConstantsDef());
+    if (workflow.getConstants() != null) {
+      if (!workflow.getConstants().getConstantsDef().isEmpty()) {  
+          gen.writeObjectField("constants", workflow.getConstants().getConstantsDef());
+      } else if (workflow.getConstants().getRefValue() != null) {
+          gen.writeStringField("constants", workflow.getConstants().getRefValue());
+      }
     }
 
     if (workflow.getTimeouts() != null) {

--- a/api/src/test/java/io/serverlessworkflow/api/test/MarkupToWorkflowTest.java
+++ b/api/src/test/java/io/serverlessworkflow/api/test/MarkupToWorkflowTest.java
@@ -569,8 +569,7 @@ public class MarkupToWorkflowTest {
     JsonNode serbianTranslationNode = translationDogNode.get("Serbian");
     assertEquals("pas", serbianTranslationNode.asText());
   }
-  
-  
+
   @ParameterizedTest
   @ValueSource(strings = {"/features/constantsRef.json", "/features/constantsRef.yml"})
   public void testConstantsRef(String workflowLocation) {
@@ -583,9 +582,8 @@ public class MarkupToWorkflowTest {
 
     assertNotNull(workflow.getConstants());
     Constants constants = workflow.getConstants();
-    assertNotNull(constants.getRefValue());
+    assertEquals("constantValues.json", constants.getRefValue());
   }
-  
 
   @ParameterizedTest
   @ValueSource(strings = {"/features/timeouts.json", "/features/timeouts.yml"})

--- a/api/src/test/java/io/serverlessworkflow/api/test/MarkupToWorkflowTest.java
+++ b/api/src/test/java/io/serverlessworkflow/api/test/MarkupToWorkflowTest.java
@@ -569,6 +569,23 @@ public class MarkupToWorkflowTest {
     JsonNode serbianTranslationNode = translationDogNode.get("Serbian");
     assertEquals("pas", serbianTranslationNode.asText());
   }
+  
+  
+  @ParameterizedTest
+  @ValueSource(strings = {"/features/constantsRef.json", "/features/constantsRef.yml"})
+  public void testConstantsRef(String workflowLocation) {
+    Workflow workflow = Workflow.fromSource(WorkflowTestUtils.readWorkflowFile(workflowLocation));
+
+    assertNotNull(workflow);
+    assertNotNull(workflow.getId());
+    assertNotNull(workflow.getName());
+    assertNotNull(workflow.getStates());
+
+    assertNotNull(workflow.getConstants());
+    Constants constants = workflow.getConstants();
+    assertNotNull(constants.getRefValue());
+  }
+  
 
   @ParameterizedTest
   @ValueSource(strings = {"/features/timeouts.json", "/features/timeouts.yml"})

--- a/api/src/test/java/io/serverlessworkflow/api/test/WorkflowToMarkupTest.java
+++ b/api/src/test/java/io/serverlessworkflow/api/test/WorkflowToMarkupTest.java
@@ -32,6 +32,7 @@ import io.serverlessworkflow.api.schedule.Schedule;
 import io.serverlessworkflow.api.start.Start;
 import io.serverlessworkflow.api.states.SleepState;
 import io.serverlessworkflow.api.workflow.Auth;
+import io.serverlessworkflow.api.workflow.Constants;
 import io.serverlessworkflow.api.workflow.Events;
 import io.serverlessworkflow.api.workflow.Functions;
 import java.util.Arrays;
@@ -47,6 +48,7 @@ public class WorkflowToMarkupTest {
             .withName("test-workflow-name")
             .withVersion("1.0")
             .withStart(new Start().withSchedule(new Schedule().withInterval("PT1S")))
+            .withConstants(new Constants("constantsValues.json"))
             .withStates(
                 Arrays.asList(
                     new SleepState()
@@ -62,11 +64,13 @@ public class WorkflowToMarkupTest {
 
     assertNotNull(workflow);
     assertNotNull(workflow.getStart());
+    Constants constants = workflow.getConstants();
+    assertNotNull(constants);
+    assertEquals("constantsValues.json", constants.getRefValue());
     assertEquals(1, workflow.getStates().size());
     State state = workflow.getStates().get(0);
     assertTrue(state instanceof SleepState);
     assertNotNull(state.getEnd());
-
     assertNotNull(Workflow.toJson(workflow));
     assertNotNull(Workflow.toYaml(workflow));
   }

--- a/api/src/test/resources/features/constantsRef.json
+++ b/api/src/test/resources/features/constantsRef.json
@@ -1,0 +1,17 @@
+{
+  "id": "secrets",
+  "version": "1.0",
+  "specVersion": "0.8",
+  "name": "Custom secrets flow",
+  "expressionLang": "abc",
+  "start": "TestFunctionRefs",
+  "constants": "contantsValues.json",
+  "states": [
+    {
+      "name": "TestFunctionRefs",
+      "type": "operation",
+      "actions": [],
+      "end": true
+    }
+  ]
+}

--- a/api/src/test/resources/features/constantsRef.json
+++ b/api/src/test/resources/features/constantsRef.json
@@ -5,7 +5,7 @@
   "name": "Custom secrets flow",
   "expressionLang": "abc",
   "start": "TestFunctionRefs",
-  "constants": "contantsValues.json",
+  "constants": "constantValues.json",
   "states": [
     {
       "name": "TestFunctionRefs",

--- a/api/src/test/resources/features/constantsRef.yml
+++ b/api/src/test/resources/features/constantsRef.yml
@@ -1,0 +1,14 @@
+id: secrets
+version: '1.0'
+specVersion: '0.8'
+name: Custom secrets flow
+expressionLang: abc
+start: TestFunctionRefs
+constants:
+  constantValues.json
+states:
+  - name: TestFunctionRefs
+    type: operation
+    actionMode: sequential
+    actions: 
+    end: true


### PR DESCRIPTION
Setting the ref value when constant is an uri to allow implementations
to try load them in case default loading fails
