### PR TITLE
[4.x] - Upgrade to Java 17

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @tsurdilo @manuelstein @ricardozanini
+* @ricardozanini @fjtirado

--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -1,10 +1,8 @@
 reviewers:
-  - tsurdilo
-  - manuelstein
   - ricardozanini
+  - fjtirado
 approvers:
-  - tsurdilo
-  - manuelstein
   - ricardozanini
+  - fjtirado
 labels:
   - sig/contributor-experience

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,4 +11,4 @@ updates:
       interval: "weekly"
     assignees:
       - ricardozanini
-      - tsurdilo
+      - fjtirado

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -16,11 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 17
           cache: 'maven'
 
       - name: Verify with Maven

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,11 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 17
           cache: 'maven'
           server-id: ossrh
           server-username: MAVEN_USERNAME

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ to parse and validate workflow definitions as well as generate the workflow diag
 
 ### Status
 
-| Latest Releases | Conformance to spec version |
-| :---: | :---: |
-| [4.0.5.1.Final](https://github.com/serverlessworkflow/sdk-java/releases/) | [v0.8](https://github.com/serverlessworkflow/specification/tree/0.8.x) |
+|                             Latest Releases                             | Conformance to spec version |
+|:-----------------------------------------------------------------------:| :---: |
+| [4.1.0.Final](https://github.com/serverlessworkflow/sdk-java/releases/) | [v0.8](https://github.com/serverlessworkflow/specification/tree/0.8.x) |
 | [3.0.0.Final](https://github.com/serverlessworkflow/sdk-java/releases/) | [v0.7](https://github.com/serverlessworkflow/specification/tree/0.7.x) |
 | [2.0.0.Final](https://github.com/serverlessworkflow/sdk-java/releases/) | [v0.6](https://github.com/serverlessworkflow/specification/tree/0.6.x) |
 | [1.0.3.Final](https://github.com/serverlessworkflow/sdk-java/releases/) | [v0.5](https://github.com/serverlessworkflow/specification/tree/0.5.x) |
@@ -64,31 +64,31 @@ b) Add the following dependencies to your pom.xml `dependencies` section:
 <dependency>
     <groupId>io.serverlessworkflow</groupId>
     <artifactId>serverlessworkflow-api</artifactId>
-    <version>4.0.4.Final</version>
+    <version>4.1.0.Final</version>
 </dependency>
 
 <dependency>
     <groupId>io.serverlessworkflow</groupId>
     <artifactId>serverlessworkflow-spi</artifactId>
-    <version>4.0.4.Final</version>
+    <version>4.1.0.Final</version>
 </dependency>
 
 <dependency>
     <groupId>io.serverlessworkflow</groupId>
     <artifactId>serverlessworkflow-validation</artifactId>
-    <version>4.0.4.Final</version>
+    <version>4.1.0.Final</version>
 </dependency>
 
 <dependency>
     <groupId>io.serverlessworkflow</groupId>
     <artifactId>serverlessworkflow-diagram</artifactId>
-    <version>4.0.4.Final</version>
+    <version>4.1.0.Final</version>
 </dependency>
 
 <dependency>
     <groupId>io.serverlessworkflow</groupId>
     <artifactId>serverlessworkflow-util</artifactId>
-    <version>4.0.4.Final</version>
+    <version>4.1.0.Final</version>
 </dependency>
 ```
 
@@ -103,11 +103,11 @@ maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
 b) Add the following dependencies to your build.gradle `dependencies` section:
 
 ```text
-implementation("io.serverlessworkflow:serverlessworkflow-api:4.0.4.Final")
-implementation("io.serverlessworkflow:serverlessworkflow-spi:4.0.4.Final")
-implementation("io.serverlessworkflow:serverlessworkflow-validation:4.0.4.Final")
-implementation("io.serverlessworkflow:serverlessworkflow-diagram:4.0.4.Final")
-implementation("io.serverlessworkflow:serverlessworkflow-util:4.0.4.Final")
+implementation("io.serverlessworkflow:serverlessworkflow-api:4.1.0.Final")
+implementation("io.serverlessworkflow:serverlessworkflow-spi:4.1.0.Final")
+implementation("io.serverlessworkflow:serverlessworkflow-validation:4.1.0.Final")
+implementation("io.serverlessworkflow:serverlessworkflow-diagram:4.1.0.Final")
+implementation("io.serverlessworkflow:serverlessworkflow-util:4.1.0.Final")
 ```
 
 ### How to Use 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -34,8 +34,8 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
         </dependency>
         <!-- test -->
         <dependency>
@@ -83,12 +83,13 @@
                     <includeJsr303Annotations>true</includeJsr303Annotations>
                     <generateBuilders>true</generateBuilders>
                     <includeAdditionalProperties>false</includeAdditionalProperties>
+                    <useJakartaValidation>true</useJakartaValidation>
                     <includeToString>false</includeToString>
                     <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
                     <includeConstructors>true</includeConstructors>
                     <constructorsRequiredPropertiesOnly>true</constructorsRequiredPropertiesOnly>
                     <serializable>true</serializable>
-                    <targetVersion>1.8</targetVersion>
+                    <targetVersion>${java.version}</targetVersion>
                     <usePrimitives>true</usePrimitives>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -45,10 +45,10 @@
   </modules>
 
   <properties>
-    <java.version>1.8</java.version>
+    <java.version>17</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <maven.compiler.release>8</maven.compiler.release>
+    <maven.compiler.release>${java.version}</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <version.maven>3.9.7</version.maven>
 
@@ -78,7 +78,7 @@
     <version.commons.lang>3.17.0</version.commons.lang>
     <version.graphviz>0.18.1</version.graphviz>
     <version.hamcrest>3.0</version.hamcrest>
-    <version.javax.validation>2.0.1.Final</version.javax.validation>
+    <version.jakarta.validation>3.1.1</version.jakarta.validation>
     <version.jsonassert>1.5.3</version.jsonassert>
     <version.org.assertj>3.27.3</version.org.assertj>
     <version.org.junit.jupiter>5.12.2</version.org.junit.jupiter>
@@ -151,9 +151,9 @@
         <version>${version.com.fasterxml.jackson}</version>
       </dependency>
       <dependency>
-        <groupId>javax.validation</groupId>
-        <artifactId>validation-api</artifactId>
-        <version>${version.javax.validation}</version>
+        <groupId>jakarta.validation</groupId>
+        <artifactId>jakarta.validation-api</artifactId>
+        <version>${version.jakarta.validation}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Since this stream is still in use, we must upgrade to Java 17 to keep it up to date with Quarkus LTS and other dependencies, or we will fall behind on CVE fixes.

Additionally, I removed a few old content.