### PR TITLE
Used Bean Validations to validate workflows

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -40,8 +40,19 @@
             <version>[2.13.0,)</version>
         </dependency>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>7.0.3.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.el</artifactId>
+            <version>4.0.2</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>
@@ -96,6 +107,7 @@
                     <targetPackage>io.serverlessworkflow.api.types</targetPackage>
                     <outputDirectory>${project.build.directory}/generated-sources/src/main/java</outputDirectory>
                     <includeJsr303Annotations>true</includeJsr303Annotations>
+                    <useJakartaValidation>true</useJakartaValidation>
                     <generateBuilders>true</generateBuilders>
                     <includeAdditionalProperties>false</includeAdditionalProperties>
                     <includeToString>false</includeToString>

--- a/api/src/main/resources/schema/events/onevents.json
+++ b/api/src/main/resources/schema/events/onevents.json
@@ -6,6 +6,7 @@
     "eventRefs": {
       "type": "array",
       "description": "References one or more unique event names in the defined workflow events",
+      "minItems": 1,
       "items": {
         "type": "object",
         "existingJavaType": "java.lang.String"

--- a/api/src/main/resources/schema/workflow.json
+++ b/api/src/main/resources/schema/workflow.json
@@ -25,7 +25,8 @@
     },
     "version": {
       "type": "string",
-      "description": "Workflow version"
+      "description": "Workflow version",
+      "minLength": 1
     },
     "annotations": {
       "type": "array",
@@ -144,7 +145,8 @@
             "$ref": "states/callbackstate.json"
           }
         ]
