### PR TITLE
Make serialized workflow compatible with schema

### DIFF
--- a/api/src/main/java/io/serverlessworkflow/api/serializers/WorkflowSerializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/serializers/WorkflowSerializer.java
@@ -110,9 +110,6 @@ public class WorkflowSerializer extends StdSerializer<Workflow> {
         gen.writeObject(eventDefinition);
       }
       gen.writeEndArray();
-    } else {
-      gen.writeArrayFieldStart("events");
-      gen.writeEndArray();
     }
 
     if (workflow.getFunctions() != null && !workflow.getFunctions().getFunctionDefs().isEmpty()) {
@@ -120,9 +117,6 @@ public class WorkflowSerializer extends StdSerializer<Workflow> {
       for (FunctionDefinition function : workflow.getFunctions().getFunctionDefs()) {
         gen.writeObject(function);
       }
-      gen.writeEndArray();
-    } else {
-      gen.writeArrayFieldStart("functions");
       gen.writeEndArray();
     }
 
@@ -132,9 +126,6 @@ public class WorkflowSerializer extends StdSerializer<Workflow> {
         gen.writeObject(retry);
       }
       gen.writeEndArray();
-    } else {
-      gen.writeArrayFieldStart("retries");
-      gen.writeEndArray();
     }
 
     if (workflow.getErrors() != null && !workflow.getErrors().getErrorDefs().isEmpty()) {
@@ -143,9 +134,6 @@ public class WorkflowSerializer extends StdSerializer<Workflow> {
         gen.writeObject(error);
       }
       gen.writeEndArray();
-    } else {
-      gen.writeArrayFieldStart("errors");
-      gen.writeEndArray();
     }
 
     if (workflow.getSecrets() != null && !workflow.getSecrets().getSecretDefs().isEmpty()) {
@@ -153,9 +141,6 @@ public class WorkflowSerializer extends StdSerializer<Workflow> {
       for (String secretDef : workflow.getSecrets().getSecretDefs()) {
         gen.writeString(secretDef);
       }
-      gen.writeEndArray();
-    } else {
-      gen.writeArrayFieldStart("secrets");
       gen.writeEndArray();
     }
 
@@ -181,9 +166,6 @@ public class WorkflowSerializer extends StdSerializer<Workflow> {
       for (State state : workflow.getStates()) {
         gen.writeObject(state);
       }
-      gen.writeEndArray();
-    } else {
-      gen.writeArrayFieldStart("states");
       gen.writeEndArray();
     }
 


### PR DESCRIPTION
Before the PR, the file resulting of executing this code
```
Workflow workflow = new Workflow("HelloWorld", "Hello World", "1.0", Arrays.asList(
             new InjectState(START_STATE, Type.INJECT).withData(new ObjectMapper().createObjectNode().put("response","Hello World!!!")).withEnd(new End())))
             .withStart(new Start().withStateName(START_STATE));
try (Writer writer = new FileWriter("helloworld.json")) {
        new JsonObjectMapper().writeValue(writer, workflow);
        } catch (IOException io) {
            throw new UncheckedIOException(io);
        }
```

was 
```

{
  "id" : "HelloWorld",
  "name" : "HelloWorld",
  "version" : "1_0",
  "start" : "inject_0",
  "expressionLang" : "jq",
  "events" : [ ],
  "functions" : [ ],
  "retries" : [ ],
  "errors" : [ ],
  "secrets" : [ ],
  "states" : [ {
    "data" : {
      "response" : "Hello World!!!"
    },
    "usedForCompensation" : false,
    "name" : "inject_0",
    "type" : "inject",
    "end" : true,
    "onErrors" : [ ]
  } ]
}
```
which is not compatible with json schema (becasuse, for example, events, functions, retries, errores, secrets should be not present or has at least 1 element)

After the change, the result is 

```
{
  "id" : "HelloWorld",
  "name" : "HelloWorld",
  "version" : "1_0",
  "start" : "inject_0",
  "expressionLang" : "jq",
  "states" : [ {
    "data" : {
      "response" : "Hello World!!!"
    },
    "usedForCompensation" : false,
    "name" : "inject_0",
    "type" : "inject",
    "end" : true
  } ]
}
```
which is schema compatible