### PR TITLE
Validate if method has no arguments before invoking without arguments

### DIFF
--- a/api/src/main/java/io/serverlessworkflow/serialization/SerializeHelper.java
+++ b/api/src/main/java/io/serverlessworkflow/serialization/SerializeHelper.java
@@ -23,6 +23,9 @@ public class SerializeHelper {
   public static void serializeOneOf(JsonGenerator jgen, Object item) throws IOException {
     try {
       for (Method m : item.getClass().getDeclaredMethods()) {
+        if (m.getParameterCount() > 0) {
+          continue;
+        }
         Object value = m.invoke(item);
         if (value != null) {
           jgen.writeObject(value);


### PR DESCRIPTION
**What this PR does / why we need it**:

During development, our tests suddenly started to fail with an `IllegalArgumentException` when using an input
schema validation and serializing it again to send over the network as JSON. After some time we figured out that was due to this part of the code at `serializeOneOf` in the `SerializeHelper`:
```java
public class SerializeHelper {
  public static void serializeOneOf(JsonGenerator jgen, Object item) throws IOException {
    try {
      for (Method m : item.getClass().getDeclaredMethods()) {
        Object value = m.invoke(item); // <<--- Invoking method that may have parameters
        if (value != null) {
          jgen.writeObject(value);
          break;
        }
      }
    } catch (ReflectiveOperationException ex) {
      throw new IOException(ex);
    }
  }
}
```

This issue ocurred when we added a new test using `@SpringBootTest` annotation and ran it on different orders.  The method `withFormat` from `Schema` class was appearing first on the list returned by `getDeclaredMethods` method.

And raising the following exception:
```
Caused by: java.lang.IllegalArgumentException: wrong number of arguments: 0 expected: 1
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.checkArgumentCount(DirectMethodHandleAccessor.java:329)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:101)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at io.serverlessworkflow.serialization.SerializeHelper.serializeOneOf(SerializeHelper.java:26)
	at io.serverlessworkflow.api.types.SchemaSerializer.serialize(SchemaSerializer.java:19)
	at io.serverlessworkflow.api.types.SchemaSerializer.serialize(SchemaSerializer.java:10)
	at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:732)
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:770)
```
To resolve this we added a small check to avoid the, error as `getDeclaredMethods` does not guarantee a specific order.

Let me know if you'd like any further adjustments!