### PR TITLE
New validations implemented

### DIFF
--- a/validation/README.md
+++ b/validation/README.md
@@ -1,0 +1,49 @@
+# Workflow Validations
+
+| Description                                 | Implemented |
+|---------------------------------------------|-------------|
+| `id` must be present and not be empty.      | Yes         |
+| `version` must be present and not be empty. | Yes         |
+| `start` must refer to an existing `state`.  | Yes         |
+| `states` must be present and not be empty.  | Yes         |
+
+
+## Functions
+
+| Description                                                    | Implemented |
+|----------------------------------------------------------------|-------------|
+| `operation` must be present.                                   | No          |
+
+## States
+
+| Description                              | Implemented |
+|------------------------------------------|-------------|
+| `name` must be present and not be empty. | Yes         |
+
+
+### Switch State
+
+| Description                                                    | Implemented |
+|----------------------------------------------------------------|-------------|
+| `dataCondition` or `eventCondition` must be present.           | Yes         |
+| Both `dataCondition` and `eventCondition` must not be present. | Yes         |
+| `defaultCondition` must not be present.                        | Yes         |
+
+#### Default Condition
+
+| Description                                    | Implemented |
+|------------------------------------------------|-------------|
+| `nextState` or `end` must be present.          | Yes         |
+| `nextState` must refer to an existing `state`. | Yes         |
+
+#### Event Condition
+
+| Description                                | Implemented |
+|--------------------------------------------|-------------|
+| Event or workflow timeout must be present. | Yes         |
+
+#### Timeouts
+
+| Description                                       | Implemented |
+|---------------------------------------------------|-------------|
+| `eventTimeout` must be a valid ISO 8601 duration. | Yes         |

--- a/validation/src/main/java/io/serverlessworkflow/validation/state/CallbackStateValidator.java
+++ b/validation/src/main/java/io/serverlessworkflow/validation/state/CallbackStateValidator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.validation.state;
+
+import io.serverlessworkflow.api.Workflow;
+import io.serverlessworkflow.api.states.CallbackState;
+import io.serverlessworkflow.api.validation.ValidationError;
+import java.util.Collection;
+
+final class CallbackStateValidator extends CommonStateValidator<CallbackState> {
+
+  CallbackStateValidator(Collection<ValidationError> validationErrors) {
+    super(validationErrors);
+  }
+
+  @Override
+  protected boolean isValidSpecificState(Workflow workflow, CallbackState state) {
+    return true;
+  }
+}

--- a/validation/src/main/java/io/serverlessworkflow/validation/state/CommonStateValidator.java
+++ b/validation/src/main/java/io/serverlessworkflow/validation/state/CommonStateValidator.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.validation.state;
+
+import io.serverlessworkflow.api.Workflow;
+import io.serverlessworkflow.api.interfaces.State;
+import io.serverlessworkflow.api.validation.ValidationError;
+import java.util.Collection;
+
+abstract class CommonStateValidator<T extends State> implements StateValidator {
+
+  static final String EMPTY_STATE_NAME_MSG = "State name should not be empty";
+
+  private final Collection<ValidationError> validationErrors;
+
+  protected CommonStateValidator(Collection<ValidationError> validationErrors) {
+    this.validationErrors = validationErrors;
+  }
+
+  @Override
+  public final boolean isValidState(Workflow workflow, State state) {
+    @SuppressWarnings("unchecked")
+    T typedState = (T) state;
+
+    return isValidSpecificState(workflow, typedState) && isStateNameValid(state);
+  }
+
+  private boolean isStateNameValid(State state) {
+    if (state.getName() != null && !state.getName().trim().isEmpty()) {
+      return true;
+    } else {
+      addError(EMPTY_STATE_NAME_MSG);
+      return false;
+    }
+  }
+
+  protected final void addError(String message) {
+    ValidationError error = new ValidationError();
+    error.setType(ValidationError.WORKFLOW_VALIDATION);
+    error.setMessage(message);
+    validationErrors.add(error);
+  }
+
+  protected abstract boolean isValidSpecificState(Workflow workflow, T state);
+}

--- a/validation/src/main/java/io/serverlessworkflow/validation/state/EventStateValidator.java
+++ b/validation/src/main/java/io/serverlessworkflow/validation/state/EventStateValidator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.validation.state;
+
+import io.serverlessworkflow.api.Workflow;
+import io.serverlessworkflow.api.states.EventState;
+import io.serverlessworkflow.api.validation.ValidationError;
+import java.util.Collection;
+
+final class EventStateValidator extends CommonStateValidator<EventState> {
+
+  EventStateValidator(Collection<ValidationError> validationErrors) {
+    super(validationErrors);
+  }
+
+  @Override
+  protected boolean isValidSpecificState(Workflow workflow, EventState state) {
+    return true;
+  }
+}

--- a/validation/src/main/java/io/serverlessworkflow/validation/state/ForEachStateValidator.java
+++ b/validation/src/main/java/io/serverlessworkflow/validation/state/ForEachStateValidator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.validation.state;
+
+import io.serverlessworkflow.api.Workflow;
+import io.serverlessworkflow.api.states.ForEachState;
+import io.serverlessworkflow.api.validation.ValidationError;
+import java.util.Collection;
+
+final class ForEachStateValidator extends CommonStateValidator<ForEachState> {
+
+  ForEachStateValidator(Collection<ValidationError> validationErrors) {
+    super(validationErrors);
+  }
+
+  @Override
+  protected boolean isValidSpecificState(Workflow workflow, ForEachState state) {
+    return true;
+  }
+}

--- a/validation/src/main/java/io/serverlessworkflow/validation/state/InjectStateValidator.java
+++ b/validation/src/main/java/io/serverlessworkflow/validation/state/InjectStateValidator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.validation.state;
+
+import io.serverlessworkflow.api.Workflow;
+import io.serverlessworkflow.api.states.InjectState;
+import io.serverlessworkflow.api.validation.ValidationError;
+import java.util.Collection;
+
+final class InjectStateValidator extends CommonStateValidator<InjectState> {
+
+  InjectStateValidator(Collection<ValidationError> validationErrors) {
+    super(validationErrors);
+  }
+
+  @Override
+  protected boolean isValidSpecificState(Workflow workflow, InjectState state) {
+    return true;
+  }
+}

