### PR TITLE
Force id to be mandatory

### DIFF
--- a/api/src/main/resources/schema/workflow.json
+++ b/api/src/main/resources/schema/workflow.json
@@ -161,6 +161,7 @@
     }
   },
  "required": [
+        "id",
         "name",
         "version",
         "states"

--- a/validation/src/test/java/io/serverlessworkflow/validation/test/WorkflowValidationTest.java
+++ b/validation/src/test/java/io/serverlessworkflow/validation/test/WorkflowValidationTest.java
@@ -58,7 +58,7 @@ public class WorkflowValidationTest {
     List<ValidationError> validationErrors =
         workflowValidator.setSource("---\n" + "key: abc\n").validate();
     Assertions.assertNotNull(validationErrors);
-    Assertions.assertEquals(3, validationErrors.size());
+    Assertions.assertEquals(4, validationErrors.size());
   }
 
   @Test
@@ -119,11 +119,10 @@ public class WorkflowValidationTest {
                     + "}")
             .validate();
     Assertions.assertNotNull(validationErrors);
-    Assertions.assertEquals(2, validationErrors.size());
+    Assertions.assertEquals(1, validationErrors.size());
 
     Assertions.assertEquals(
-        "Workflow id or key should not be empty", validationErrors.get(0).getMessage());
-    Assertions.assertEquals("No states found", validationErrors.get(1).getMessage());
+        "$.id: is missing but it is required", validationErrors.get(0).getMessage());
   }
 
   @Test


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
This makes id mandatory, keeping current constructor unchanged from the previous version

**Special notes for reviewers**:

**Additional information (if needed):**
SDK has currently two misaligments with the spec: id and name are mandatory, while the former is mandatory only if there is no key and the latter is optional. Since making id optionally depending on key is not a good idea that will be probably changed in 0.9 (where ID will be mandatory always and key removed or make optional), I think is better to postpone the API breaking change to the migration to 0.9