### PR TITLE
Ensure not workflowmodel is returned within a Map or Collection

### DIFF
--- a/experimental/lambda/src/main/java/io/serverlessworkflow/impl/expressions/JavaModel.java
+++ b/experimental/lambda/src/main/java/io/serverlessworkflow/impl/expressions/JavaModel.java
@@ -21,10 +21,12 @@ import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
-public class JavaModel implements WorkflowModel {
+class JavaModel implements WorkflowModel {
 
   private Object object;
 
@@ -33,7 +35,7 @@ public class JavaModel implements WorkflowModel {
   static final JavaModel NullModel = new JavaModel(null);
 
   JavaModel(Object object) {
-    this.object = object;
+    this.object = asJavaObject(object);
   }
 
   @Override
@@ -87,6 +89,20 @@ public class JavaModel implements WorkflowModel {
   @Override
   public Object asJavaObject() {
     return object;
+  }
+
+  static Object asJavaObject(Object object) {
+    if (object instanceof WorkflowModel model) {
+      return model.asJavaObject();
+    } else if (object instanceof Map map) {
+      return ((Map<String, Object>) map)
+          .entrySet().stream()
+              .collect(Collectors.toMap(Entry::getKey, e -> asJavaObject(e.getValue())));
+    } else if (object instanceof Collection col) {
+      return col.stream().map(JavaModel::asJavaObject).collect(Collectors.toList());
+    } else {
+      return object;
+    }
   }
 
   @Override

--- a/experimental/lambda/src/main/java/io/serverlessworkflow/impl/expressions/JavaModelCollection.java
+++ b/experimental/lambda/src/main/java/io/serverlessworkflow/impl/expressions/JavaModelCollection.java
@@ -22,7 +22,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Optional;
 
-public class JavaModelCollection implements Collection<WorkflowModel>, WorkflowModelCollection {
+class JavaModelCollection implements Collection<WorkflowModel>, WorkflowModelCollection {
 
   private final Collection object;
 
@@ -31,7 +31,7 @@ public class JavaModelCollection implements Collection<WorkflowModel>, WorkflowM
   }
 
   JavaModelCollection(Collection<?> object) {
-    this.object = object;
+    this.object = (Collection) JavaModel.asJavaObject(object);
   }
 
   @Override
@@ -86,12 +86,12 @@ public class JavaModelCollection implements Collection<WorkflowModel>, WorkflowM
 
   @Override
   public boolean add(WorkflowModel e) {
-    return object.add(e.asIs());
+    return object.add(e.asJavaObject());
   }
 
   @Override
   public boolean remove(Object o) {
-    return object.remove(((WorkflowModel) o).asIs());
+    return object.remove(((WorkflowModel) o).asJavaObject());
   }
 
   @Override

--- a/experimental/lambda/src/main/java/io/serverlessworkflow/impl/expressions/JavaModelFactory.java
+++ b/experimental/lambda/src/main/java/io/serverlessworkflow/impl/expressions/JavaModelFactory.java
@@ -23,7 +23,7 @@ import io.serverlessworkflow.impl.WorkflowModelFactory;
 import java.time.OffsetDateTime;
 import java.util.Map;
 
-public class JavaModelFactory implements WorkflowModelFactory {
+class JavaModelFactory implements WorkflowModelFactory {
 
   @Override
   public WorkflowModel combine(Map<String, WorkflowModel> workflowVariables) {


### PR DESCRIPTION
When using a map, not JavaModel should be returned as value. 
JavaModel should not be visible to final user. 