### PR TITLE
Make classes serializable

### DIFF
--- a/api/src/main/java/io/serverlessworkflow/api/workflow/Auth.java
+++ b/api/src/main/java/io/serverlessworkflow/api/workflow/Auth.java
@@ -17,10 +17,11 @@
 package io.serverlessworkflow.api.workflow;
 
 import io.serverlessworkflow.api.auth.AuthDefinition;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-public class Auth {
+public class Auth implements Serializable {
   private String refValue;
   private List<AuthDefinition> authDefs;
 

--- a/api/src/main/java/io/serverlessworkflow/api/workflow/Constants.java
+++ b/api/src/main/java/io/serverlessworkflow/api/workflow/Constants.java
@@ -16,8 +16,9 @@
 package io.serverlessworkflow.api.workflow;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.io.Serializable;
 
-public class Constants {
+public class Constants implements Serializable {
   private String refValue;
   private JsonNode constantsDef;
 

--- a/api/src/main/java/io/serverlessworkflow/api/workflow/DataInputSchema.java
+++ b/api/src/main/java/io/serverlessworkflow/api/workflow/DataInputSchema.java
@@ -16,8 +16,9 @@
 package io.serverlessworkflow.api.workflow;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.io.Serializable;
 
-public class DataInputSchema {
+public class DataInputSchema implements Serializable {
   private String refValue;
   private JsonNode schemaDef;
   private boolean failOnValidationErrors = true;

--- a/api/src/main/java/io/serverlessworkflow/api/workflow/Errors.java
+++ b/api/src/main/java/io/serverlessworkflow/api/workflow/Errors.java
@@ -16,9 +16,10 @@
 package io.serverlessworkflow.api.workflow;
 
 import io.serverlessworkflow.api.error.ErrorDefinition;
+import java.io.Serializable;
 import java.util.List;
 
-public class Errors {
+public class Errors implements Serializable {
   private String refValue;
   private List<ErrorDefinition> errorDefs;
 

--- a/api/src/main/java/io/serverlessworkflow/api/workflow/Functions.java
+++ b/api/src/main/java/io/serverlessworkflow/api/workflow/Functions.java
@@ -16,9 +16,10 @@
 package io.serverlessworkflow.api.workflow;
 
 import io.serverlessworkflow.api.functions.FunctionDefinition;
+import java.io.Serializable;
 import java.util.List;
 
-public class Functions {
+public class Functions implements Serializable {
   private String refValue;
   private List<FunctionDefinition> functionDefs;
 

--- a/api/src/main/java/io/serverlessworkflow/api/workflow/Retries.java
+++ b/api/src/main/java/io/serverlessworkflow/api/workflow/Retries.java
@@ -16,9 +16,10 @@
 package io.serverlessworkflow.api.workflow;
 
 import io.serverlessworkflow.api.retry.RetryDefinition;
+import java.io.Serializable;
 import java.util.List;
 
-public class Retries {
+public class Retries implements Serializable {
   private String refValue;
   private List<RetryDefinition> retryDefs;
 

--- a/api/src/main/java/io/serverlessworkflow/api/workflow/Secrets.java
+++ b/api/src/main/java/io/serverlessworkflow/api/workflow/Secrets.java
@@ -15,9 +15,10 @@
  */
 package io.serverlessworkflow.api.workflow;
 
+import java.io.Serializable;
 import java.util.List;
 
-public class Secrets {
+public class Secrets implements Serializable {
   private String refValue;
   private List<String> secretDefs;
 


### PR DESCRIPTION

**What this PR does / why we need it**:
There were some manually created POJOs which did not implement serializable interface. Making those implement Serializable interface here. This will enable Workflow objects transferrable over wire. 