### PR TITLE
Add single value enum when using const keyword for compatiblity

### DIFF
--- a/api/src/main/resources/schema/workflow.yaml
+++ b/api/src/main/resources/schema/workflow.yaml
@@ -202,6 +202,7 @@ $defs:
           call:
             type: string
             const: asyncapi
+            enum: [asyncapi]
           with:
             type: object
             title: AsyncApiArguments
@@ -247,6 +248,7 @@ $defs:
           call:
             type: string
             const: grpc
+            enum: [grpc]
           with:
             type: object
             title: GRPCArguments
@@ -301,7 +303,8 @@ $defs:
         properties:
           call:
             type: string
-            const: http
+            const: http 
+            enum: [http]
           with:
             type: object
             title: HTTPArguments
@@ -350,6 +353,7 @@ $defs:
           call:
             type: string
             const: openapi
+            enum: [openapi]
           with:
             type: object
             title: OpenAPIArguments

--- a/api/src/test/java/io/serverlessworkflow/api/ApiTest.java
+++ b/api/src/test/java/io/serverlessworkflow/api/ApiTest.java
@@ -18,6 +18,7 @@ package io.serverlessworkflow.api;
 import static io.serverlessworkflow.api.WorkflowReader.readWorkflowFromClasspath;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.serverlessworkflow.api.types.CallFunction;
 import io.serverlessworkflow.api.types.CallHTTP;
 import io.serverlessworkflow.api.types.CallTask;
 import io.serverlessworkflow.api.types.Task;
@@ -26,6 +27,24 @@ import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 public class ApiTest {
+
+  @Test
+  void testCallFunctionAPIWithoutArguments() throws IOException {
+    Workflow workflow = readWorkflowFromClasspath("features/callFunction.yaml");
+    assertThat(workflow.getDo()).isNotEmpty();
+    assertThat(workflow.getDo().get(0).getName()).isNotNull();
+    assertThat(workflow.getDo().get(0).getTask()).isNotNull();
+    Task task = workflow.getDo().get(0).getTask();
+    CallTask callTask = task.getCallTask();
+    assertThat(callTask).isNotNull();
+    assertThat(callTask.get()).isInstanceOf(CallFunction.class);
+    if (callTask.get() instanceof CallFunction) {
+      CallFunction functionCall = callTask.getCallFunction();
+      assertThat(functionCall).isNotNull();
+      assertThat(callTask.getCallAsyncAPI()).isNull();
+      assertThat(functionCall.getWith()).isNull();
+    }
+  }
 
   @Test
   void testCallHTTPAPI() throws IOException {

--- a/api/src/test/resources/features/callFunction.yaml
+++ b/api/src/test/resources/features/callFunction.yaml
@@ -1,0 +1,18 @@
+document:
+  dsl: 1.0.0-alpha1
+  namespace: default
+  name: http-call-with-response-output
+
+use:
+  functions:
+    getPet:
+      call: http
+      with:
+        method: get
+        endpoint:
+          uri: https://petstore.swagger.io/v2/pet/{petId}
+        output: response
+
+do:
+  - getPetFunctionCall:
+      call: getPet


### PR DESCRIPTION
Use extra single value enum where const is used due to lack of support from jsonschema2pojo

**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
jsonschema2pojo does not support `const` keyword yet.
This was causing a bug when using resusable tasks that have no value on `with` block. It would always match to `CallAsyncAPI`.

In order to achieve proper behaviour I added a single value `enum` below each `const`. This will make it compatible with jsonschema2pojo while they solve the issue #1001.

https://github.com/joelittlejohn/jsonschema2pojo/issues/1001.

Also addded a test to validate the behaviour

**Special notes for reviewers**:
I think this may be a good idead to adopt as a single enum on the main spec too. const and single value enum are the same thing under the hood, for jsonschema2pojo at least.


**Additional information (if needed):**