--- a/validation/src/main/java/io/serverlessworkflow/validation/state/OperationStateValidator.java
+++ b/validation/src/main/java/io/serverlessworkflow/validation/state/OperationStateValidator.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2022-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.validation.state;
+
+import io.serverlessworkflow.api.Workflow;
+import io.serverlessworkflow.api.actions.Action;
+import io.serverlessworkflow.api.events.EventDefinition;
+import io.serverlessworkflow.api.functions.FunctionDefinition;
+import io.serverlessworkflow.api.states.OperationState;
+import io.serverlessworkflow.api.validation.ValidationError;
+import java.util.Collection;
+import java.util.List;
+
+final class OperationStateValidator extends CommonStateValidator<OperationState> {
+
+  OperationStateValidator(Collection<ValidationError> validationErrors) {
+    super(validationErrors);
+  }
+
+  @Override
+  protected boolean isValidSpecificState(Workflow workflow, OperationState operationState) {
+    boolean isValidSpecificState = true;
+
+    List<FunctionDefinition> functions =
+        workflow.getFunctions() != null ? workflow.getFunctions().getFunctionDefs() : null;
+
+    List<EventDefinition> events =
+        workflow.getEvents() != null ? workflow.getEvents().getEventDefs() : null;
+
+    List<Action> actions = operationState.getActions();
+    for (Action action : actions) {
+      if (action.getFunctionRef() != null) {
+        if (action.getFunctionRef().getRefName().isEmpty()) {
+          addError("Operation State action functionRef should not be null or empty");
+          isValidSpecificState = false;
+        }
+
+        if (!hasFunctionDefinition(action.getFunctionRef().getRefName(), functions)) {
+          addError(
+              "Operation State action functionRef does not reference an existing workflow function definition");
+          isValidSpecificState = false;
+        }
+      }
+
+      if (action.getEventRef() != null) {
+        if (action.getEventRef().getTriggerEventRef().isEmpty()) {
+          addError(
+              "Operation State action trigger eventRef does not reference an existing workflow event definition");
+          isValidSpecificState = false;
+        }
+
+        if (action.getEventRef().getResultEventRef().isEmpty()) {
+          addError(
+              "Operation State action results eventRef does not reference an existing workflow event definition");
+          isValidSpecificState = false;
+        }
+
+        if (doesntHaveEventsDefinition(action.getEventRef().getTriggerEventRef(), events)) {
+          addError(
+              "Operation State action trigger event def does not reference an existing workflow event definition");
+          isValidSpecificState = false;
+        }
+
+        if (doesntHaveEventsDefinition(action.getEventRef().getResultEventRef(), events)) {
+          addError(
+              "Operation State action results event def does not reference an existing workflow event definition");
+          isValidSpecificState = false;
+        }
+      }
+    }
+    return isValidSpecificState;
+  }
+
+  private boolean doesntHaveEventsDefinition(String eventName, List<EventDefinition> events) {
+    if (events != null) {
+      EventDefinition eve =
+          events.stream().filter(e -> e.getName().equals(eventName)).findFirst().orElse(null);
+
+      return eve == null;
+    } else {
+      return true;
+    }
+  }
+
+  private boolean hasFunctionDefinition(String functionName, List<FunctionDefinition> functions) {
+    if (functions != null) {
+      FunctionDefinition fun =
+          functions.stream().filter(f -> f.getName().equals(functionName)).findFirst().orElse(null);
+
+      return fun != null;
+    } else {
+      return false;
+    }
+  }
+}

--- a/validation/src/main/java/io/serverlessworkflow/validation/state/OperationStateValidator.java
+++ b/validation/src/main/java/io/serverlessworkflow/validation/state/OperationStateValidator.java
@@ -16,93 +16,22 @@
 package io.serverlessworkflow.validation.state;
 
 import io.serverlessworkflow.api.Workflow;
-import io.serverlessworkflow.api.actions.Action;
-import io.serverlessworkflow.api.events.EventDefinition;
-import io.serverlessworkflow.api.functions.FunctionDefinition;
 import io.serverlessworkflow.api.states.OperationState;
 import io.serverlessworkflow.api.validation.ValidationError;
+import io.serverlessworkflow.validation.state.action.ActionValidator;
 import java.util.Collection;
-import java.util.List;
 
 final class OperationStateValidator extends CommonStateValidator<OperationState> {
 
+  private final ActionValidator actionValidator;
+
   OperationStateValidator(Collection<ValidationError> validationErrors) {
     super(validationErrors);
+    actionValidator = new ActionValidator(validationErrors);
   }
 
   @Override
   protected boolean isValidSpecificState(Workflow workflow, OperationState operationState) {
-    boolean isValidSpecificState = true;
-
-    List<FunctionDefinition> functions =
-        workflow.getFunctions() != null ? workflow.getFunctions().getFunctionDefs() : null;
-
-    List<EventDefinition> events =
-        workflow.getEvents() != null ? workflow.getEvents().getEventDefs() : null;
-
-    List<Action> actions = operationState.getActions();
-    for (Action action : actions) {
-      if (action.getFunctionRef() != null) {
-        if (action.getFunctionRef().getRefName().isEmpty()) {
-          addError("Operation State action functionRef should not be null or empty");
-          isValidSpecificState = false;
-        }
-
-        if (!hasFunctionDefinition(action.getFunctionRef().getRefName(), functions)) {
-          addError(
-              "Operation State action functionRef does not reference an existing workflow function definition");
-          isValidSpecificState = false;
-        }
-      }
-
-      if (action.getEventRef() != null) {
-        if (action.getEventRef().getTriggerEventRef().isEmpty()) {
-          addError(
-              "Operation State action trigger eventRef does not reference an existing workflow event definition");
-          isValidSpecificState = false;
-        }
-
-        if (action.getEventRef().getResultEventRef().isEmpty()) {
-          addError(
-              "Operation State action results eventRef does not reference an existing workflow event definition");
-          isValidSpecificState = false;
-        }
-
-        if (doesntHaveEventsDefinition(action.getEventRef().getTriggerEventRef(), events)) {
-          addError(
-              "Operation State action trigger event def does not reference an existing workflow event definition");
-          isValidSpecificState = false;
-        }
-
-        if (doesntHaveEventsDefinition(action.getEventRef().getResultEventRef(), events)) {
-          addError(
-              "Operation State action results event def does not reference an existing workflow event definition");
-          isValidSpecificState = false;
-        }
-      }
-    }
-    return isValidSpecificState;
-  }
-
-  private boolean doesntHaveEventsDefinition(String eventName, List<EventDefinition> events) {
-    if (events != null) {
-      EventDefinition eve =
-          events.stream().filter(e -> e.getName().equals(eventName)).findFirst().orElse(null);
-
-      return eve == null;
-    } else {
-      return true;
-    }
-  }
-
-  private boolean hasFunctionDefinition(String functionName, List<FunctionDefinition> functions) {
-    if (functions != null) {
-      FunctionDefinition fun =
-          functions.stream().filter(f -> f.getName().equals(functionName)).findFirst().orElse(null);
-
-      return fun != null;
-    } else {
-      return false;
-    }
+    return actionValidator.areValidActions(workflow, operationState.getActions());
   }
 }

--- a/validation/src/main/java/io/serverlessworkflow/validation/state/ParallelStateValidator.java
+++ b/validation/src/main/java/io/serverlessworkflow/validation/state/ParallelStateValidator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.validation.state;
+
+import io.serverlessworkflow.api.Workflow;
+import io.serverlessworkflow.api.states.ParallelState;
+import io.serverlessworkflow.api.validation.ValidationError;
+import java.util.Collection;
+
+final class ParallelStateValidator extends CommonStateValidator<ParallelState> {
+
+  ParallelStateValidator(Collection<ValidationError> validationErrors) {
+    super(validationErrors);
+  }
+
+  @Override
+  protected boolean isValidSpecificState(Workflow workflow, ParallelState state) {
+    return true;
+  }
+}

--- a/validation/src/main/java/io/serverlessworkflow/validation/state/SleepStateValidator.java
+++ b/validation/src/main/java/io/serverlessworkflow/validation/state/SleepStateValidator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.validation.state;
+
+import io.serverlessworkflow.api.Workflow;
+import io.serverlessworkflow.api.states.SleepState;
+import io.serverlessworkflow.api.validation.ValidationError;
+import java.util.Collection;
+
+final class SleepStateValidator extends CommonStateValidator<SleepState> {
+
+  SleepStateValidator(Collection<ValidationError> validationErrors) {
+    super(validationErrors);
+  }
+
+  @Override
+  protected boolean isValidSpecificState(Workflow workflow, SleepState state) {
+    return true;
+  }
+}

--- a/validation/src/main/java/io/serverlessworkflow/validation/state/StateValidator.java
+++ b/validation/src/main/java/io/serverlessworkflow/validation/state/StateValidator.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.validation.state;
+
+import io.serverlessworkflow.api.Workflow;
+import io.serverlessworkflow.api.interfaces.State;
+
+interface StateValidator {
+
+  boolean isValidState(Workflow workflow, State state);
+}

