### PR TITLE
Fix 4.0.x branch to enable release 4.0.5

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: 4.0.5.1
-  next-version: 5.0.0-SNAPSHOT
+  current-version: 4.0.5
+  next-version: 4.0.6-SNAPSHOT

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.serverlessworkflow</groupId>
         <artifactId>serverlessworkflow-parent</artifactId>
-        <version>4.0.x</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>serverlessworkflow-api</artifactId>

--- a/diagram/pom.xml
+++ b/diagram/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.serverlessworkflow</groupId>
         <artifactId>serverlessworkflow-parent</artifactId>
-        <version>4.0.x</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>serverlessworkflow-diagram</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.serverlessworkflow</groupId>
   <artifactId>serverlessworkflow-parent</artifactId>
-  <version>4.0.x</version>
+  <version>4.0.5-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Serverless Workflow :: Parent</name>
@@ -65,6 +65,8 @@
     <version.jar.plugin>3.2.0</version.jar.plugin>
     <version.jdk>${java.version}</version.jdk>
     <version.jsonschema2pojo-maven-plugin>1.0.1</version.jsonschema2pojo-maven-plugin>
+    <version.javadoc.plugin>3.6.0</version.javadoc.plugin>
+    <version.release.plugin>2.3.2</version.release.plugin>
     <version.source.plugin>3.3.0</version.source.plugin>
     <version.surefire.plugin>2.22.0</version.surefire.plugin>
 

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.serverlessworkflow</groupId>
         <artifactId>serverlessworkflow-parent</artifactId>
-        <version>4.0.x</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>serverlessworkflow-spi</artifactId>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.serverlessworkflow</groupId>
         <artifactId>serverlessworkflow-parent</artifactId>
-        <version>4.0.x</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>serverlessworkflow-util</artifactId>

--- a/validation/pom.xml
+++ b/validation/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.serverlessworkflow</groupId>
         <artifactId>serverlessworkflow-parent</artifactId>
-        <version>4.0.x</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>serverlessworkflow-validation</artifactId>


### PR DESCRIPTION
Another try to release 4.0.5.

The `pom.xml` file should have the `-SNAPSHOT` suffix, the maven release and javadoc plugin were missing the version numbers.

Release was approved in #273 