-      }
+      },
+      "minItems": 1
     },
     "extensions": {
       "type": "array",

--- a/pom.xml
+++ b/pom.xml
@@ -48,14 +48,14 @@
 
         <version.org.slf4j>1.7.25</version.org.slf4j>
         <version.com.fasterxml.jackson>2.10.3</version.com.fasterxml.jackson>
-        <version.javax.validation>2.0.1.Final</version.javax.validation>
+        <version.jakarta.validation>3.0.2</version.jakarta.validation>
         <version.org.junit.minor>6.0</version.org.junit.minor>
         <version.org.junit>5.${version.org.junit.minor}</version.org.junit>
         <version.org.junit.jupiter>${version.org.junit}</version.org.junit.jupiter>
         <version.org.mockito>3.0.0</version.org.mockito>
         <version.ch.qos.logback>1.1.3</version.ch.qos.logback>
         <version.org.assertj>3.13.2</version.org.assertj>
-        <version.jsonschema2pojo-maven-plugin>1.0.1</version.jsonschema2pojo-maven-plugin>
+        <version.jsonschema2pojo-maven-plugin>1.1.2 </version.jsonschema2pojo-maven-plugin>
         <commons.lang.version>3.9</commons.lang.version>
         <hamcrest.version>1.3</hamcrest.version>
         <jsonassert.version>1.5.0</jsonassert.version>
@@ -118,9 +118,9 @@
                 <version>${version.com.fasterxml.jackson}</version>
             </dependency>
             <dependency>
-                <groupId>javax.validation</groupId>
+                <groupId>jakarta.validation</groupId>
                 <artifactId>validation-api</artifactId>
-                <version>${version.javax.validation}</version>
+                <version>${version.jakarta.validation}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/validation/src/test/java/io/serverlessworkflow/validation/test/WorkflowValidationTest.java
+++ b/validation/src/test/java/io/serverlessworkflow/validation/test/WorkflowValidationTest.java
@@ -24,7 +24,7 @@ import io.serverlessworkflow.api.start.Start;
 import io.serverlessworkflow.api.states.SleepState;
 import io.serverlessworkflow.api.validation.ValidationError;
 import io.serverlessworkflow.validation.WorkflowValidatorImpl;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -54,10 +54,14 @@ public class WorkflowValidationTest {
     Workflow workflow =
         new Workflow()
             .withId("test-workflow")
+            .withName("Test workflow")
+            /* We need to force null annotations while https://github.com/serverlessworkflow/sdk-java/issues/204 is not
+            fixed */
+            .withAnnotations(null)
             .withVersion("1.0")
             .withStart(new Start())
             .withStates(
-                Arrays.asList(
+                Collections.singletonList(
                     new SleepState()
                         .withName("sleepState")
                         .withType(SLEEP)
@@ -90,7 +94,8 @@ public class WorkflowValidationTest {
     Assertions.assertNotNull(validationErrors);
     Assertions.assertEquals(1, validationErrors.size());
 
-    Assertions.assertEquals("No states found", validationErrors.get(0).getMessage());
+    Assertions.assertEquals(
+        "#/states: expected minimum item count: 1, found: 0", validationErrors.get(0).getMessage());
   }
 
   @Test
@@ -103,6 +108,10 @@ public class WorkflowValidationTest {
                     + "\"id\": \"checkInbox\",\n"
                     + "  \"name\": \"Check Inbox Workflow\",\n"
                     + "\"description\": \"Periodically Check Inbox\",\n"
+                    /*
+                    annotations is needed while https://github.com/serverlessworkflow/sdk-java/issues/204 is not fixed
+                     */
+                    + "\"annotations\": [ \"test\"],\n"
                     + "\"version\": \"1.0\",\n"
                     + "\"start\": \"CheckInbox\",\n"
                     + "\"functions\": [\n"
@@ -117,7 +126,15 @@ public class WorkflowValidationTest {
                     + "            {\n"
                     + "                \"functionRef\": {\n"
                     + "                    \"refName\": \"checkInboxFunction\"\n"
-                    + "                }\n"
+                    + "                },\n"
+                    /*
+                    nonRetryableErrors is needed while https://github.com/serverlessworkflow/sdk-java/issues/204 is not fixed
+                     */
+                    + "                \"nonRetryableErrors\": [ \"an_error\"],\n"
+                    /*
+                    retryableErrors is needed while https://github.com/serverlessworkflow/sdk-java/issues/204 is not fixed
+                     */
+                    + "                \"retryableErrors\": [ \"an_error\"]\n"
                     + "            }\n"
                     + "        ],\n"
                     + "        \"transition\": {\n"
@@ -150,9 +167,13 @@ public class WorkflowValidationTest {
     Workflow workflow =
         new Workflow()
             .withId("test-workflow")
+            .withName("test workflow")
             .withVersion("1.0")
+            /* We need to force null annotations while https://github.com/serverlessworkflow/sdk-java/issues/204 is not
+            fixed */
+            .withAnnotations(null)
             .withStates(
-                Arrays.asList(
+                Collections.singletonList(
                     new SleepState()
                         .withName("sleepState")
                         .withType(SLEEP)
@@ -175,6 +196,10 @@ public class WorkflowValidationTest {
                     + "\"id\": \"checkInbox\",\n"
                     + "  \"name\": \"Check Inbox Workflow\",\n"
                     + "\"description\": \"Periodically Check Inbox\",\n"
+                    /*
+                    annotations is needed while https://github.com/serverlessworkflow/sdk-java/issues/204 is not fixed
+                     */
+                    + "\"annotations\": [ \"test\"],\n"
                     + "\"version\": \"1.0\",\n"
                     + "\"start\": \"CheckInbox\",\n"
                     + "\"functions\": [\n"
@@ -189,7 +214,15 @@ public class WorkflowValidationTest {
                     + "            {\n"
                     + "                \"functionRef\": {\n"
                     + "                    \"refName\": \"checkInboxFunction\"\n"
-                    + "                }\n"
+                    + "                },\n"
+                    /*
+                    nonRetryableErrors is needed while https://github.com/serverlessworkflow/sdk-java/issues/204 is not fixed
+                     */
+                    + "                \"nonRetryableErrors\": [ \"an_error\"],\n"
+                    /*
+                    retryableErrors is needed while https://github.com/serverlessworkflow/sdk-java/issues/204 is not fixed
+                     */
+                    + "                \"retryableErrors\": [ \"an_error\"]\n"
                     + "            }\n"
                     + "        ],\n"
                     + "        \"transition\": {\n"
@@ -225,6 +258,10 @@ public class WorkflowValidationTest {
                     + "  \"version\": \"1.0\",\n"
                     + "  \"specVersion\": \"0.8\",\n"
                     + "  \"name\": \"Callback State Test\",\n"
+                    /*
+                    annotations is needed while https://github.com/serverlessworkflow/sdk-java/issues/204 is not fixed
+                     */
+                    + "\"annotations\": [ \"test\"],\n"
                     + "  \"start\": \"CheckCredit\",\n"
                     + "  \"states\": [\n"
                     + "    {\n"
@@ -236,7 +273,15 @@ public class WorkflowValidationTest {
                     + "          \"arguments\": {\n"
                     + "            \"customer\": \"${ .customer }\"\n"
                     + "          }\n"
-                    + "        }\n"
+                    + "        },\n"
+                    /*
+                    nonRetryableErrors is needed while https://github.com/serverlessworkflow/sdk-java/issues/204 is not fixed
+                     */
+                    + "        \"nonRetryableErrors\": [ \"an_error\"],\n"
+                    /*
+                    retryableErrors is needed while https://github.com/serverlessworkflow/sdk-java/issues/204 is not fixed
+                     */
+                    + "        \"retryableErrors\": [ \"an_error\"]\n"
                     + "      },\n"
                     + "      \"eventRef\": \"CreditCheckCompletedEvent\",\n"
                     + "      \"timeouts\": {\n"


### PR DESCRIPTION
By using Jakarta Bean Validations we automatically gain several validations and we can remove some of those manually implemented.

This PR: 

- Adds an invocation of Bean Validations to `WorkflowValidatorImpl`
- Removes existing manually implemented validations that are automatically done by Bean Validations
- Updates Java Bean Validations dependency to the re-branded Jakarta Bean Validations
- Includes Bean Validations implementation as dependency
  - Hibernate Validator
  - Glassfish Jakarta Expression Language (EL) Implementation
- Updates jsonschema2pojo Maven plugin to support Jakarta Bean Validations
- Fixes schemas to match https://serverlessworkflow.io/schemas/0.8/workflow.json for tests that started to fail after using Bean Validations