### PR TITLE
Created a new POJO for DataInputSchema to support inline schema

### DIFF
--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/DataInputSchemaDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/DataInputSchemaDeserializer.java
@@ -47,16 +47,14 @@ public class DataInputSchemaDeserializer extends StdDeserializer<DataInputSchema
 
     DataInputSchema dataInputSchema = new DataInputSchema();
 
-    if (!node.isObject()) {
-      dataInputSchema.setSchema(node.asText());
-      dataInputSchema.setFailOnValidationErrors(true); // default
-
-      return dataInputSchema;
-    } else {
+    if (node.get("schemaContent") == null || node.get("schemaContent").isEmpty() ||
+            !node.get("schemaContent").isObject()) {
       dataInputSchema.setSchema(node.get("schema").asText());
+      dataInputSchema.setFailOnValidationErrors(true); // default
+    } else {
+      dataInputSchema.setSchemaContent(node.get("schemaContent"));
       dataInputSchema.setFailOnValidationErrors(node.get("failOnValidationErrors").asBoolean());
-
-      return dataInputSchema;
     }
+    return dataInputSchema;
   }
 }

--- a/api/src/main/java/io/serverlessworkflow/api/mapper/BaseObjectMapper.java
+++ b/api/src/main/java/io/serverlessworkflow/api/mapper/BaseObjectMapper.java
@@ -15,10 +15,12 @@
  */
 package io.serverlessworkflow.api.mapper;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
+import java.util.Map;
 
 public class BaseObjectMapper extends ObjectMapper {
 
@@ -31,6 +33,11 @@ public class BaseObjectMapper extends ObjectMapper {
 
     configure(SerializationFeature.INDENT_OUTPUT, true);
     registerModule(workflowModule);
+    configure(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS, false);
+    configOverride(Map.class)
+        .setInclude(
+            JsonInclude.Value.construct(
+                JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL));
   }
 
   public WorkflowModule getWorkflowModule() {

--- a/api/src/main/java/io/serverlessworkflow/api/workflow/DataInputSchema.java
+++ b/api/src/main/java/io/serverlessworkflow/api/workflow/DataInputSchema.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.api.workflow;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class DataInputSchema {
+  private String schema;
+  private JsonNode schemaContent;
+  private boolean failOnValidationErrors = true;
+
+  public DataInputSchema() {}
+
+  public String getSchema() {
+    return schema;
+  }
+
+  public void setSchema(String schema) {
+    this.schema = schema;
+  }
+
+  public JsonNode getSchemaContent() {
+    return schemaContent;
+  }
+
+  public void setSchemaContent(JsonNode schemaContent) {
+    this.schemaContent = schemaContent;
+  }
+
+  public boolean isFailOnValidationErrors() {
+    return failOnValidationErrors;
+  }
+
+  public void setFailOnValidationErrors(boolean failOnValidationErrors) {
+    this.failOnValidationErrors = failOnValidationErrors;
+  }
+}

--- a/api/src/main/resources/schema/datainputschema/datainputschema.json
+++ b/api/src/main/resources/schema/datainputschema/datainputschema.json
@@ -8,6 +8,11 @@
       "description":  "URI of the JSON Schema used to validate the workflow data input",
       "minLength": 1
     },
+    "schemaContent":  {
+      "type": "object",
+      "description": "The JSON Schema object used to validate the workflow data input",
+      "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"
+    },
     "failOnValidationErrors": {
       "type": "boolean",
       "default": true,
@@ -15,7 +20,6 @@
     }
   },
   "required": [
-    "schema",
     "failOnValidationErrors"
   ]
 }

--- a/api/src/main/resources/schema/switchconditions/datacondition.json
+++ b/api/src/main/resources/schema/switchconditions/datacondition.json
@@ -23,8 +23,18 @@
       "description": "Workflow end definition"
     }
   },
-  "required": [
-    "condition",
-    "transition"
+  "oneOf": [
+    {
+      "required": [
+        "condition",
+        "transition"
+      ]
+    },
+    {
+      "required": [
+        "condition",
+        "end"
+      ]
+    }
   ]
 }

--- a/api/src/test/java/io/serverlessworkflow/api/test/MarkupToWorkflowTest.java
+++ b/api/src/test/java/io/serverlessworkflow/api/test/MarkupToWorkflowTest.java
@@ -492,9 +492,17 @@ public class MarkupToWorkflowTest {
     assertNotNull(workflow.getName());
     assertNotNull(workflow.getStates());
 
+    assertNotNull(workflow.getDataInputSchema());
     DataInputSchema dataInputSchema = workflow.getDataInputSchema();
-    assertNotNull(dataInputSchema);
-    assertEquals("somejsonschema.json", dataInputSchema.getSchema());
+    assertNotNull(dataInputSchema.getSchemaContent());
+
+    JsonNode schemaObj = dataInputSchema.getSchemaContent();
+    assertNotNull(schemaObj.get("properties"));
+    JsonNode properties = schemaObj.get("properties");
+    assertNotNull(properties.get("firstName"));
+    JsonNode typeNode = properties.get("firstName");
+    JsonNode stringNode = typeNode.get("type");
+    assertEquals("string", stringNode.asText());
     assertFalse(dataInputSchema.isFailOnValidationErrors());
   }
 