--- a/validation/src/main/java/io/serverlessworkflow/validation/state/StatesValidator.java
+++ b/validation/src/main/java/io/serverlessworkflow/validation/state/StatesValidator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.validation.state;
+
+import io.serverlessworkflow.api.Workflow;
+import io.serverlessworkflow.api.interfaces.State;
+import io.serverlessworkflow.api.states.DefaultState.Type;
+import io.serverlessworkflow.api.validation.ValidationError;
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+public final class StatesValidator {
+  private final Map<Type, StateValidator> stateValidators = new EnumMap<>(Type.class);
+
+  private final Collection<ValidationError> validationErrors;
+
+  public StatesValidator(Collection<ValidationError> validationErrors) {
+    this.validationErrors = validationErrors;
+
+    stateValidators.put(Type.EVENT, new EventStateValidator(validationErrors));
+    stateValidators.put(Type.OPERATION, new OperationStateValidator(validationErrors));
+    stateValidators.put(Type.SWITCH, new SwitchStateValidator(validationErrors));
+    stateValidators.put(Type.SLEEP, new SleepStateValidator(validationErrors));
+    stateValidators.put(Type.PARALLEL, new ParallelStateValidator(validationErrors));
+    stateValidators.put(Type.INJECT, new InjectStateValidator(validationErrors));
+    stateValidators.put(Type.FOREACH, new ForEachStateValidator(validationErrors));
+    stateValidators.put(Type.CALLBACK, new CallbackStateValidator(validationErrors));
+  }
+
+  public boolean hasValidStates(Workflow workflow) {
+    boolean finalValidationResult = true;
+
+    List<State> states = workflow.getStates();
+    if (states != null && !states.isEmpty()) {
+      for (State state : states) {
+        StateValidator stateValidator = stateValidators.get(state.getType());
+
+        if (stateValidator != null) {
+          finalValidationResult =
+              finalValidationResult && stateValidator.isValidState(workflow, state);
+        } else {
+          throw new IllegalStateException("No validator found for state type: " + state.getType());
+        }
+      }
+    }
+
+    return finalValidationResult;
+  }
+}

--- a/validation/src/main/java/io/serverlessworkflow/validation/state/SwitchStateValidator.java
+++ b/validation/src/main/java/io/serverlessworkflow/validation/state/SwitchStateValidator.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2022-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.validation.state;
+
+import io.serverlessworkflow.api.Workflow;
+import io.serverlessworkflow.api.defaultdef.DefaultConditionDefinition;
+import io.serverlessworkflow.api.interfaces.State;
+import io.serverlessworkflow.api.states.SwitchState;
+import io.serverlessworkflow.api.timeouts.TimeoutsDefinition;
+import io.serverlessworkflow.api.validation.ValidationError;
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+class SwitchStateValidator extends CommonStateValidator<SwitchState> {
+
+  private static final String NON_NEGATIVE_DURATION_MUST_BE_PROVIDED =
+      "When configured, it must be set with a greater than zero ISO 8601 time duration. For example PT30S.";
+
+  static final String INVALID_EVENT_TIMEOUT_ERROR =
+      "An invalid \"eventTimeout\": \"%s\" configuration was provided for the serverless workflow: \"%s\". "
+          + NON_NEGATIVE_DURATION_MUST_BE_PROVIDED;
+
+  static final String EVENT_TIMEOUT_REQUIRED_ERROR =
+      "The \"eventTimeout\" configuration is required for the \"eventConditions\" based switch state \"%s\" that belongs to the serverless workflow: \"%s\".";
+
+  static final String DATA_CONDITIONS_AND_EVENT_CONDITIONS_FOUND_ERROR =
+      "DataConditions and eventConditions where found at the same time for the switch state \"%s\".";
+
+  static final String NEXT_STATE_NOT_FOUND_FOR_DEFAULT_CONDITION_ERROR =
+      "The \"nextState\" : \"%s\" configured for the \"defaultCondition\" transition in the switch state \"%s\", was not found in the serverless workflow: \"%s\".";
+
+  static final String NEXT_STATE_REQUIRED_FOR_DEFAULT_CONDITION_ERROR =
+      "The \"nextState\" is required for the \"defaultCondition\" transition in the switch state \"%s\" that belongs to the serverless workflow: \"%s\".";
+
+  SwitchStateValidator(Collection<ValidationError> validationErrors) {
+    super(validationErrors);
+  }
+
+  @Override
+  protected boolean isValidSpecificState(Workflow workflow, SwitchState state) {
+    return isValidDefaultCondition(workflow, state)
+        && isValidEventCondition(workflow, state)
+        && isOnlyDataConditionOrOnlyEventConditionPresent(state);
+  }
+
+  private boolean isOnlyDataConditionOrOnlyEventConditionPresent(SwitchState switchState) {
+    if (!switchState.getDataConditions().isEmpty() && !switchState.getEventConditions().isEmpty()) {
+      addError(
+          String.format(DATA_CONDITIONS_AND_EVENT_CONDITIONS_FOUND_ERROR, switchState.getName()));
+      return false;
+    } else {
+      return true;
+    }
+  }
+
+  private boolean isDefaultConditionNextStateFound(
+      Workflow workflow, String switchStateName, String nextState) {
+    if (nextState != null && !stateExists(workflow, nextState) && !"end".equals(nextState)) {
+      addError(
+          String.format(
+              NEXT_STATE_NOT_FOUND_FOR_DEFAULT_CONDITION_ERROR,
+              nextState,
+              switchStateName,
+              workflow.getName()));
+
+      return false;
+    } else {
+      return true;
+    }
+  }
+
+  private static boolean stateExists(Workflow workflow, String state) {
+    List<State> states = workflow.getStates();
+    if (states != null) {
+      return states.stream()
+          .map(State::getName)
+          .filter(Objects::nonNull)
+          .anyMatch(name -> name.equals(state));
+    } else {
+      return false;
+    }
+  }
+
+  private boolean isValidEventTimeoutDuration(Workflow workflow, String timeout) {
+    if (isInvalidDuration(timeout)) {
+      addError(String.format(INVALID_EVENT_TIMEOUT_ERROR, timeout, workflow.getName()));
+      return false;
+    } else {
+      return true;
+    }
+  }
+
+  private static boolean isInvalidDuration(String timeout) {
+    try {
+      Duration.parse(timeout);
+      return false;
+    } catch (DateTimeParseException e) {
+      return true;
+    }
+  }
+
+  private static boolean switchStateHasEventCondition(SwitchState switchState) {
+    return switchState.getEventConditions() != null && !switchState.getEventConditions().isEmpty();
+  }
+
+  private static Optional<String> resolveEventTimeout(SwitchState switchState, Workflow workflow) {
+    return resolveStateTimeout(switchState).or(() -> resolveWorkflowTimeout(workflow));
+  }
+
+  private static Optional<String> resolveStateTimeout(SwitchState switchState) {
+    return Optional.ofNullable(switchState.getTimeouts()).map(TimeoutsDefinition::getEventTimeout);
+  }
+
+  private static Optional<String> resolveWorkflowTimeout(Workflow workflow) {
+    return Optional.ofNullable(workflow.getTimeouts()).map(TimeoutsDefinition::getEventTimeout);
+  }
+
+  private boolean isValidNextState(
+      Workflow workflow, String switchStateName, DefaultConditionDefinition defaultCondition) {
+    String nextState =
+        defaultCondition.getTransition() != null
+            ? defaultCondition.getTransition().getNextState()
+            : null;
+    if (nextState != null && !nextState.isEmpty()) {
+      return isDefaultConditionNextStateFound(workflow, switchStateName, nextState);
+    } else {
+      addError(
+          String.format(
+              NEXT_STATE_REQUIRED_FOR_DEFAULT_CONDITION_ERROR,
+              switchStateName,
+              workflow.getName()));
+
+      return false;
+    }
+  }
+
+  private boolean isValidDefaultCondition(Workflow workflow, SwitchState switchState) {
+    DefaultConditionDefinition defaultCondition = switchState.getDefaultCondition();
+    if (defaultCondition != null) {
+      return isValidNextState(workflow, switchState.getName(), defaultCondition);
+    } else {
+      return true;
+    }
+  }
+
+  private boolean isValidEventCondition(Workflow workflow, SwitchState switchState) {
+    if (switchStateHasEventCondition(switchState)) {
+      Optional<String> eventTimeout = resolveEventTimeout(switchState, workflow);
+      if (eventTimeout.isPresent()) {
+        return isValidEventTimeoutDuration(workflow, eventTimeout.orElseThrow());
+      } else {
+        addError(
+            String.format(EVENT_TIMEOUT_REQUIRED_ERROR, switchState.getName(), workflow.getName()));
+        return false;
+      }
+    } else {
+      return true;
+    }
+  }
+}

