### PR TITLE
[Fix #558] ProduceEvent.data shoud be an object, not only a string

### DIFF
--- a/api/src/main/resources/schema/produce/produceevent.json
+++ b/api/src/main/resources/schema/produce/produceevent.json
@@ -8,8 +8,9 @@
       "minLength": 1
     },
     "data": {
-      "type": "string",
-      "description": "Workflow expression which selects parts of the states data output to become the data of the produced event"
+      "type": "object",
+      "description": "Workflow expression which selects parts of the states data output to become the data of the produced event",
+      "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"
     },
     "contextAttributes": {
       "type": "object",


### PR DESCRIPTION
Fix https://github.com/serverlessworkflow/sdk-java/issues/558