--- a/api/src/test/java/io/serverlessworkflow/api/test/WorkflowToMarkupTest.java
+++ b/api/src/test/java/io/serverlessworkflow/api/test/WorkflowToMarkupTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.serverlessworkflow.api.Workflow;
 import io.serverlessworkflow.api.auth.AuthDefinition;
 import io.serverlessworkflow.api.auth.BasicAuthDefinition;
+import io.serverlessworkflow.api.defaultdef.DefaultConditionDefinition;
 import io.serverlessworkflow.api.end.End;
 import io.serverlessworkflow.api.events.EventDefinition;
 import io.serverlessworkflow.api.functions.FunctionDefinition;
@@ -31,6 +32,10 @@ import io.serverlessworkflow.api.produce.ProduceEvent;
 import io.serverlessworkflow.api.schedule.Schedule;
 import io.serverlessworkflow.api.start.Start;
 import io.serverlessworkflow.api.states.SleepState;
+import io.serverlessworkflow.api.states.SwitchState;
+import io.serverlessworkflow.api.switchconditions.DataCondition;
+import io.serverlessworkflow.api.switchconditions.EventCondition;
+import io.serverlessworkflow.api.transitions.Transition;
 import io.serverlessworkflow.api.workflow.Auth;
 import io.serverlessworkflow.api.workflow.Constants;
 import io.serverlessworkflow.api.workflow.Events;
@@ -188,5 +193,47 @@ public class WorkflowToMarkupTest {
     assertEquals("testuser", workflow.getAuth().getAuthDefs().get(0).getBasicauth().getUsername());
     assertEquals(
         "testPassword", workflow.getAuth().getAuthDefs().get(0).getBasicauth().getPassword());
+  }
+
+  @Test
+  public void testSwitchConditionWithTransition() {
+    Workflow workflow =
+        new Workflow()
+            .withId("test-workflow")
+            .withName("test-workflow-name")
+            .withVersion("1.0")
+            .withSpecVersion("0.8")
+            .withStates(
+                Arrays.asList(
+                    new SwitchState()
+                        .withDataConditions(
+                            Arrays.asList(
+                                new DataCondition()
+                                    .withCondition("test-condition")
+                                    .withTransition(
+                                        new Transition().withNextState("test-next-state"))))
+                        .withDefaultCondition(
+                            new DefaultConditionDefinition()
+                                .withTransition(new Transition("test-next-state-default")))));
+    assertNotNull(Workflow.toJson(workflow));
+    assertNotNull(Workflow.toYaml(workflow));
+  }
+
+  @Test
+  public void testSwitchConditionWithEnd() {
+    Workflow workflow =
+        new Workflow()
+            .withId("test-workflow")
+            .withName("test-workflow-name")
+            .withVersion("1.0")
+            .withSpecVersion("0.8")
+            .withStates(
+                Arrays.asList(
+                    new SwitchState()
+                        .withEventConditions(Arrays.asList(new EventCondition().withEnd(new End())))
+                        .withDefaultCondition(
+                            new DefaultConditionDefinition().withEnd(new End()))));
+    assertNotNull(Workflow.toJson(workflow));
+    assertNotNull(Workflow.toYaml(workflow));
   }
 }

--- a/api/src/test/resources/features/datainputschemaobj.json
+++ b/api/src/test/resources/features/datainputschemaobj.json
@@ -4,7 +4,18 @@
   "specVersion": "0.8",
   "name": "Data Input Schema test",
   "dataInputSchema": {
-    "schema": "somejsonschema.json",
+    "schema":null,
+    "schemaContent":{
+      "title": "MyJSONSchema",
+      "properties":{
+        "firstName":{
+          "type": "string"
+        },
+        "lastName":{
+          "type": "string"
+        }
+      }
+    },
     "failOnValidationErrors": false
   },
   "start": "TestFunctionRefs",

--- a/api/src/test/resources/features/datainputschemaobj.yml
+++ b/api/src/test/resources/features/datainputschemaobj.yml
@@ -3,7 +3,14 @@ version: '1.0'
 specVersion: '0.8'
 name: Data Input Schema test
 dataInputSchema:
-  schema: somejsonschema.json
+  schema:
+  schemaContent:
+    title: MyJSONSchema
+    properties:
+      firstName:
+        type: string
+      lastName:
+        type: string
   failOnValidationErrors: false
 start: TestFunctionRefs
 states:

--- a/api/src/test/resources/features/datainputschemastring.json
+++ b/api/src/test/resources/features/datainputschemastring.json
@@ -3,7 +3,10 @@
   "version": "1.0",
   "specVersion": "0.8",
   "name": "Data Input Schema test",
-  "dataInputSchema": "somejsonschema.json",
+  "dataInputSchema": {
+    "schema": "somejsonschema.json",
+    "failOnValidationErrors": false
+  },
   "start": "TestFunctionRefs",
   "states": [
     {

--- a/api/src/test/resources/features/datainputschemastring.yml
+++ b/api/src/test/resources/features/datainputschemastring.yml
@@ -2,7 +2,9 @@ id: datainputschemaobj
 version: '1.0'
 specVersion: '0.8'
 name: Data Input Schema test
-dataInputSchema: somejsonschema.json
+dataInputSchema:
+  schema: somejsonschema.json
+  failOnValidationErrors: false
 start: TestFunctionRefs
 states:
   - name: TestFunctionRefs


### PR DESCRIPTION
Currently SDK is not supporting the inline schema as mentioned in the spec. It is supporting only URI.
Created a new pojo for DataInputSchema to handle the same. Also, made the related changes to DataInputSchemaDeserializer and created supporting tests.