--- a/validation/src/main/java/io/serverlessworkflow/validation/state/action/ActionValidator.java
+++ b/validation/src/main/java/io/serverlessworkflow/validation/state/action/ActionValidator.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2022-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.validation.state.action;
+
+import io.serverlessworkflow.api.Workflow;
+import io.serverlessworkflow.api.actions.Action;
+import io.serverlessworkflow.api.events.EventDefinition;
+import io.serverlessworkflow.api.functions.FunctionDefinition;
+import io.serverlessworkflow.api.validation.ValidationError;
+import java.util.Collection;
+import java.util.List;
+
+public final class ActionValidator {
+
+  private final Collection<ValidationError> validationErrors;
+
+  public ActionValidator(Collection<ValidationError> validationErrors) {
+    this.validationErrors = validationErrors;
+  }
+
+  public boolean areValidActions(Workflow workflow, Collection<Action> actions) {
+    List<FunctionDefinition> functions =
+        workflow.getFunctions() != null ? workflow.getFunctions().getFunctionDefs() : null;
+
+    List<EventDefinition> events =
+        workflow.getEvents() != null ? workflow.getEvents().getEventDefs() : null;
+
+    boolean areValidActions = true;
+    for (Action action : actions) {
+      if (action.getFunctionRef() != null) {
+        if (action.getFunctionRef().getRefName().isEmpty()) {
+          addError("Operation State action functionRef should not be null or empty");
+          areValidActions = false;
+        }
+
+        if (!hasFunctionDefinition(action.getFunctionRef().getRefName(), functions)) {
+          addError(
+              "Operation State action functionRef does not reference an existing workflow function definition");
+          areValidActions = false;
+        }
+      }
+
+      if (action.getEventRef() != null) {
+        if (action.getEventRef().getTriggerEventRef().isEmpty()) {
+          addError(
+              "Operation State action trigger eventRef does not reference an existing workflow event definition");
+          areValidActions = false;
+        }
+
+        if (action.getEventRef().getResultEventRef().isEmpty()) {
+          addError(
+              "Operation State action results eventRef does not reference an existing workflow event definition");
+          areValidActions = false;
+        }
+
+        if (doesntHaveEventsDefinition(action.getEventRef().getTriggerEventRef(), events)) {
+          addError(
+              "Operation State action trigger event def does not reference an existing workflow event definition");
+          areValidActions = false;
+        }
+
+        if (doesntHaveEventsDefinition(action.getEventRef().getResultEventRef(), events)) {
+          addError(
+              "Operation State action results event def does not reference an existing workflow event definition");
+          areValidActions = false;
+        }
+      }
+    }
+
+    return areValidActions;
+  }
+
+  private boolean doesntHaveEventsDefinition(String eventName, List<EventDefinition> events) {
+    if (events != null) {
+      EventDefinition eve =
+          events.stream().filter(e -> e.getName().equals(eventName)).findFirst().orElse(null);
+
+      return eve == null;
+    } else {
+      return true;
+    }
+  }
+
+  private boolean hasFunctionDefinition(String functionName, List<FunctionDefinition> functions) {
+    if (functions != null) {
+      FunctionDefinition fun =
+          functions.stream().filter(f -> f.getName().equals(functionName)).findFirst().orElse(null);
+
+      return fun != null;
+    } else {
+      return false;
+    }
+  }
+
+  private void addError(String message) {
+    ValidationError error = new ValidationError();
+    error.setType(ValidationError.WORKFLOW_VALIDATION);
+    error.setMessage(message);
+    validationErrors.add(error);
+  }
+}

--- a/validation/src/test/java/io/serverlessworkflow/validation/state/CommonStateValidatorTest.java
+++ b/validation/src/test/java/io/serverlessworkflow/validation/state/CommonStateValidatorTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.validation.state;
+
+import static io.serverlessworkflow.validation.state.CommonStateValidator.EMPTY_STATE_NAME_MSG;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.serverlessworkflow.api.validation.ValidationError;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class CommonStateValidatorTest extends StateValidatorTestUtil {
+
+  public static Stream<Arguments> testInvalidWorkflowSource() {
+    return Stream.of(
+        Arguments.of("/states/invalid/empty_state_name.json", EMPTY_STATE_NAME_MSG),
+        Arguments.of("/states/invalid/missing_state_name.json", EMPTY_STATE_NAME_MSG));
+  }
+
+  @ParameterizedTest
+  @MethodSource("testInvalidWorkflowSource")
+  void testInvalidWorkflow(String workflowFilePath, String expectedError) throws IOException {
+    Collection<ValidationError> errors = validateFile(workflowFilePath);
+
+    assertThat(errors).hasSize(1).allMatch(error -> expectedError.equals(error.getMessage()));
+  }
+}

--- a/validation/src/test/java/io/serverlessworkflow/validation/state/StateValidatorTestUtil.java
+++ b/validation/src/test/java/io/serverlessworkflow/validation/state/StateValidatorTestUtil.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.validation.state;
+
+import io.serverlessworkflow.api.Workflow;
+import io.serverlessworkflow.api.validation.ValidationError;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Objects;
+
+abstract class StateValidatorTestUtil {
+
+  protected StateValidatorTestUtil() {}
+
+  protected final Collection<ValidationError> validateFile(String workflowFilePath)
+      throws IOException {
+    String source =
+        Files.readString(
+            Path.of(
+                Objects.requireNonNull(SwitchStateValidatorTest.class.getResource(workflowFilePath))
+                    .getPath()));
+
+    Collection<ValidationError> errors = new ArrayList<>();
+    new StatesValidator(errors).hasValidStates(Workflow.fromSource(source));
+    return errors;
+  }
+}

