### PR TITLE
Prepare 4.0.5.1 release

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: 4.0.5
+  current-version: 4.0.5.1
   next-version: 5.0.0-SNAPSHOT

--- a/README.md
+++ b/README.md
@@ -20,9 +20,7 @@ to parse and validate workflow definitions as well as generate the workflow diag
 
 | Latest Releases | Conformance to spec version |
 | :---: | :---: |
-| [4.0.4.Final](https://github.com/serverlessworkflow/sdk-java/releases/) | [v0.8](https://github.com/serverlessworkflow/specification/tree/0.8.x) |
-| [4.0.3.Final](https://github.com/serverlessworkflow/sdk-java/releases/) | [v0.8](https://github.com/serverlessworkflow/specification/tree/0.8.x) |
-| [4.0.2.Final](https://github.com/serverlessworkflow/sdk-java/releases/) | [v0.8](https://github.com/serverlessworkflow/specification/tree/0.8.x) |
+| [4.0.5.1.Final](https://github.com/serverlessworkflow/sdk-java/releases/) | [v0.8](https://github.com/serverlessworkflow/specification/tree/0.8.x) |
 | [3.0.0.Final](https://github.com/serverlessworkflow/sdk-java/releases/) | [v0.7](https://github.com/serverlessworkflow/specification/tree/0.7.x) |
 | [2.0.0.Final](https://github.com/serverlessworkflow/sdk-java/releases/) | [v0.6](https://github.com/serverlessworkflow/specification/tree/0.6.x) |
 | [1.0.3.Final](https://github.com/serverlessworkflow/sdk-java/releases/) | [v0.5](https://github.com/serverlessworkflow/specification/tree/0.5.x) |


### PR DESCRIPTION
The GPG keys can't be shared in a branch from a fork, we must run the action against a branch in the main repo. That's why I'm opening the PR, to try to run the release workflow correctly this time.

In #273, the branch is from my personal fork, hence the secrets were not shared in the action run: https://github.com/serverlessworkflow/sdk-java/actions/runs/6720556047/job/18264384738