### PR TITLE
[5.x] - Upgrade to Java 17

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @tsurdilo @manick02 @ricardozanini
+* @fjtirado @ricardozanini

--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -1,10 +1,8 @@
 reviewers:
-  - tsurdilo
-  - manick02
   - ricardozanini
+  - fjtirado
 approvers:
-  - tsurdilo
-  - manick02
   - ricardozanini
+  - fjtirado
 labels:
   - sig/contributor-experience

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,4 +11,4 @@ updates:
       interval: "weekly"
     assignees:
       - ricardozanini
-      - tsurdilo
+      - fjtirado

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -16,11 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
           cache: 'maven'
 
       - name: Verify with Maven

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,11 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
           cache: 'maven'
           server-id: ossrh
           server-username: MAVEN_USERNAME

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ to parse and validate workflow definitions as well as generate the workflow diag
 
 | Latest Releases | Conformance to spec version |
 | :---: | :---: |
-| [5.0.0.Final](https://github.com/serverlessworkflow/sdk-java/releases/tag/5.0.0.Final) | [v0.8](https://github.com/serverlessworkflow/specification/tree/0.8.x) |
+| [5.1.0.Final](https://github.com/serverlessworkflow/sdk-java/releases/tag/5.1.0.Final) | [v0.8](https://github.com/serverlessworkflow/specification/tree/0.8.x) |
 | [4.0.5.Final](https://github.com/serverlessworkflow/sdk-java/releases/tag/4.0.5.Final) | [v0.8](https://github.com/serverlessworkflow/specification/tree/0.8.x) |
 | [3.0.0.Final](https://github.com/serverlessworkflow/sdk-java/releases/tag/3.0.0.Final) | [v0.7](https://github.com/serverlessworkflow/specification/tree/0.7.x) |
 | [2.0.0.Final](https://github.com/serverlessworkflow/sdk-java/releases/tag/2.0.0.Final) | [v0.6](https://github.com/serverlessworkflow/specification/tree/0.6.x) |
@@ -29,9 +29,9 @@ to parse and validate workflow definitions as well as generate the workflow diag
 ### JDK Version
 
 | SDK Version | JDK Version |
-| :---: | :---: |
-| 5.0.0 and after | 11 |
-| 4.0.x and before | 8 | 
+| :---: |:-----------:|
+| 5.0.0 and after |     17      |
+| 4.0.x and before |      8      | 
 
 ### Getting Started
 
@@ -75,31 +75,31 @@ b) Add the following dependencies to your pom.xml `dependencies` section:
 <dependency>
     <groupId>io.serverlessworkflow</groupId>
     <artifactId>serverlessworkflow-api</artifactId>
-    <version>5.1.0-SNAPSHOT</version>
+    <version>5.1.0.Final</version>
 </dependency>
 
 <dependency>
     <groupId>io.serverlessworkflow</groupId>
     <artifactId>serverlessworkflow-spi</artifactId>
-    <version>5.1.0-SNAPSHOT</version>
+    <version>5.1.0.Final</version>
 </dependency>
 
 <dependency>
     <groupId>io.serverlessworkflow</groupId>
     <artifactId>serverlessworkflow-validation</artifactId>
-    <version>5.1.0-SNAPSHOT</version>
+    <version>5.1.0.Final</version>
 </dependency>
 
 <dependency>
     <groupId>io.serverlessworkflow</groupId>
     <artifactId>serverlessworkflow-diagram</artifactId>
-    <version>5.1.0-SNAPSHOT</version>
+    <version>5.1.0.Final</version>
 </dependency>
 
 <dependency>
     <groupId>io.serverlessworkflow</groupId>
     <artifactId>serverlessworkflow-util</artifactId>
-    <version>5.1.0-SNAPSHOT</version>
+    <version>5.1.0.Final</version>
 </dependency>
 ```
 
@@ -114,11 +114,11 @@ maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
 b) Add the following dependencies to your build.gradle `dependencies` section:
 
 ```text
-implementation("io.serverlessworkflow:serverlessworkflow-api:5.1.0-SNAPSHOT")
-implementation("io.serverlessworkflow:serverlessworkflow-spi:5.1.0-SNAPSHOT")
-implementation("io.serverlessworkflow:serverlessworkflow-validation:5.1.0-SNAPSHOT")
-implementation("io.serverlessworkflow:serverlessworkflow-diagram:5.1.0-SNAPSHOT")
-implementation("io.serverlessworkflow:serverlessworkflow-util:5.1.0-SNAPSHOT")
+implementation("io.serverlessworkflow:serverlessworkflow-api:5.1.0.Final")
+implementation("io.serverlessworkflow:serverlessworkflow-spi:5.1.0.Final")
+implementation("io.serverlessworkflow:serverlessworkflow-validation:5.1.0.Final")
+implementation("io.serverlessworkflow:serverlessworkflow-diagram:5.1.0.Final")
+implementation("io.serverlessworkflow:serverlessworkflow-util:5.1.0.Final")
 ```
 
 ### How to Use 

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
   </modules>
 
   <properties>
-    <java.version>11</java.version>
+    <java.version>17</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven.compiler.release>${java.version}</maven.compiler.release>


### PR DESCRIPTION
Supersedes #601. 

This version was released as an attempt to add Jakarta support and upgrade to Java 11. Since we are moving 4.x and 5.x to Java 17, it's better to stop upgrading 4.x and just deprecate it.

Users can migrate directly to the 5.x stream instead.

@fjtirado FYI.