--- a/validation/src/test/java/io/serverlessworkflow/validation/state/SwitchStateValidatorTest.java
+++ b/validation/src/test/java/io/serverlessworkflow/validation/state/SwitchStateValidatorTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2022-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.validation.state;
+
+import static io.serverlessworkflow.validation.state.SwitchStateValidator.DATA_CONDITIONS_AND_EVENT_CONDITIONS_FOUND_ERROR;
+import static io.serverlessworkflow.validation.state.SwitchStateValidator.EVENT_TIMEOUT_REQUIRED_ERROR;
+import static io.serverlessworkflow.validation.state.SwitchStateValidator.INVALID_EVENT_TIMEOUT_ERROR;
+import static io.serverlessworkflow.validation.state.SwitchStateValidator.NEXT_STATE_NOT_FOUND_FOR_DEFAULT_CONDITION_ERROR;
+import static io.serverlessworkflow.validation.state.SwitchStateValidator.NEXT_STATE_REQUIRED_FOR_DEFAULT_CONDITION_ERROR;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.serverlessworkflow.api.validation.ValidationError;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class SwitchStateValidatorTest extends StateValidatorTestUtil {
+
+  public static Stream<Arguments> testInvalidWorkflowSource() {
+    return Stream.of(
+        Arguments.of(
+            "/states/switchstate/invalid/data_condition_and_event_condition_present.json",
+            String.format(DATA_CONDITIONS_AND_EVENT_CONDITIONS_FOUND_ERROR, "CheckVisaStatus")),
+        Arguments.of(
+            "/states/switchstate/defaultcondition/invalid/next_state_empty.json",
+            String.format(
+                NEXT_STATE_REQUIRED_FOR_DEFAULT_CONDITION_ERROR,
+                "CheckVisaStatus",
+                "Event Based Switch Transitions")),
+        Arguments.of(
+            "/states/switchstate/defaultcondition/invalid/next_state_null.json",
+            String.format(
+                NEXT_STATE_REQUIRED_FOR_DEFAULT_CONDITION_ERROR,
+                "CheckVisaStatus",
+                "Event Based Switch Transitions")),
+        Arguments.of(
+            "/states/switchstate/defaultcondition/invalid/next_state_present_but_non_existing.json",
+            String.format(
+                NEXT_STATE_NOT_FOUND_FOR_DEFAULT_CONDITION_ERROR,
+                "NonExistingNextState",
+                "CheckVisaStatus",
+                "Event Based Switch Transitions")),
+        Arguments.of(
+            "/states/switchstate/eventcondition/invalid/missing_event_timeout.json",
+            String.format(
+                EVENT_TIMEOUT_REQUIRED_ERROR,
+                "CheckContinueVitalChecks",
+                "Check Car Vitals Workflow")),
+        Arguments.of(
+            "/states/switchstate/timeouts/eventtimeout/duration/invalid/state_timeout_duration.json",
+            String.format(
+                INVALID_EVENT_TIMEOUT_ERROR,
+                "Serverless Workflow is Awesome",
+                "Event Based Switch Transitions")),
+        Arguments.of(
+            "/states/switchstate/timeouts/eventtimeout/duration/invalid/workflow_timeout_duration.json",
+            String.format(
+                INVALID_EVENT_TIMEOUT_ERROR,
+                "Serverless Workflow is Awesome",
+                "Event Based Switch Transitions")));
+  }
+
+  public static Stream<Arguments> testValidWorkflowSource() {
+    return Stream.of(
+        Arguments.of("/states/switchstate/defaultcondition/valid/next_state_present.json"),
+        Arguments.of("/states/switchstate/defaultcondition/valid/next_state_end.json"),
+        Arguments.of("/states/switchstate/timeouts/eventtimeout/valid/event_timeout_on_state.json"),
+        Arguments.of(
+            "/states/switchstate/timeouts/eventtimeout/valid/event_timeout_on_workflow.json"),
+        Arguments.of(
+            "/states/switchstate/timeouts/eventtimeout/valid/missing_event_timeout_on_state_without_event_condition.json"),
+        Arguments.of("/states/switchstate/timeouts/eventtimeout/duration/valid/state_timeout.json"),
+        Arguments.of(
+            "/states/switchstate/timeouts/eventtimeout/duration/valid/workflow_timeout.json"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("testInvalidWorkflowSource")
+  void testInvalidWorkflow(String workflowFilePath, String expectedError) throws IOException {
+    Collection<ValidationError> errors = validateFile(workflowFilePath);
+
+    assertThat(errors).hasSize(1).allMatch(error -> expectedError.equals(error.getMessage()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("testValidWorkflowSource")
+  void testValidWorkflow(String workflowFilePath) throws IOException {
+    Collection<ValidationError> errors = validateFile(workflowFilePath);
+    assertThat(errors).isEmpty();
+  }
+}

--- a/validation/src/test/resources/states/invalid/empty_state_name.json
+++ b/validation/src/test/resources/states/invalid/empty_state_name.json
@@ -1,0 +1,72 @@
+{
+  "id": "eventbasedswitchstate",
+  "version": "1.0",
+  "specVersion": "0.8",
+  "name": "Event Based Switch Transitions",
+  "description": "Event Based Switch Transitions",
+  "start": "CheckVisaStatus",
+  "events": [
+    {
+      "name": "visaApprovedEvent",
+      "type": "VisaApproved",
+      "source": "visaCheckSource"
+    },
+    {
+      "name": "visaRejectedEvent",
+      "type": "VisaRejected",
+      "source": "visaCheckSource"
+    }
+  ],
+  "states": [
+    {
+      "name": "",
+      "type": "switch",
+      "timeouts": {
+        "eventTimeout": "PT1H"
+      },
+      "eventConditions": [
+        {
+          "eventRef": "visaApprovedEvent",
+          "transition": "HandleApprovedVisa"
+        },
+        {
+          "eventRef": "visaRejectedEvent",
+          "transition": "HandleRejectedVisa"
+        }
+      ],
+      "defaultCondition": {
+        "transition": "end"
+      }
+    },
+    {
+      "name": "HandleApprovedVisa",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleApprovedVisaWorkflowID"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name": "HandleRejectedVisa",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleRejectedVisaWorkflowID"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name": "HandleNoVisaDecision",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleNoVisaDecisionWorkflowId"
+        }
+      ],
+      "end": true
+    }
+  ]
+}

--- a/validation/src/test/resources/states/invalid/missing_state_name.json
+++ b/validation/src/test/resources/states/invalid/missing_state_name.json
@@ -1,0 +1,71 @@
+{
+  "id": "eventbasedswitchstate",
+  "version": "1.0",
+  "specVersion": "0.8",
+  "name": "Event Based Switch Transitions",
+  "description": "Event Based Switch Transitions",
+  "start": "CheckVisaStatus",
+  "events": [
+    {
+      "name": "visaApprovedEvent",
+      "type": "VisaApproved",
+      "source": "visaCheckSource"
+    },
+    {
+      "name": "visaRejectedEvent",
+      "type": "VisaRejected",
+      "source": "visaCheckSource"
+    }
+  ],
+  "states": [
+    {
+      "type": "switch",
+      "timeouts": {
+        "eventTimeout": "PT1H"
+      },
+      "eventConditions": [
+        {
+          "eventRef": "visaApprovedEvent",
+          "transition": "HandleApprovedVisa"
+        },
+        {
+          "eventRef": "visaRejectedEvent",
+          "transition": "HandleRejectedVisa"
+        }
+      ],
+      "defaultCondition": {
+        "transition": "end"
+      }
+    },
+    {
+      "name": "HandleApprovedVisa",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleApprovedVisaWorkflowID"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name": "HandleRejectedVisa",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleRejectedVisaWorkflowID"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name": "HandleNoVisaDecision",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleNoVisaDecisionWorkflowId"
+        }
+      ],
+      "end": true
+    }
+  ]
+}

--- a/validation/src/test/resources/states/switchstate/defaultcondition/invalid/next_state_empty.json
+++ b/validation/src/test/resources/states/switchstate/defaultcondition/invalid/next_state_empty.json
@@ -1,0 +1,72 @@
+{
+  "id": "eventbasedswitchstate",
+  "version": "1.0",
+  "specVersion": "0.8",
+  "name": "Event Based Switch Transitions",
+  "description": "Event Based Switch Transitions",
+  "start": "CheckVisaStatus",
+  "events": [
+    {
+      "name": "visaApprovedEvent",
+      "type": "VisaApproved",
+      "source": "visaCheckSource"
+    },
+    {
+      "name": "visaRejectedEvent",
+      "type": "VisaRejected",
+      "source": "visaCheckSource"
+    }
+  ],
+  "states": [
+    {
+      "name": "CheckVisaStatus",
+      "type": "switch",
+      "timeouts": {
+        "eventTimeout": "PT1H"
+      },
+      "eventConditions": [
+        {
+          "eventRef": "visaApprovedEvent",
+          "transition": "HandleApprovedVisa"
+        },
+        {
+          "eventRef": "visaRejectedEvent",
+          "transition": "HandleRejectedVisa"
+        }
+      ],
+      "defaultCondition": {
+        "transition": ""
+      }
+    },
+    {
+      "name": "HandleApprovedVisa",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleApprovedVisaWorkflowID"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name": "HandleRejectedVisa",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleRejectedVisaWorkflowID"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name": "HandleNoVisaDecision",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleNoVisaDecisionWorkflowId"
+        }
+      ],
+      "end": true
+    }
+  ]
+}

