### PR TITLE
Release 4.1.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: 4.0.5.Final
-  next-version: 4.0.6-SNAPSHOT
+  current-version: 4.1.0.Final
+  next-version: 4.1.1-SNAPSHOT


### PR DESCRIPTION
Using 4.1.0 since change is not API backward compatible (it is for workflow defintions, which are still loaded, but the API changed from string to JsonNode, so implementors has to perform changes)