### PR TITLE
[4.x] Fix #603 - Add guard code to collections, tidy up Workflow serializer

### DIFF
--- a/api/src/main/java/io/serverlessworkflow/api/mapper/WorkflowModule.java
+++ b/api/src/main/java/io/serverlessworkflow/api/mapper/WorkflowModule.java
@@ -42,11 +42,11 @@ import io.serverlessworkflow.api.workflow.*;
 
 public class WorkflowModule extends SimpleModule {
 
-  private static final long serialVersionUID = 510l;
+  private static final long serialVersionUID = 510L;
 
-  private WorkflowPropertySource workflowPropertySource;
-  private ExtensionSerializer extensionSerializer;
-  private ExtensionDeserializer extensionDeserializer;
+  private final WorkflowPropertySource workflowPropertySource;
+  private final ExtensionSerializer extensionSerializer;
+  private final ExtensionDeserializer extensionDeserializer;
 
   public WorkflowModule() {
     this(null);

--- a/api/src/main/java/io/serverlessworkflow/api/serializers/FunctionRefSerializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/serializers/FunctionRefSerializer.java
@@ -41,12 +41,12 @@ public class FunctionRefSerializer extends StdSerializer<FunctionRef> {
           && (functionRef.getInvoke() == null
               || functionRef.getInvoke().equals(FunctionRef.Invoke.SYNC))
           && functionRef.getRefName() != null
-          && functionRef.getRefName().length() > 0) {
+          && !functionRef.getRefName().isEmpty()) {
         gen.writeString(functionRef.getRefName());
       } else {
         gen.writeStartObject();
 
-        if (functionRef.getRefName() != null && functionRef.getRefName().length() > 0) {
+        if (functionRef.getRefName() != null && !functionRef.getRefName().isEmpty()) {
           gen.writeStringField("refName", functionRef.getRefName());
         }
 
@@ -54,7 +54,7 @@ public class FunctionRefSerializer extends StdSerializer<FunctionRef> {
           gen.writeObjectField("arguments", functionRef.getArguments());
         }
 
-        if (functionRef.getSelectionSet() != null && functionRef.getSelectionSet().length() > 0) {
+        if (functionRef.getSelectionSet() != null && !functionRef.getSelectionSet().isEmpty()) {
           gen.writeStringField("selectionSet", functionRef.getSelectionSet());
         }
 

--- a/api/src/main/java/io/serverlessworkflow/api/workflow/Auth.java
+++ b/api/src/main/java/io/serverlessworkflow/api/workflow/Auth.java
@@ -16,42 +16,48 @@
 
 package io.serverlessworkflow.api.workflow;
 
-import io.serverlessworkflow.api.auth.AuthDefinition;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
+import io.serverlessworkflow.api.auth.AuthDefinition;
+
 public class Auth {
-  private String refValue;
-  private List<AuthDefinition> authDefs;
+    private String refValue;
+    private List<AuthDefinition> authDefs;
 
-  public Auth() {}
+    public Auth() {
+    }
 
-  public Auth(AuthDefinition authDef) {
-    this.authDefs = new ArrayList<>();
-    this.authDefs.add(authDef);
-  }
+    public Auth(AuthDefinition authDef) {
+        this.authDefs = new ArrayList<>();
+        this.authDefs.add(authDef);
+    }
 
-  public Auth(List<AuthDefinition> authDefs) {
-    this.authDefs = authDefs;
-  }
+    public Auth(List<AuthDefinition> authDefs) {
+        this.authDefs = authDefs;
+    }
 
-  public Auth(String refValue) {
-    this.refValue = refValue;
-  }
+    public Auth(String refValue) {
+        this.refValue = refValue;
+    }
 
-  public String getRefValue() {
-    return refValue;
-  }
+    public String getRefValue() {
+        return refValue;
+    }
 
-  public void setRefValue(String refValue) {
-    this.refValue = refValue;
-  }
+    public void setRefValue(String refValue) {
+        this.refValue = refValue;
+    }
 
-  public List<AuthDefinition> getAuthDefs() {
-    return authDefs;
-  }
+    public List<AuthDefinition> getAuthDefs() {
+        if (authDefs == null) {
+            return Collections.emptyList();
+        }
+        return authDefs;
+    }
 
-  public void setAuthDefs(List<AuthDefinition> authDefs) {
-    this.authDefs = authDefs;
-  }
+    public void setAuthDefs(List<AuthDefinition> authDefs) {
+        this.authDefs = authDefs;
+    }
 }

--- a/api/src/main/java/io/serverlessworkflow/api/workflow/BaseWorkflow.java
+++ b/api/src/main/java/io/serverlessworkflow/api/workflow/BaseWorkflow.java
@@ -15,6 +15,9 @@
  */
 package io.serverlessworkflow.api.workflow;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -23,53 +26,53 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.serverlessworkflow.api.Workflow;
 import io.serverlessworkflow.api.mapper.JsonObjectMapper;
 import io.serverlessworkflow.api.mapper.YamlObjectMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-/** Base Workflow provides some extra functionality for the Workflow types */
+/**
+ * Base Workflow provides some extra functionality for the Workflow types
+ */
 public class BaseWorkflow {
 
-  private static JsonObjectMapper jsonObjectMapper = new JsonObjectMapper();
-  private static YamlObjectMapper yamlObjectMapper = new YamlObjectMapper();
+    private static JsonObjectMapper jsonObjectMapper = new JsonObjectMapper();
+    private static YamlObjectMapper yamlObjectMapper = new YamlObjectMapper();
 
-  private static Logger logger = LoggerFactory.getLogger(BaseWorkflow.class);
+    private static Logger logger = LoggerFactory.getLogger(BaseWorkflow.class);
 
-  public static Workflow fromSource(String source) {
-    // try it as json markup first, if fails try yaml
-    try {
-      return jsonObjectMapper.readValue(source, Workflow.class);
-    } catch (Exception e) {
-      logger.info("Unable to convert as json markup, trying as yaml");
-      try {
-        return yamlObjectMapper.readValue(source, Workflow.class);
-      } catch (Exception ee) {
-        throw new IllegalArgumentException(
-            "Could not convert markup to Workflow: " + ee.getMessage());
-      }
+    public static Workflow fromSource(String source) {
+        // try it as json markup first, if fails try yaml
+        try {
+            return jsonObjectMapper.readValue(source, Workflow.class);
+        } catch (Exception e) {
+            logger.info("Unable to convert as json markup, trying as yaml");
+            try {
+                return yamlObjectMapper.readValue(source, Workflow.class);
+            } catch (Exception ee) {
+                throw new IllegalArgumentException(
+                        "Could not convert markup to Workflow: " + ee.getMessage());
+            }
+        }
     }
-  }
 
-  public static String toJson(Workflow workflow) {
-    try {
-      return jsonObjectMapper.writeValueAsString(workflow);
-    } catch (JsonProcessingException e) {
-      logger.error("Error mapping to json: " + e.getMessage());
-      return null;
+    public static String toJson(Workflow workflow) {
+        try {
+            return jsonObjectMapper.writeValueAsString(workflow);
+        } catch (JsonProcessingException e) {
+            logger.error("Error mapping to json: {}", e.getMessage());
+            throw new IllegalArgumentException("Could not convert workflow to json: " + e.getMessage());
+        }
     }
-  }
 
-  public static String toYaml(Workflow workflow) {
-    try {
-      String jsonString = jsonObjectMapper.writeValueAsString(workflow);
-      JsonNode jsonNode = jsonObjectMapper.readTree(jsonString);
-      YAMLFactory yamlFactory =
-          new YAMLFactory()
-              .disable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
-              .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
-      return new YAMLMapper(yamlFactory).writeValueAsString(jsonNode);
-    } catch (Exception e) {
-      logger.error("Error mapping to yaml: " + e.getMessage());
-      return null;
+    public static String toYaml(Workflow workflow) {
+        try {
+            String jsonString = jsonObjectMapper.writeValueAsString(workflow);
+            JsonNode jsonNode = jsonObjectMapper.readTree(jsonString);
+            YAMLFactory yamlFactory =
+                    new YAMLFactory()
+                            .disable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
+                            .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
+            return new YAMLMapper(yamlFactory).writeValueAsString(jsonNode);
+        } catch (Exception e) {
+            logger.error("Error mapping to yaml: {}", e.getMessage());
+            throw new IllegalArgumentException("Could not convert workflow to yaml: " + e.getMessage());
+        }
     }
-  }
 }

--- a/api/src/main/java/io/serverlessworkflow/api/workflow/Errors.java
+++ b/api/src/main/java/io/serverlessworkflow/api/workflow/Errors.java
@@ -15,36 +15,42 @@
  */
 package io.serverlessworkflow.api.workflow;
 
-import io.serverlessworkflow.api.error.ErrorDefinition;
+import java.util.Collections;
 import java.util.List;
 
+import io.serverlessworkflow.api.error.ErrorDefinition;
+
 public class Errors {
-  private String refValue;
-  private List<ErrorDefinition> errorDefs;
+    private String refValue;
+    private List<ErrorDefinition> errorDefs;
 
-  public Errors() {}
+    public Errors() {
+    }
 
-  public Errors(List<ErrorDefinition> errorDefs) {
-    this.errorDefs = errorDefs;
-  }
+    public Errors(List<ErrorDefinition> errorDefs) {
+        this.errorDefs = errorDefs;
+    }
 
-  public Errors(String refValue) {
-    this.refValue = refValue;
-  }
+    public Errors(String refValue) {
+        this.refValue = refValue;
+    }
 
-  public String getRefValue() {
-    return refValue;
-  }
+    public String getRefValue() {
+        return refValue;
+    }
 
-  public void setRefValue(String refValue) {
-    this.refValue = refValue;
-  }
+    public void setRefValue(String refValue) {
+        this.refValue = refValue;
+    }
 
-  public List<ErrorDefinition> getErrorDefs() {
-    return errorDefs;
-  }
+    public List<ErrorDefinition> getErrorDefs() {
+        if (errorDefs == null) {
+            return Collections.emptyList();
+        }
+        return errorDefs;
+    }
 
-  public void setErrorDefs(List<ErrorDefinition> errorDefs) {
-    this.errorDefs = errorDefs;
-  }
+    public void setErrorDefs(List<ErrorDefinition> errorDefs) {
+        this.errorDefs = errorDefs;
+    }
 }

--- a/api/src/main/java/io/serverlessworkflow/api/workflow/Events.java
+++ b/api/src/main/java/io/serverlessworkflow/api/workflow/Events.java
@@ -15,36 +15,42 @@
  */
 package io.serverlessworkflow.api.workflow;
 
-import io.serverlessworkflow.api.events.EventDefinition;
+import java.util.Collections;
 import java.util.List;
 
+import io.serverlessworkflow.api.events.EventDefinition;
+
 public class Events {
-  private String refValue;
-  private List<EventDefinition> eventDefs;
+    private String refValue;
+    private List<EventDefinition> eventDefs;
 
-  public Events() {}
+    public Events() {
+    }
 
-  public Events(List<EventDefinition> eventDefs) {
-    this.eventDefs = eventDefs;
-  }
+    public Events(List<EventDefinition> eventDefs) {
+        this.eventDefs = eventDefs;
+    }
 
-  public Events(String refValue) {
-    this.refValue = refValue;
-  }
+    public Events(String refValue) {
+        this.refValue = refValue;
+    }
 
-  public String getRefValue() {
-    return refValue;
-  }
+    public String getRefValue() {
+        return refValue;
+    }
 
-  public void setRefValue(String refValue) {
-    this.refValue = refValue;
-  }
+    public void setRefValue(String refValue) {
+        this.refValue = refValue;
+    }
 
-  public List<EventDefinition> getEventDefs() {
-    return eventDefs;
-  }
+    public List<EventDefinition> getEventDefs() {
+        if (eventDefs == null) {
+            return Collections.emptyList();
+        }
+        return eventDefs;
+    }
 
-  public void setEventDefs(List<EventDefinition> eventDefs) {
-    this.eventDefs = eventDefs;
-  }
+    public void setEventDefs(List<EventDefinition> eventDefs) {
+        this.eventDefs = eventDefs;
+    }
 }

--- a/api/src/main/java/io/serverlessworkflow/api/workflow/Functions.java
+++ b/api/src/main/java/io/serverlessworkflow/api/workflow/Functions.java
@@ -15,36 +15,42 @@
  */
 package io.serverlessworkflow.api.workflow;
 
-import io.serverlessworkflow.api.functions.FunctionDefinition;
+import java.util.Collections;
 import java.util.List;
 
+import io.serverlessworkflow.api.functions.FunctionDefinition;
+
 public class Functions {
-  private String refValue;
-  private List<FunctionDefinition> functionDefs;
+    private String refValue;
+    private List<FunctionDefinition> functionDefs;
 
-  public Functions() {}
+    public Functions() {
+    }
 
-  public Functions(List<FunctionDefinition> functionDefs) {
-    this.functionDefs = functionDefs;
-  }
+    public Functions(List<FunctionDefinition> functionDefs) {
+        this.functionDefs = functionDefs;
+    }
 
-  public Functions(String refValue) {
-    this.refValue = refValue;
-  }
+    public Functions(String refValue) {
+        this.refValue = refValue;
+    }
 
-  public String getRefValue() {
-    return refValue;
-  }
+    public String getRefValue() {
+        return refValue;
+    }
 
-  public void setRefValue(String refValue) {
-    this.refValue = refValue;
-  }
+    public void setRefValue(String refValue) {
+        this.refValue = refValue;
+    }
 
-  public List<FunctionDefinition> getFunctionDefs() {
-    return functionDefs;
-  }
+    public List<FunctionDefinition> getFunctionDefs() {
+        if (functionDefs == null) {
+            return Collections.emptyList();
+        }
+        return functionDefs;
+    }
 
-  public void setFunctionDefs(List<FunctionDefinition> functionDefs) {
-    this.functionDefs = functionDefs;
-  }
+    public void setFunctionDefs(List<FunctionDefinition> functionDefs) {
+        this.functionDefs = functionDefs;
+    }
 }

--- a/api/src/main/java/io/serverlessworkflow/api/workflow/Retries.java
+++ b/api/src/main/java/io/serverlessworkflow/api/workflow/Retries.java
@@ -15,36 +15,42 @@
  */
 package io.serverlessworkflow.api.workflow;
 
-import io.serverlessworkflow.api.retry.RetryDefinition;
+import java.util.Collections;
 import java.util.List;
 
+import io.serverlessworkflow.api.retry.RetryDefinition;
+
 public class Retries {
-  private String refValue;
-  private List<RetryDefinition> retryDefs;
+    private String refValue;
+    private List<RetryDefinition> retryDefs;
 
-  public Retries() {}
+    public Retries() {
+    }
 
-  public Retries(List<RetryDefinition> retryDefs) {
-    this.retryDefs = retryDefs;
-  }
+    public Retries(List<RetryDefinition> retryDefs) {
+        this.retryDefs = retryDefs;
+    }
 
-  public Retries(String refValue) {
-    this.refValue = refValue;
-  }
+    public Retries(String refValue) {
+        this.refValue = refValue;
+    }
 
-  public String getRefValue() {
-    return refValue;
-  }
+    public String getRefValue() {
+        return refValue;
+    }
 
-  public void setRefValue(String refValue) {
-    this.refValue = refValue;
-  }
+    public void setRefValue(String refValue) {
+        this.refValue = refValue;
+    }
 
-  public List<RetryDefinition> getRetryDefs() {
-    return retryDefs;
-  }
+    public List<RetryDefinition> getRetryDefs() {
+        if (retryDefs == null) {
+            return Collections.emptyList();
+        }
+        return retryDefs;
+    }
 
-  public void setRetryDefs(List<RetryDefinition> retryDefs) {
-    this.retryDefs = retryDefs;
-  }
+    public void setRetryDefs(List<RetryDefinition> retryDefs) {
+        this.retryDefs = retryDefs;
+    }
 }

--- a/api/src/main/java/io/serverlessworkflow/api/workflow/Secrets.java
+++ b/api/src/main/java/io/serverlessworkflow/api/workflow/Secrets.java
@@ -15,35 +15,40 @@
  */
 package io.serverlessworkflow.api.workflow;
 
+import java.util.Collections;
 import java.util.List;
 
 public class Secrets {
-  private String refValue;
-  private List<String> secretDefs;
+    private String refValue;
+    private List<String> secretDefs;
 
-  public Secrets() {}
+    public Secrets() {
+    }
 
-  public Secrets(String refValue) {
-    this.refValue = refValue;
-  }
+    public Secrets(String refValue) {
+        this.refValue = refValue;
+    }
 
-  public Secrets(List<String> secretDefs) {
-    this.secretDefs = secretDefs;
-  }
+    public Secrets(List<String> secretDefs) {
+        this.secretDefs = secretDefs;
+    }
 
-  public String getRefValue() {
-    return refValue;
-  }
+    public String getRefValue() {
+        return refValue;
+    }
 
-  public void setRefValue(String refValue) {
-    this.refValue = refValue;
-  }
+    public void setRefValue(String refValue) {
+        this.refValue = refValue;
+    }
 
-  public List<String> getSecretDefs() {
-    return secretDefs;
-  }
+    public List<String> getSecretDefs() {
+        if (secretDefs == null) {
+            return Collections.emptyList();
+        }
+        return secretDefs;
+    }
 
-  public void setSecretDefs(List<String> secretDefs) {
-    this.secretDefs = secretDefs;
-  }
+    public void setSecretDefs(List<String> secretDefs) {
+        this.secretDefs = secretDefs;
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,15 @@
     </dependencies>
   </dependencyManagement>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-nop</artifactId>
+      <version>${version.org.slf4j}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
   <build>
     <plugins>
       <!-- Set properties containing the scm revision -->


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**
Fix #603 

**What this PR does / why we need it**:

**Special notes for reviewers**:
@fjtirado I've made a "breaking" change. Previously, the `Workflow.toJson()` methods would swallow all exceptions, logging them to the console. Since the API did not come with an SLF4J implementation, the message will not be displayed, and the exception will be lost forever.

Instead, we now throw an `IllegalException` to fail fast and avoid forcing client code to catch exceptions.

@gmunozfe, mind taking a look too? Perhaps we can give it a try with Kogito and assess this change impact.

**Additional information (if needed):**