--- a/validation/src/test/resources/states/switchstate/defaultcondition/invalid/next_state_null.json
+++ b/validation/src/test/resources/states/switchstate/defaultcondition/invalid/next_state_null.json
@@ -1,0 +1,71 @@
+{
+  "id": "eventbasedswitchstate",
+  "version": "1.0",
+  "specVersion": "0.8",
+  "name": "Event Based Switch Transitions",
+  "description": "Event Based Switch Transitions",
+  "start": "CheckVisaStatus",
+  "events": [
+    {
+      "name": "visaApprovedEvent",
+      "type": "VisaApproved",
+      "source": "visaCheckSource"
+    },
+    {
+      "name": "visaRejectedEvent",
+      "type": "VisaRejected",
+      "source": "visaCheckSource"
+    }
+  ],
+  "states": [
+    {
+      "name": "CheckVisaStatus",
+      "type": "switch",
+      "timeouts": {
+        "eventTimeout": "PT1H"
+      },
+      "eventConditions": [
+        {
+          "eventRef": "visaApprovedEvent",
+          "transition": "HandleApprovedVisa"
+        },
+        {
+          "eventRef": "visaRejectedEvent",
+          "transition": "HandleRejectedVisa"
+        }
+      ],
+      "defaultCondition": {
+      }
+    },
+    {
+      "name": "HandleApprovedVisa",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleApprovedVisaWorkflowID"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name": "HandleRejectedVisa",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleRejectedVisaWorkflowID"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name": "HandleNoVisaDecision",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleNoVisaDecisionWorkflowId"
+        }
+      ],
+      "end": true
+    }
+  ]
+}

--- a/validation/src/test/resources/states/switchstate/defaultcondition/invalid/next_state_present_but_non_existing.json
+++ b/validation/src/test/resources/states/switchstate/defaultcondition/invalid/next_state_present_but_non_existing.json
@@ -1,0 +1,72 @@
+{
+  "id": "eventbasedswitchstate",
+  "version": "1.0",
+  "specVersion": "0.8",
+  "name": "Event Based Switch Transitions",
+  "description": "Event Based Switch Transitions",
+  "start": "CheckVisaStatus",
+  "events": [
+    {
+      "name": "visaApprovedEvent",
+      "type": "VisaApproved",
+      "source": "visaCheckSource"
+    },
+    {
+      "name": "visaRejectedEvent",
+      "type": "VisaRejected",
+      "source": "visaCheckSource"
+    }
+  ],
+  "states": [
+    {
+      "name": "CheckVisaStatus",
+      "type": "switch",
+      "timeouts": {
+        "eventTimeout": "PT1H"
+      },
+      "eventConditions": [
+        {
+          "eventRef": "visaApprovedEvent",
+          "transition": "HandleApprovedVisa"
+        },
+        {
+          "eventRef": "visaRejectedEvent",
+          "transition": "HandleRejectedVisa"
+        }
+      ],
+      "defaultCondition": {
+        "transition": "NonExistingNextState"
+      }
+    },
+    {
+      "name": "HandleApprovedVisa",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleApprovedVisaWorkflowID"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name": "HandleRejectedVisa",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleRejectedVisaWorkflowID"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name": "HandleNoVisaDecision",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleNoVisaDecisionWorkflowId"
+        }
+      ],
+      "end": true
+    }
+  ]
+}

--- a/validation/src/test/resources/states/switchstate/defaultcondition/valid/next_state_end.json
+++ b/validation/src/test/resources/states/switchstate/defaultcondition/valid/next_state_end.json
@@ -1,0 +1,72 @@
+{
+  "id": "eventbasedswitchstate",
+  "version": "1.0",
+  "specVersion": "0.8",
+  "name": "Event Based Switch Transitions",
+  "description": "Event Based Switch Transitions",
+  "start": "CheckVisaStatus",
+  "events": [
+    {
+      "name": "visaApprovedEvent",
+      "type": "VisaApproved",
+      "source": "visaCheckSource"
+    },
+    {
+      "name": "visaRejectedEvent",
+      "type": "VisaRejected",
+      "source": "visaCheckSource"
+    }
+  ],
+  "states": [
+    {
+      "name": "CheckVisaStatus",
+      "type": "switch",
+      "timeouts": {
+        "eventTimeout": "PT1H"
+      },
+      "eventConditions": [
+        {
+          "eventRef": "visaApprovedEvent",
+          "transition": "HandleApprovedVisa"
+        },
+        {
+          "eventRef": "visaRejectedEvent",
+          "transition": "HandleRejectedVisa"
+        }
+      ],
+      "defaultCondition": {
+        "transition": "end"
+      }
+    },
+    {
+      "name": "HandleApprovedVisa",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleApprovedVisaWorkflowID"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name": "HandleRejectedVisa",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleRejectedVisaWorkflowID"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name": "HandleNoVisaDecision",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleNoVisaDecisionWorkflowId"
+        }
+      ],
+      "end": true
+    }
+  ]
+}

--- a/validation/src/test/resources/states/switchstate/defaultcondition/valid/next_state_present.json
+++ b/validation/src/test/resources/states/switchstate/defaultcondition/valid/next_state_present.json
@@ -1,0 +1,72 @@
+{
+  "id": "eventbasedswitchstate",
+  "version": "1.0",
+  "specVersion": "0.8",
+  "name": "Event Based Switch Transitions",
+  "description": "Event Based Switch Transitions",
+  "start": "CheckVisaStatus",
+  "events": [
+    {
+      "name": "visaApprovedEvent",
+      "type": "VisaApproved",
+      "source": "visaCheckSource"
+    },
+    {
+      "name": "visaRejectedEvent",
+      "type": "VisaRejected",
+      "source": "visaCheckSource"
+    }
+  ],
+  "states": [
+    {
+      "name": "CheckVisaStatus",
+      "type": "switch",
+      "timeouts": {
+        "eventTimeout": "PT1H"
+      },
+      "eventConditions": [
+        {
+          "eventRef": "visaApprovedEvent",
+          "transition": "HandleApprovedVisa"
+        },
+        {
+          "eventRef": "visaRejectedEvent",
+          "transition": "HandleRejectedVisa"
+        }
+      ],
+      "defaultCondition": {
+        "transition": "HandleNoVisaDecision"
+      }
+    },
+    {
+      "name": "HandleApprovedVisa",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleApprovedVisaWorkflowID"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name": "HandleRejectedVisa",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleRejectedVisaWorkflowID"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name": "HandleNoVisaDecision",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleNoVisaDecisionWorkflowId"
+        }
+      ],
+      "end": true
+    }
+  ]
+}

--- a/validation/src/test/resources/states/switchstate/eventcondition/invalid/missing_event_timeout.json
+++ b/validation/src/test/resources/states/switchstate/eventcondition/invalid/missing_event_timeout.json
@@ -1,0 +1,58 @@
+{
+  "id": "checkcarvitals",
+  "name": "Check Car Vitals Workflow",
+  "version": "1.0",
+  "specVersion": "0.8",
+  "start": "WhenCarIsOn",
+  "states": [
+    {
+      "name": "WhenCarIsOn",
+      "type": "event",
+      "onEvents": [
+        {
+          "eventRefs": ["CarTurnedOnEvent"]
+        }
+      ],
+      "transition": "DoCarVitalChecks"
+    },
+    {
+      "name": "DoCarVitalChecks",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "vitalscheck",
+          "sleep": {
+            "after": "PT1S"
+          }
+        }
+      ],
+      "transition": "CheckContinueVitalChecks"
+    },
+    {
+      "name": "CheckContinueVitalChecks",
+      "type": "switch",
+      "eventConditions": [
+        {
+          "name": "Car Turned Off Condition",
+          "eventRef": "CarTurnedOffEvent",
+          "end": true
+        }
+      ],
+      "defaultCondition": {
+        "transition": "DoCarVitalChecks"
+      }
+    }
+  ],
+  "events": [
+    {
+      "name": "CarTurnedOnEvent",
+      "type": "car.events",
+      "source": "my/car"
+    },
+    {
+      "name": "CarTurnedOffEvent",
+      "type": "car.events",
+      "source": "my/car"
+    }
+  ]
+}

