### PR TITLE
Change to not initialize collections by default on generated POJOs

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -97,6 +97,7 @@
                     <outputDirectory>${project.build.directory}/generated-sources/src/main/java</outputDirectory>
                     <includeJsr303Annotations>true</includeJsr303Annotations>
                     <generateBuilders>true</generateBuilders>
+                    <initializeCollections>false</initializeCollections>
                     <includeAdditionalProperties>false</includeAdditionalProperties>
                     <includeToString>false</includeToString>
                     <includeHashcodeAndEquals>false</includeHashcodeAndEquals>

--- a/api/src/test/java/io/serverlessworkflow/api/test/CodegenTest.java
+++ b/api/src/test/java/io/serverlessworkflow/api/test/CodegenTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.api.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.serverlessworkflow.api.Workflow;
+import io.serverlessworkflow.api.test.utils.WorkflowTestUtils;
+import org.junit.jupiter.api.Test;
+
+class CodegenTest {
+
+  @Test
+  void collectionsShouldNotBeInitializedByDefault() {
+    Workflow workflow =
+        Workflow.fromSource(WorkflowTestUtils.readWorkflowFile("/features/functionrefs.json"));
+    assertThat(workflow.getAnnotations()).isNull();
+  }
+}

--- a/api/src/test/java/io/serverlessworkflow/api/test/MarkupToWorkflowTest.java
+++ b/api/src/test/java/io/serverlessworkflow/api/test/MarkupToWorkflowTest.java
@@ -229,8 +229,7 @@ public class MarkupToWorkflowTest {
     DefaultConditionDefinition defaultDefinition = switchState.getDefaultCondition();
     assertNotNull(defaultDefinition.getTransition());
     assertEquals("RejectApplication", defaultDefinition.getTransition().getNextState());
-    assertNotNull(defaultDefinition.getTransition().getProduceEvents());
-    assertTrue(defaultDefinition.getTransition().getProduceEvents().isEmpty());
+    assertNull(defaultDefinition.getTransition().getProduceEvents());
     assertTrue(defaultDefinition.getTransition().isCompensate());
   }
 


### PR DESCRIPTION
Fixes https://github.com/serverlessworkflow/sdk-java/issues/204.

Changes:
* Set [initializeCollections](https://joelittlejohn.github.io/jsonschema2pojo/site/1.1.2/generate-mojo.html#initializeCollections) jsonschema2pojo property to `false`
* Added test
* Fixed test that started to fail after setting `initializeCollections` to `false`