### PR TITLE
Http dependencies

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -8,6 +8,9 @@
     </parent>
     <name>Serverless Workflow :: Examples</name>
     <artifactId>serverlessworkflow-examples</artifactId>
+    <properties>
+        <version.org.glassfish.jersey>3.1.10</version.org.glassfish.jersey>
+    </properties>
     <packaging>pom</packaging>
     <dependencyManagement>
         <dependencies>
@@ -30,6 +33,19 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
                 <version>${version.org.slf4j}</version>
+                <scope>runtime</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.core</groupId>
+                <artifactId>jersey-client</artifactId>
+                <version>${version.org.glassfish.jersey}</version>
+                <scope>runtime</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.media</groupId>
+                <artifactId>jersey-media-json-jackson</artifactId>
+                <version>${version.org.glassfish.jersey}</version>
+                <scope>runtime</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/examples/simpleGet/pom.xml
+++ b/examples/simpleGet/pom.xml
@@ -18,6 +18,14 @@
             <artifactId>serverlessworkflow-impl-http</artifactId>
         </dependency>
         <dependency>
+          <groupId>org.glassfish.jersey.media</groupId>
+          <artifactId>jersey-media-json-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
         </dependency>

--- a/impl/http/pom.xml
+++ b/impl/http/pom.xml
@@ -8,18 +8,21 @@
     <artifactId>serverlessworkflow-impl-http</artifactId>
     <name>Serverless Workflow :: Impl :: HTTP</name>
     <dependencies>
+         <dependency>
+           <groupId>jakarta.ws.rs</groupId>
+           <artifactId>jakarta.ws.rs-api</artifactId>
+         </dependency>
+         <dependency>
+           <groupId>io.serverlessworkflow</groupId>
+           <artifactId>serverlessworkflow-impl-core</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.glassfish.jersey.media</groupId>
+          <artifactId>jersey-media-json-jackson</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-json-jackson</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.serverlessworkflow</groupId>
-            <artifactId>serverlessworkflow-impl-core</artifactId>
         </dependency>
         <dependency>
             <groupId>io.serverlessworkflow</groupId>
@@ -34,22 +37,18 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>ch.qos.logback</groupId>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -13,6 +13,7 @@
         <version.io.cloudevents>4.0.1</version.io.cloudevents>
         <version.net.thisptr>1.3.0</version.net.thisptr>
         <version.com.github.f4b6a3>5.2.3</version.com.github.f4b6a3>
+        <version.jakarta.ws.rs>3.1.0</version.jakarta.ws.rs>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -35,11 +36,13 @@
                 <groupId>org.glassfish.jersey.core</groupId>
                 <artifactId>jersey-client</artifactId>
                 <version>${version.org.glassfish.jersey}</version>
+                <scope>runtime</scope>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.media</groupId>
                 <artifactId>jersey-media-json-jackson</artifactId>
                 <version>${version.org.glassfish.jersey}</version>
+                <scope>runtime</scope>
             </dependency>
             <dependency>
                 <groupId>io.cloudevents</groupId>
@@ -60,6 +63,11 @@
                 <groupId>com.github.f4b6a3</groupId>
                 <artifactId>ulid-creator</artifactId>
                 <version>${version.com.github.f4b6a3}</version>
+            </dependency>
+            <dependency>
+              <groupId>jakarta.ws.rs</groupId>
+              <artifactId>jakarta.ws.rs-api</artifactId>
+              <version>${version.jakarta.ws.rs}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Avoid direct dependency of HTTP module with Jersey. 
User will have to add a valid Jakarta RS implementation in the pom