--- a/validation/src/test/resources/states/switchstate/invalid/data_condition_and_event_condition_present.json
+++ b/validation/src/test/resources/states/switchstate/invalid/data_condition_and_event_condition_present.json
@@ -1,0 +1,82 @@
+{
+  "id": "eventbasedswitchstate",
+  "version": "1.0",
+  "specVersion": "0.8",
+  "name": "Event Based Switch Transitions",
+  "description": "Event Based Switch Transitions",
+  "start": "CheckVisaStatus",
+  "events": [
+    {
+      "name": "visaApprovedEvent",
+      "type": "VisaApproved",
+      "source": "visaCheckSource"
+    },
+    {
+      "name": "visaRejectedEvent",
+      "type": "VisaRejected",
+      "source": "visaCheckSource"
+    }
+  ],
+  "states": [
+    {
+      "name": "CheckVisaStatus",
+      "type": "switch",
+      "timeouts": {
+        "eventTimeout": "PT1H"
+      },
+      "dataConditions": [
+        {
+          "condition": "${ .applicants | .age >= 18 }",
+          "transition": "StartApplication"
+        },
+        {
+          "condition": "${ .applicants | .age < 18 }",
+          "transition": "RejectApplication"
+        }
+      ],
+      "eventConditions": [
+        {
+          "eventRef": "visaApprovedEvent",
+          "transition": "HandleApprovedVisa"
+        },
+        {
+          "eventRef": "visaRejectedEvent",
+          "transition": "HandleRejectedVisa"
+        }
+      ],
+      "defaultCondition": {
+        "transition": "HandleNoVisaDecision"
+      }
+    },
+    {
+      "name": "HandleApprovedVisa",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleApprovedVisaWorkflowID"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name": "HandleRejectedVisa",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleRejectedVisaWorkflowID"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name": "HandleNoVisaDecision",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleNoVisaDecisionWorkflowId"
+        }
+      ],
+      "end": true
+    }
+  ]
+}

--- a/validation/src/test/resources/states/switchstate/timeouts/eventtimeout/duration/invalid/state_timeout_duration.json
+++ b/validation/src/test/resources/states/switchstate/timeouts/eventtimeout/duration/invalid/state_timeout_duration.json
@@ -1,0 +1,72 @@
+{
+  "id": "eventbasedswitchstate",
+  "version": "1.0",
+  "specVersion": "0.8",
+  "name": "Event Based Switch Transitions",
+  "description": "Event Based Switch Transitions",
+  "start": "CheckVisaStatus",
+  "events": [
+    {
+      "name": "visaApprovedEvent",
+      "type": "VisaApproved",
+      "source": "visaCheckSource"
+    },
+    {
+      "name": "visaRejectedEvent",
+      "type": "VisaRejected",
+      "source": "visaCheckSource"
+    }
+  ],
+  "states": [
+    {
+      "name": "CheckVisaStatus",
+      "type": "switch",
+      "eventConditions": [
+        {
+          "eventRef": "visaApprovedEvent",
+          "transition": "HandleApprovedVisa"
+        },
+        {
+          "eventRef": "visaRejectedEvent",
+          "transition": "HandleRejectedVisa"
+        }
+      ],
+      "timeouts": {
+        "eventTimeout": "Serverless Workflow is Awesome"
+      },
+      "defaultCondition": {
+        "transition": "HandleNoVisaDecision"
+      }
+    },
+    {
+      "name": "HandleApprovedVisa",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleApprovedVisaWorkflowID"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name": "HandleRejectedVisa",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleRejectedVisaWorkflowID"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name": "HandleNoVisaDecision",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleNoVisaDecisionWorkflowId"
+        }
+      ],
+      "end": true
+    }
+  ]
+}

--- a/validation/src/test/resources/states/switchstate/timeouts/eventtimeout/duration/invalid/workflow_timeout_duration.json
+++ b/validation/src/test/resources/states/switchstate/timeouts/eventtimeout/duration/invalid/workflow_timeout_duration.json
@@ -1,0 +1,72 @@
+{
+  "id": "eventbasedswitchstate",
+  "version": "1.0",
+  "specVersion": "0.8",
+  "name": "Event Based Switch Transitions",
+  "description": "Event Based Switch Transitions",
+  "start": "CheckVisaStatus",
+  "timeouts": {
+    "eventTimeout": "Serverless Workflow is Awesome"
+  },
+  "events": [
+    {
+      "name": "visaApprovedEvent",
+      "type": "VisaApproved",
+      "source": "visaCheckSource"
+    },
+    {
+      "name": "visaRejectedEvent",
+      "type": "VisaRejected",
+      "source": "visaCheckSource"
+    }
+  ],
+  "states":[
+    {
+      "name":"CheckVisaStatus",
+      "type":"switch",
+      "eventConditions": [
+        {
+          "eventRef": "visaApprovedEvent",
+          "transition": "HandleApprovedVisa"
+        },
+        {
+          "eventRef": "visaRejectedEvent",
+          "transition": "HandleRejectedVisa"
+        }
+      ],
+      "defaultCondition": {
+        "transition": "HandleNoVisaDecision"
+      }
+    },
+    {
+      "name": "HandleApprovedVisa",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleApprovedVisaWorkflowID"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name": "HandleRejectedVisa",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleRejectedVisaWorkflowID"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name": "HandleNoVisaDecision",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleNoVisaDecisionWorkflowId"
+        }
+      ],
+      "end": true
+    }
+  ]
+}

--- a/validation/src/test/resources/states/switchstate/timeouts/eventtimeout/duration/valid/state_timeout.json
+++ b/validation/src/test/resources/states/switchstate/timeouts/eventtimeout/duration/valid/state_timeout.json
@@ -1,0 +1,72 @@
+{
+  "id": "eventbasedswitchstate",
+  "version": "1.0",
+  "specVersion": "0.8",
+  "name": "Event Based Switch Transitions",
+  "description": "Event Based Switch Transitions",
+  "start": "CheckVisaStatus",
+  "events": [
+    {
+      "name": "visaApprovedEvent",
+      "type": "VisaApproved",
+      "source": "visaCheckSource"
+    },
+    {
+      "name": "visaRejectedEvent",
+      "type": "VisaRejected",
+      "source": "visaCheckSource"
+    }
+  ],
+  "states": [
+    {
+      "name": "CheckVisaStatus",
+      "type": "switch",
+      "eventConditions": [
+        {
+          "eventRef": "visaApprovedEvent",
+          "transition": "HandleApprovedVisa"
+        },
+        {
+          "eventRef": "visaRejectedEvent",
+          "transition": "HandleRejectedVisa"
+        }
+      ],
+      "timeouts": {
+        "eventTimeout": "PT1H"
+      },
+      "defaultCondition": {
+        "transition": "HandleNoVisaDecision"
+      }
+    },
+    {
+      "name": "HandleApprovedVisa",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleApprovedVisaWorkflowID"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name": "HandleRejectedVisa",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleRejectedVisaWorkflowID"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name": "HandleNoVisaDecision",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleNoVisaDecisionWorkflowId"
+        }
+      ],
+      "end": true
+    }
+  ]
+}

--- a/validation/src/test/resources/states/switchstate/timeouts/eventtimeout/duration/valid/workflow_timeout.json
+++ b/validation/src/test/resources/states/switchstate/timeouts/eventtimeout/duration/valid/workflow_timeout.json
@@ -1,0 +1,72 @@
+{
+  "id": "eventbasedswitchstate",
+  "version": "1.0",
+  "specVersion": "0.8",
+  "name": "Event Based Switch Transitions",
+  "description": "Event Based Switch Transitions",
+  "start": "CheckVisaStatus",
+  "timeouts": {
+    "eventTimeout": "PT1H"
+  },
+  "events": [
+    {
+      "name": "visaApprovedEvent",
+      "type": "VisaApproved",
+      "source": "visaCheckSource"
+    },
+    {
+      "name": "visaRejectedEvent",
+      "type": "VisaRejected",
+      "source": "visaCheckSource"
+    }
+  ],
+  "states":[
+    {
+      "name":"CheckVisaStatus",
+      "type":"switch",
+      "eventConditions": [
+        {
+          "eventRef": "visaApprovedEvent",
+          "transition": "HandleApprovedVisa"
+        },
+        {
+          "eventRef": "visaRejectedEvent",
+          "transition": "HandleRejectedVisa"
+        }
+      ],
+      "defaultCondition": {
+        "transition": "HandleNoVisaDecision"
+      }
+    },
+    {
+      "name": "HandleApprovedVisa",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleApprovedVisaWorkflowID"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name": "HandleRejectedVisa",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleRejectedVisaWorkflowID"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name": "HandleNoVisaDecision",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleNoVisaDecisionWorkflowId"
+        }
+      ],
+      "end": true
+    }
+  ]
+}

