### PR TITLE
Relase 4.0.5.Final

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: 4.0.5
+  current-version: 4.0.5.Final
   next-version: 4.0.6-SNAPSHOT


### PR DESCRIPTION
PR to trigger the 4.0.5.Final release on branch 4.0.x

- Tag the release from 4.0.x branch
- Release in Maven central

Release already approved in #273