### PR TITLE
add missing support for contextAttributes in ProduceEvent

### DIFF
--- a/api/src/main/resources/schema/produce/produceevent.json
+++ b/api/src/main/resources/schema/produce/produceevent.json
@@ -10,6 +10,11 @@
     "data": {
       "type": "string",
       "description": "Workflow expression which selects parts of the states data output to become the data of the produced event"
+    },
+    "contextAttributes": {
+      "type": "object",
+      "description": "Add additional event extension context attributes",
+      "existingJavaType": "java.util.Map<String, String>"
     }
   },
   "required": [

--- a/api/src/test/java/io/serverlessworkflow/api/test/MarkupToWorkflowTest.java
+++ b/api/src/test/java/io/serverlessworkflow/api/test/MarkupToWorkflowTest.java
@@ -40,6 +40,8 @@ import io.serverlessworkflow.api.test.utils.WorkflowTestUtils;
 import io.serverlessworkflow.api.timeouts.WorkflowExecTimeout;
 import io.serverlessworkflow.api.workflow.*;
 import java.util.List;
+import java.util.Map;
+
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -260,6 +262,11 @@ public class MarkupToWorkflowTest {
     assertEquals("RejectApplication", cond2.getTransition().getNextState());
     assertNotNull(cond2.getTransition().getProduceEvents());
     assertEquals(1, cond2.getTransition().getProduceEvents().size());
+    assertNotNull(cond2.getTransition().getProduceEvents().get(0).getContextAttributes());
+    Map<String, String> contextAttributes = cond2.getTransition().getProduceEvents().get(0).getContextAttributes();
+    assertEquals(2, contextAttributes.size());
+    assertEquals("IN", contextAttributes.get("order_location"));
+    assertEquals("online", contextAttributes.get("order_type"));
     assertFalse(cond2.getTransition().isCompensate());
 
     assertNotNull(switchState.getDefaultCondition());

--- a/api/src/test/resources/features/transitions.json
+++ b/api/src/test/resources/features/transitions.json
@@ -23,7 +23,11 @@
             "produceEvents": [
               {
                 "eventRef": "provisioningCompleteEvent",
-                "data": "${ .provisionedOrders }"
+                "data": "${ .provisionedOrders }",
+                "contextAttributes": {
+                  "order_location": "IN",
+                  "order_type": "online"
+                }
               }
             ]
           }

--- a/api/src/test/resources/features/transitions.yml
+++ b/api/src/test/resources/features/transitions.yml
@@ -18,6 +18,9 @@ states:
           produceEvents:
             - eventRef: provisioningCompleteEvent
               data: "${ .provisionedOrders }"
+              contextAttributes:
+                "order_location": "IN"
+                "order_type": "online"
     defaultCondition:
       transition:
         nextState: RejectApplication


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**: 
The ProduceEvent Definition [here](https://github.com/serverlessworkflow/specification/blob/0.8.x/specification.md#producedevent-definition) has this concept of contextAttributes but in the SDK, the POJO does not have it ([ref](https://github.com/serverlessworkflow/sdk-java/blob/dc1a9dc48d75764fcd16a51c60f06f0718a3696e/api/src/main/resources/schema/produce/produceevent.json#L4)). Which causes exception at the time of converting String to Workflow POJO.
This PR attempts to fix that.

**Special notes for reviewers**:
N/A
**Additional information (if needed):**
N/A