--- a/validation/src/test/resources/states/switchstate/timeouts/eventtimeout/valid/event_timeout_on_state.json
+++ b/validation/src/test/resources/states/switchstate/timeouts/eventtimeout/valid/event_timeout_on_state.json
@@ -1,0 +1,72 @@
+{
+  "id": "eventbasedswitchstate",
+  "version": "1.0",
+  "specVersion": "0.8",
+  "name": "Event Based Switch Transitions",
+  "description": "Event Based Switch Transitions",
+  "start": "CheckVisaStatus",
+  "events": [
+    {
+      "name": "visaApprovedEvent",
+      "type": "VisaApproved",
+      "source": "visaCheckSource"
+    },
+    {
+      "name": "visaRejectedEvent",
+      "type": "VisaRejected",
+      "source": "visaCheckSource"
+    }
+  ],
+  "states": [
+    {
+      "name": "CheckVisaStatus",
+      "type": "switch",
+      "timeouts": {
+        "eventTimeout": "PT1H"
+      },
+      "eventConditions": [
+        {
+          "eventRef": "visaApprovedEvent",
+          "transition": "HandleApprovedVisa"
+        },
+        {
+          "eventRef": "visaRejectedEvent",
+          "transition": "HandleRejectedVisa"
+        }
+      ],
+      "defaultCondition": {
+        "transition": "HandleNoVisaDecision"
+      }
+    },
+    {
+      "name": "HandleApprovedVisa",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleApprovedVisaWorkflowID"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name": "HandleRejectedVisa",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleRejectedVisaWorkflowID"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name": "HandleNoVisaDecision",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleNoVisaDecisionWorkflowId"
+        }
+      ],
+      "end": true
+    }
+  ]
+}

--- a/validation/src/test/resources/states/switchstate/timeouts/eventtimeout/valid/event_timeout_on_workflow.json
+++ b/validation/src/test/resources/states/switchstate/timeouts/eventtimeout/valid/event_timeout_on_workflow.json
@@ -1,0 +1,72 @@
+{
+  "id": "eventbasedswitchstate",
+  "version": "1.0",
+  "specVersion": "0.8",
+  "name": "Event Based Switch Transitions",
+  "description": "Event Based Switch Transitions",
+  "start": "CheckVisaStatus",
+  "timeouts": {
+    "eventTimeout": "PT1H"
+  },
+  "events": [
+    {
+      "name": "visaApprovedEvent",
+      "type": "VisaApproved",
+      "source": "visaCheckSource"
+    },
+    {
+      "name": "visaRejectedEvent",
+      "type": "VisaRejected",
+      "source": "visaCheckSource"
+    }
+  ],
+  "states": [
+    {
+      "name": "CheckVisaStatus",
+      "type": "switch",
+      "eventConditions": [
+        {
+          "eventRef": "visaApprovedEvent",
+          "transition": "HandleApprovedVisa"
+        },
+        {
+          "eventRef": "visaRejectedEvent",
+          "transition": "HandleRejectedVisa"
+        }
+      ],
+      "defaultCondition": {
+        "transition": "HandleNoVisaDecision"
+      }
+    },
+    {
+      "name": "HandleApprovedVisa",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleApprovedVisaWorkflowID"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name": "HandleRejectedVisa",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleRejectedVisaWorkflowID"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name": "HandleNoVisaDecision",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "handleNoVisaDecisionWorkflowId"
+        }
+      ],
+      "end": true
+    }
+  ]
+}

--- a/validation/src/test/resources/states/switchstate/timeouts/eventtimeout/valid/missing_event_timeout_on_state_without_event_condition.json
+++ b/validation/src/test/resources/states/switchstate/timeouts/eventtimeout/valid/missing_event_timeout_on_state_without_event_condition.json
@@ -1,0 +1,59 @@
+{
+  "id": "applicantrequest",
+  "version": "1.0",
+  "specVersion": "0.8",
+  "name": "Applicant Request Decision Workflow",
+  "description": "Determine if applicant request is valid",
+  "start": "CheckApplication",
+  "functions": [
+    {
+      "name": "sendRejectionEmailFunction",
+      "operation": "http://myapis.org/applicationapi.json#emailRejection"
+    }
+  ],
+  "states":[
+    {
+      "name":"CheckApplication",
+      "type":"switch",
+      "dataConditions": [
+        {
+          "condition": "${ .applicants | .age >= 18 }",
+          "transition": "StartApplication"
+        },
+        {
+          "condition": "${ .applicants | .age < 18 }",
+          "transition": "RejectApplication"
+        }
+      ],
+      "defaultCondition": {
+        "transition": "RejectApplication"
+      }
+    },
+    {
+      "name": "StartApplication",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": "startApplicationWorkflowId"
+        }
+      ],
+      "end": true
+    },
+    {
+      "name":"RejectApplication",
+      "type":"operation",
+      "actionMode":"sequential",
+      "actions":[
+        {
+          "functionRef": {
+            "refName": "sendRejectionEmailFunction",
+            "arguments": {
+              "applicant": "${ .applicant }"
+            }
+          }
+        }
+      ],
+      "end": true
+    }
+  ]
+}


### PR DESCRIPTION
This is a work in progress...

# Validations Implemented

- [x] Switch state must contains dataCondition or eventCondition, not both
- [x] Switch state - Default condition - next state or end required
- [x] Switch state - Default condition - next state must be the name of an existing state
- [x] Switch state - Event conditions - timeout required
- [x] States - Event timeout - timeout must be a valid duration

# Final proposal

Validations are grouped by workflow definitions (state, even, function...).

# Initial proposal (not approved)

I'm implementing new workflow validations and wanted to check what do you guys think of my approach?
Currently, we’re performing all the validations in the `io.serverlessworkflow.validation.WorkflowValidatorImpl#validate` method. That method already is quite long, and my new validations would make it even longer. That would increase the code complexity and it would become harder to test.
So I decided to break the new validations into new classes.

I created this `io.serverlessworkflow.validation.WorkflowValidation` interface:
```java
interface WorkflowValidation {
  List<ValidationError> validate(Workflow workflow);
}
```

Each validation will implement that interface and be registered as a service on `resources/META-INF/services/io.serverlessworkflow.validation.WorkflowValidation`, so the original `WorkflowValidatorImpl#validate` method can load those services and perform the validations.

The current validations are still in the original method. I only implemented a couple of new validations in this new structure. If you like it, we can move all the validations to their respective classes in the future.

Advantages of this approach:

- The validation code is simpler and easier to read, since it only cares about what's being validated.
- The code is easier to test, since we don't need a full valid workflow to test a class. We can just set the workflow elements that matter for that test and we don't need to care about the other ones.
- Changes in one validation won't affect other validation tests.
    For instance: If we have a new required attribute in the spec, we just have to create a new validation and test it. We don't need to change all the other tests to include this new required attribute, because they don't care about this new attribute.

Disadvantage of this approach:
- We'll might lose a bit of performance, since we'll visit the same structure more than once. But, I don't believe this will be significant.

Please let me know what do you think and if I can continue implementing the validations this way. Feel free to suggest improvements in this solution as well.