### PR TITLE
[Fix][Add snapshot] Prepare Release 7.0.0-alpha1

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
   current-version: 7.0.0-alpha1
-  next-version: 7.0.0-alpha2
+  next-version: 7.0.0-SNAPSHOT


### PR DESCRIPTION
We have to keep the `snapshot` suffix to the version.