### PR TITLE
Introduce LangChain4j Agentic Workflow Implementation

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,40 @@
+name: sdk-java Integration Tests
+on:
+  issue_comment:
+    types: [ created ]
+
+jobs:
+  run-integration-tests:
+    # 2) Only run if the comment is exactly "/run integration-tests"
+    #    and it’s on a pull request (not on an issue)
+    if: >
+      github.event.comment.body == '/run integration-tests' &&
+      github.event.issue.pull_request != null
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: write
+      id-token: write
+
+    steps:
+      # 3) Checkout the **PR’s** code
+      - name: Checkout PR code
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.issue.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.issue.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # 4) Set up Java/Maven (cache enabled)
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: maven
+
+      # 5) Run only the IT suite
+      - name: Run integration-tests profile
+        run: mvn -B -f pom.xml clean verify -Pintegration-tests

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -36,7 +36,7 @@ jobs:
       # 4. Build the external agentic module
       - name: Build langchain4j-agentic
         run: |
-          mvn -B -U -T12C clean package -DskipTests
+          mvn -B -U -T12C -f langchain4j/pom.xml clean package -DskipTests
           mvn -B -f langchain4j/langchain4j-agentic/pom.xml clean install -DskipTests
 
       # 5. Verify the main sdk-java project, excluding the two agentic modules

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -17,15 +17,7 @@ jobs:
       - name: Checkout sdk-java
         uses: actions/checkout@v4
 
-      # 2. (Temporary) Checkout the langchain4j repo at agentic-module
-      - name: Checkout langchain4j (agentic-module)
-        uses: actions/checkout@v4
-        with:
-          repository: mariofusco/langchain4j
-          ref: agentic-module
-          path: langchain4j
-
-      # 3. Set up JDK 17 for both builds
+      # 2. Set up JDK 17 for both builds
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -33,19 +25,12 @@ jobs:
           java-version: 17
           cache: 'maven'
 
-      # 4. Build the external agentic module
-      - name: Build langchain4j-agentic
-        run: |
-          mvn -B -U -T12C -f langchain4j/pom.xml clean package -DskipTests
-          mvn -B -f langchain4j/langchain4j-agentic/pom.xml clean install -DskipTests
-
-      # 5. Verify the main sdk-java project, excluding the two agentic modules
+      # 3. Verify the main sdk-java project, excluding the two agentic modules
       - name: Verify with Maven
         run: |
-          mvn -B -f pom.xml clean install verify \
-            -am
+          mvn -B -f pom.xml clean install verify -am
 
-      # 6. Verify examples
+      # 4. Verify examples
       - name: Verify Examples with Maven
         run: |
           mvn -B -f examples/pom.xml clean install verify

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -43,7 +43,6 @@ jobs:
       - name: Verify with Maven
         run: |
           mvn -B -f pom.xml clean install verify \
-            -pl ",!fluent/agentic" -pl ",!experimental/agentic" \
             -am
 
       # 6. Verify examples

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -1,6 +1,3 @@
-# This workflow will build a Java project with Maven
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
-
 name: sdk-java Verify
 
 on:
@@ -14,9 +11,21 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
 
+    steps:
+      # 1. Checkout this repo
+      - name: Checkout sdk-java
+        uses: actions/checkout@v4
+
+      # 2. (Temporary) Checkout the langchain4j repo at agentic-module
+      - name: Checkout langchain4j (agentic-module)
+        uses: actions/checkout@v4
+        with:
+          repository: mariofusco/langchain4j
+          ref: agentic-module
+          path: langchain4j
+
+      # 3. Set up JDK 17 for both builds
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -24,12 +33,20 @@ jobs:
           java-version: 17
           cache: 'maven'
 
+      # 4. Build the external agentic module
+      - name: Build langchain4j-agentic
+        run: |
+          mvn -B -U -T12C clean package -DskipTests
+          mvn -B -f langchain4j/langchain4j-agentic/pom.xml clean install -DskipTests
+
+      # 5. Verify the main sdk-java project, excluding the two agentic modules
       - name: Verify with Maven
         run: |
           mvn -B -f pom.xml clean install verify \
             -pl ",!fluent/agentic" -pl ",!experimental/agentic" \
             -am
 
+      # 6. Verify examples
       - name: Verify Examples with Maven
         run: |
           mvn -B -f examples/pom.xml clean install verify

--- a/experimental/agentic/src/main/java/io/serverlessworkflow/impl/expressions/agentic/AgenticModel.java
+++ b/experimental/agentic/src/main/java/io/serverlessworkflow/impl/expressions/agentic/AgenticModel.java
@@ -15,16 +15,17 @@
  */
 package io.serverlessworkflow.impl.expressions.agentic;
 
-import dev.langchain4j.agentic.cognisphere.Cognisphere;
+import dev.langchain4j.agentic.scope.AgenticScope;
 import io.serverlessworkflow.impl.WorkflowModel;
 import io.serverlessworkflow.impl.expressions.func.JavaModel;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Optional;
 
 class AgenticModel extends JavaModel {
 
-  AgenticModel(Cognisphere cognisphere) {
-    super(cognisphere);
+  AgenticModel(AgenticScope agenticScope) {
+    super(agenticScope);
   }
 
   @Override
@@ -39,8 +40,10 @@ class AgenticModel extends JavaModel {
 
   @Override
   public <T> Optional<T> as(Class<T> clazz) {
-    if (Cognisphere.class.isAssignableFrom(clazz)) {
+    if (AgenticScope.class.isAssignableFrom(clazz)) {
       return Optional.of(clazz.cast(object));
+    } else if (Map.class.isAssignableFrom(clazz)) {
+      return Optional.of(clazz.cast(((AgenticScope) object).state()));
     } else {
       return super.as(clazz);
     }

--- a/experimental/agentic/src/main/java/io/serverlessworkflow/impl/expressions/agentic/AgenticModel.java
+++ b/experimental/agentic/src/main/java/io/serverlessworkflow/impl/expressions/agentic/AgenticModel.java
@@ -16,20 +16,15 @@
 package io.serverlessworkflow.impl.expressions.agentic;
 
 import dev.langchain4j.agentic.cognisphere.Cognisphere;
-import dev.langchain4j.agentic.cognisphere.ResultWithCognisphere;
 import io.serverlessworkflow.impl.WorkflowModel;
 import io.serverlessworkflow.impl.expressions.func.JavaModel;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Optional;
 
 class AgenticModel extends JavaModel {
 
-  private final Cognisphere cognisphere;
-
-  AgenticModel(Object object, Cognisphere cognisphere) {
-    super(object);
-    this.cognisphere = cognisphere;
+  AgenticModel(Cognisphere cognisphere) {
+    super(cognisphere);
   }
 
   @Override
@@ -39,17 +34,13 @@ class AgenticModel extends JavaModel {
 
   @Override
   public Collection<WorkflowModel> asCollection() {
-    return object instanceof Collection value
-        ? new AgenticModelCollection(value, cognisphere)
-        : Collections.emptyList();
+    throw new UnsupportedOperationException("Not supported yet.");
   }
 
   @Override
   public <T> Optional<T> as(Class<T> clazz) {
     if (Cognisphere.class.isAssignableFrom(clazz)) {
-      return Optional.of(clazz.cast(cognisphere));
-    } else if (ResultWithCognisphere.class.isAssignableFrom(clazz)) {
-      return Optional.of(clazz.cast(new ResultWithCognisphere<>(cognisphere, object)));
+      return Optional.of(clazz.cast(object));
     } else {
       return super.as(clazz);
     }

--- a/experimental/agentic/src/main/java/io/serverlessworkflow/impl/expressions/agentic/AgenticModel.java
+++ b/experimental/agentic/src/main/java/io/serverlessworkflow/impl/expressions/agentic/AgenticModel.java
@@ -39,6 +39,11 @@ class AgenticModel extends JavaModel {
   }
 
   @Override
+  public Optional<Map<String, Object>> asMap() {
+    return Optional.of(((AgenticScope) object).state());
+  }
+
+  @Override
   public <T> Optional<T> as(Class<T> clazz) {
     if (AgenticScope.class.isAssignableFrom(clazz)) {
       return Optional.of(clazz.cast(object));

--- a/experimental/agentic/src/main/java/io/serverlessworkflow/impl/expressions/agentic/AgenticModelCollection.java
+++ b/experimental/agentic/src/main/java/io/serverlessworkflow/impl/expressions/agentic/AgenticModelCollection.java
@@ -15,8 +15,8 @@
  */
 package io.serverlessworkflow.impl.expressions.agentic;
 
-import dev.langchain4j.agentic.cognisphere.Cognisphere;
-import dev.langchain4j.agentic.cognisphere.ResultWithCognisphere;
+import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.agentic.scope.ResultWithAgenticScope;
 import io.serverlessworkflow.impl.WorkflowModel;
 import io.serverlessworkflow.impl.expressions.func.JavaModelCollection;
 import java.util.Collection;
@@ -24,28 +24,28 @@ import java.util.Optional;
 
 class AgenticModelCollection extends JavaModelCollection {
 
-  private final Cognisphere cognisphere;
+  private final AgenticScope agenticScope;
 
-  AgenticModelCollection(Collection<?> object, Cognisphere cognisphere) {
+  AgenticModelCollection(Collection<?> object, AgenticScope agenticScope) {
     super(object);
-    this.cognisphere = cognisphere;
+    this.agenticScope = agenticScope;
   }
 
-  AgenticModelCollection(Cognisphere cognisphere) {
-    this.cognisphere = cognisphere;
+  AgenticModelCollection(AgenticScope agenticScope) {
+    this.agenticScope = agenticScope;
   }
 
   @Override
   protected WorkflowModel nextItem(Object obj) {
-    return new AgenticModel((Cognisphere) obj);
+    return new AgenticModel((AgenticScope) obj);
   }
 
   @Override
   public <T> Optional<T> as(Class<T> clazz) {
-    if (Cognisphere.class.isAssignableFrom(clazz)) {
-      return Optional.of(clazz.cast(cognisphere));
-    } else if (ResultWithCognisphere.class.isAssignableFrom(clazz)) {
-      return Optional.of(clazz.cast(new ResultWithCognisphere<>(cognisphere, object)));
+    if (AgenticScope.class.isAssignableFrom(clazz)) {
+      return Optional.of(clazz.cast(agenticScope));
+    } else if (ResultWithAgenticScope.class.isAssignableFrom(clazz)) {
+      return Optional.of(clazz.cast(new ResultWithAgenticScope<>(agenticScope, object)));
     } else {
       return super.as(clazz);
     }

--- a/experimental/agentic/src/main/java/io/serverlessworkflow/impl/expressions/agentic/AgenticModelCollection.java
+++ b/experimental/agentic/src/main/java/io/serverlessworkflow/impl/expressions/agentic/AgenticModelCollection.java
@@ -37,7 +37,7 @@ class AgenticModelCollection extends JavaModelCollection {
 
   @Override
   protected WorkflowModel nextItem(Object obj) {
-    return new AgenticModel(obj, cognisphere);
+    return new AgenticModel((Cognisphere) obj);
   }
 
   @Override

--- a/experimental/agentic/src/main/java/io/serverlessworkflow/impl/expressions/agentic/AgenticModelFactory.java
+++ b/experimental/agentic/src/main/java/io/serverlessworkflow/impl/expressions/agentic/AgenticModelFactory.java
@@ -16,86 +16,96 @@
 package io.serverlessworkflow.impl.expressions.agentic;
 
 import dev.langchain4j.agentic.cognisphere.Cognisphere;
-import dev.langchain4j.agentic.cognisphere.CognisphereRegistry;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.CloudEventData;
 import io.serverlessworkflow.impl.WorkflowModel;
 import io.serverlessworkflow.impl.WorkflowModelCollection;
 import io.serverlessworkflow.impl.WorkflowModelFactory;
+import io.serverlessworkflow.impl.expressions.agentic.langchain4j.CognisphereRegistryAssessor;
+import io.serverlessworkflow.impl.expressions.func.JavaModel;
 import java.time.OffsetDateTime;
 import java.util.Map;
 
 class AgenticModelFactory implements WorkflowModelFactory {
 
-  private Cognisphere cognisphere = CognisphereRegistry.createEphemeralCognisphere();
-
-  private final AgenticModel TrueModel = new AgenticModel(Boolean.TRUE, cognisphere);
-  private final AgenticModel FalseModel = new AgenticModel(Boolean.FALSE, cognisphere);
-  private final AgenticModel NullModel = new AgenticModel(null, cognisphere);
-
-  public void setCognishere(Cognisphere cognisphere) {
-    this.cognisphere = cognisphere;
-  }
-
+  /**
+   * Applies any change to the model after running as task. We will always set it to
+   * a @DefaultCognisphere object since @AgentExecutor is always adding the output to the
+   * cognisphere. We just have to make sure that cognisphere is always passed to the next input
+   * task.
+   *
+   * @param prev the global Cognisphere object getting updated by the workflow context
+   * @param obj the same Cognisphere object updated by the AgentExecutor
+   * @return the workflow context model holding the cognisphere object.
+   */
   @Override
   public WorkflowModel fromAny(WorkflowModel prev, Object obj) {
-    ((AgenticModel) prev).setObject(obj);
+    // We ignore `obj` since it's already included in `prev` within the Cognisphere instance
     return prev;
   }
 
   @Override
   public WorkflowModel combine(Map<String, WorkflowModel> workflowVariables) {
-    return new AgenticModel(workflowVariables, cognisphere);
+    // TODO: create a new cognisphere object in the CognisphereRegistryAssessor per branch
+    // TODO: Since we share the same cognisphere object, both branches are updating the same
+    // instance, so for now we return the first key.
+    return workflowVariables.values().iterator().next();
   }
 
   @Override
   public WorkflowModelCollection createCollection() {
-    return new AgenticModelCollection(cognisphere);
+    throw new UnsupportedOperationException();
   }
+
+  // TODO: all these methods can use Cognisphere as long as we have access to the `outputName`
 
   @Override
   public WorkflowModel from(boolean value) {
-    return value ? TrueModel : FalseModel;
+    return new JavaModel(value);
   }
 
   @Override
   public WorkflowModel from(Number value) {
-    return new AgenticModel(value, cognisphere);
+    return new JavaModel(value);
   }
 
   @Override
   public WorkflowModel from(String value) {
-    return new AgenticModel(value, cognisphere);
+    return new JavaModel(value);
   }
 
   @Override
   public WorkflowModel from(CloudEvent ce) {
-    return new AgenticModel(ce, cognisphere);
+    return new JavaModel(ce);
   }
 
   @Override
   public WorkflowModel from(CloudEventData ce) {
-    return new AgenticModel(ce, cognisphere);
+    return new JavaModel(ce);
   }
 
   @Override
   public WorkflowModel from(OffsetDateTime value) {
-    return new AgenticModel(value, cognisphere);
+    return new JavaModel(value);
   }
 
   @Override
   public WorkflowModel from(Map<String, Object> map) {
+    final Cognisphere cognisphere = new CognisphereRegistryAssessor().getCognisphere();
     cognisphere.writeStates(map);
-    return new AgenticModel(map, cognisphere);
+    return new AgenticModel(cognisphere);
   }
 
   @Override
   public WorkflowModel fromNull() {
-    return NullModel;
+    return new JavaModel(null);
   }
 
   @Override
   public WorkflowModel fromOther(Object value) {
-    return new AgenticModel(value, cognisphere);
+    if (value instanceof Cognisphere) {
+      return new AgenticModel((Cognisphere) value);
+    }
+    return new JavaModel(value);
   }
 }

--- a/experimental/agentic/src/main/java/io/serverlessworkflow/impl/expressions/agentic/AgenticModelFactory.java
+++ b/experimental/agentic/src/main/java/io/serverlessworkflow/impl/expressions/agentic/AgenticModelFactory.java
@@ -15,13 +15,13 @@
  */
 package io.serverlessworkflow.impl.expressions.agentic;
 
-import dev.langchain4j.agentic.cognisphere.Cognisphere;
+import dev.langchain4j.agentic.scope.AgenticScope;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.CloudEventData;
 import io.serverlessworkflow.impl.WorkflowModel;
 import io.serverlessworkflow.impl.WorkflowModelCollection;
 import io.serverlessworkflow.impl.WorkflowModelFactory;
-import io.serverlessworkflow.impl.expressions.agentic.langchain4j.CognisphereRegistryAssessor;
+import io.serverlessworkflow.impl.expressions.agentic.langchain4j.AgenticScopeRegistryAssessor;
 import io.serverlessworkflow.impl.expressions.func.JavaModel;
 import java.time.OffsetDateTime;
 import java.util.Map;
@@ -29,25 +29,24 @@ import java.util.Map;
 class AgenticModelFactory implements WorkflowModelFactory {
 
   /**
-   * Applies any change to the model after running as task. We will always set it to
-   * a @DefaultCognisphere object since @AgentExecutor is always adding the output to the
-   * cognisphere. We just have to make sure that cognisphere is always passed to the next input
-   * task.
+   * Applies any change to the model after running as task. We will always set it to a @AgenticScope
+   * object since @AgentExecutor is always adding the output to the agenticScope. We just have to
+   * make sure that agenticScope is always passed to the next input task.
    *
-   * @param prev the global Cognisphere object getting updated by the workflow context
-   * @param obj the same Cognisphere object updated by the AgentExecutor
-   * @return the workflow context model holding the cognisphere object.
+   * @param prev the global AgenticScope object getting updated by the workflow context
+   * @param obj the same AgenticScope object updated by the AgentExecutor
+   * @return the workflow context model holding the agenticScope object.
    */
   @Override
   public WorkflowModel fromAny(WorkflowModel prev, Object obj) {
-    // We ignore `obj` since it's already included in `prev` within the Cognisphere instance
+    // We ignore `obj` since it's already included in `prev` within the agenticScope instance
     return prev;
   }
 
   @Override
   public WorkflowModel combine(Map<String, WorkflowModel> workflowVariables) {
-    // TODO: create a new cognisphere object in the CognisphereRegistryAssessor per branch
-    // TODO: Since we share the same cognisphere object, both branches are updating the same
+    // TODO: create a new agenticScope object in the AgenticScopeRegistryAssessor per branch
+    // TODO: Since we share the same agenticScope object, both branches are updating the same
     // instance, so for now we return the first key.
     return workflowVariables.values().iterator().next();
   }
@@ -57,7 +56,7 @@ class AgenticModelFactory implements WorkflowModelFactory {
     throw new UnsupportedOperationException();
   }
 
-  // TODO: all these methods can use Cognisphere as long as we have access to the `outputName`
+  // TODO: all these methods can use agenticScope as long as we have access to the `outputName`
 
   @Override
   public WorkflowModel from(boolean value) {
@@ -91,9 +90,9 @@ class AgenticModelFactory implements WorkflowModelFactory {
 
   @Override
   public WorkflowModel from(Map<String, Object> map) {
-    final Cognisphere cognisphere = new CognisphereRegistryAssessor().getCognisphere();
-    cognisphere.writeStates(map);
-    return new AgenticModel(cognisphere);
+    final AgenticScope agenticScope = new AgenticScopeRegistryAssessor().getAgenticScope();
+    agenticScope.writeStates(map);
+    return new AgenticModel(agenticScope);
   }
 
   @Override
@@ -103,8 +102,8 @@ class AgenticModelFactory implements WorkflowModelFactory {
 
   @Override
   public WorkflowModel fromOther(Object value) {
-    if (value instanceof Cognisphere) {
-      return new AgenticModel((Cognisphere) value);
+    if (value instanceof AgenticScope) {
+      return new AgenticModel((AgenticScope) value);
     }
     return new JavaModel(value);
   }

--- a/experimental/agentic/src/main/java/io/serverlessworkflow/impl/expressions/agentic/langchain4j/AgenticScopeRegistryAssessor.java
+++ b/experimental/agentic/src/main/java/io/serverlessworkflow/impl/expressions/agentic/langchain4j/AgenticScopeRegistryAssessor.java
@@ -15,27 +15,28 @@
  */
 package io.serverlessworkflow.impl.expressions.agentic.langchain4j;
 
-import dev.langchain4j.agentic.cognisphere.CognisphereRegistry;
-import dev.langchain4j.agentic.cognisphere.DefaultCognisphere;
-import dev.langchain4j.agentic.internal.CognisphereOwner;
+import dev.langchain4j.agentic.internal.AgenticScopeOwner;
+import dev.langchain4j.agentic.scope.AgenticScopeRegistry;
+import dev.langchain4j.agentic.scope.DefaultAgenticScope;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class CognisphereRegistryAssessor implements CognisphereOwner {
+public class AgenticScopeRegistryAssessor implements AgenticScopeOwner {
 
-  private final AtomicReference<CognisphereRegistry> cognisphereRegistry = new AtomicReference<>();
+  private final AtomicReference<AgenticScopeRegistry> agenticScopeRegistry =
+      new AtomicReference<>();
   private final String agentId;
-  private DefaultCognisphere cognisphere;
+  private DefaultAgenticScope agenticScope;
   private Object memoryId;
 
-  public CognisphereRegistryAssessor(String agentId) {
+  public AgenticScopeRegistryAssessor(String agentId) {
     Objects.requireNonNull(agentId, "Agent id cannot be null");
     this.agentId = agentId;
   }
 
   // TODO: have access to the workflow definition and assign its name instead
-  public CognisphereRegistryAssessor() {
+  public AgenticScopeRegistryAssessor() {
     this.agentId = UUID.randomUUID().toString();
   }
 
@@ -43,28 +44,28 @@ public class CognisphereRegistryAssessor implements CognisphereOwner {
     this.memoryId = memoryId;
   }
 
-  public DefaultCognisphere getCognisphere() {
-    if (cognisphere != null) {
-      return cognisphere;
+  public DefaultAgenticScope getAgenticScope() {
+    if (agenticScope != null) {
+      return agenticScope;
     }
 
     if (memoryId != null) {
-      this.cognisphere = registry().getOrCreate(memoryId);
+      this.agenticScope = registry().getOrCreate(memoryId);
     } else {
-      this.cognisphere = registry().createEphemeralCognisphere();
+      this.agenticScope = registry().createEphemeralAgenticScope();
     }
-    return this.cognisphere;
+    return this.agenticScope;
   }
 
   @Override
-  public CognisphereOwner withCognisphere(DefaultCognisphere cognisphere) {
-    this.cognisphere = cognisphere;
+  public AgenticScopeOwner withAgenticScope(DefaultAgenticScope agenticScope) {
+    this.agenticScope = agenticScope;
     return this;
   }
 
   @Override
-  public CognisphereRegistry registry() {
-    cognisphereRegistry.compareAndSet(null, new CognisphereRegistry(agentId));
-    return cognisphereRegistry.get();
+  public AgenticScopeRegistry registry() {
+    agenticScopeRegistry.compareAndSet(null, new AgenticScopeRegistry(agentId));
+    return agenticScopeRegistry.get();
   }
 }

--- a/experimental/agentic/src/main/java/io/serverlessworkflow/impl/expressions/agentic/langchain4j/CognisphereRegistryAssessor.java
+++ b/experimental/agentic/src/main/java/io/serverlessworkflow/impl/expressions/agentic/langchain4j/CognisphereRegistryAssessor.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.impl.expressions.agentic.langchain4j;
+
+import dev.langchain4j.agentic.cognisphere.CognisphereRegistry;
+import dev.langchain4j.agentic.cognisphere.DefaultCognisphere;
+import dev.langchain4j.agentic.internal.CognisphereOwner;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class CognisphereRegistryAssessor implements CognisphereOwner {
+
+  private final AtomicReference<CognisphereRegistry> cognisphereRegistry = new AtomicReference<>();
+  private final String agentId;
+  private DefaultCognisphere cognisphere;
+  private Object memoryId;
+
+  public CognisphereRegistryAssessor(String agentId) {
+    Objects.requireNonNull(agentId, "Agent id cannot be null");
+    this.agentId = agentId;
+  }
+
+  // TODO: have access to the workflow definition and assign its name instead
+  public CognisphereRegistryAssessor() {
+    this.agentId = UUID.randomUUID().toString();
+  }
+
+  public void setMemoryId(Object memoryId) {
+    this.memoryId = memoryId;
+  }
+
+  public DefaultCognisphere getCognisphere() {
+    if (cognisphere != null) {
+      return cognisphere;
+    }
+
+    if (memoryId != null) {
+      this.cognisphere = registry().getOrCreate(memoryId);
+    } else {
+      this.cognisphere = registry().createEphemeralCognisphere();
+    }
+    return this.cognisphere;
+  }
+
+  @Override
+  public CognisphereOwner withCognisphere(DefaultCognisphere cognisphere) {
+    this.cognisphere = cognisphere;
+    return this;
+  }
+
+  @Override
+  public CognisphereRegistry registry() {
+    cognisphereRegistry.compareAndSet(null, new CognisphereRegistry(agentId));
+    return cognisphereRegistry.get();
+  }
+}

--- a/experimental/lambda/src/main/java/io/serverlessworkflow/impl/expressions/func/JavaModel.java
+++ b/experimental/lambda/src/main/java/io/serverlessworkflow/impl/expressions/func/JavaModel.java
@@ -28,7 +28,7 @@ public class JavaModel implements WorkflowModel {
 
   protected Object object;
 
-  protected JavaModel(Object object) {
+  public JavaModel(Object object) {
     this.object = asJavaObject(object);
   }
 

--- a/fluent/agentic-langchain4j/pom.xml
+++ b/fluent/agentic-langchain4j/pom.xml
@@ -9,17 +9,18 @@
         <version>8.0.0-SNAPSHOT</version>
     </parent>
 
-    <name>Serverless Workflow :: Fluent :: Agentic</name>
-    <artifactId>serverlessworkflow-fluent-agentic</artifactId>
+    <artifactId>serverlessworkflow-fluent-agentic-langchain4j</artifactId>
+    <name>Serverless Workflow :: Fluent :: Agentic LangChain4j</name>
+    <description>Agentic Workflow DSL Implementation for langchain4j-agentic</description>
 
     <dependencies>
         <dependency>
             <groupId>io.serverlessworkflow</groupId>
-            <artifactId>serverlessworkflow-experimental-types</artifactId>
+            <artifactId>serverlessworkflow-experimental-agentic</artifactId>
         </dependency>
         <dependency>
             <groupId>io.serverlessworkflow</groupId>
-            <artifactId>serverlessworkflow-fluent-func</artifactId>
+            <artifactId>serverlessworkflow-fluent-agentic</artifactId>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
@@ -54,26 +55,14 @@
         </dependency>
         <dependency>
             <groupId>io.serverlessworkflow</groupId>
-            <artifactId>serverlessworkflow-experimental-agentic</artifactId>
+            <artifactId>serverlessworkflow-fluent-agentic</artifactId>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>${version.jar.plugin}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <!-- this will package up the test-classes into a separate jar -->
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+
+
+
 
 </project>

--- a/fluent/agentic-langchain4j/src/main/java/io/serverlessworkflow/fluent/agentic/langchain4j/AbstractAgentService.java
+++ b/fluent/agentic-langchain4j/src/main/java/io/serverlessworkflow/fluent/agentic/langchain4j/AbstractAgentService.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.fluent.agentic.langchain4j;
+
+import dev.langchain4j.agentic.cognisphere.Cognisphere;
+import dev.langchain4j.agentic.cognisphere.DefaultCognisphere;
+import dev.langchain4j.agentic.internal.AgentSpecification;
+import dev.langchain4j.agentic.internal.CognisphereOwner;
+import io.serverlessworkflow.api.types.Workflow;
+import io.serverlessworkflow.fluent.agentic.AgentWorkflowBuilder;
+import io.serverlessworkflow.impl.WorkflowApplication;
+import java.lang.reflect.Proxy;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public abstract class AbstractAgentService<T, S> implements WorkflowDefinitionBuilder {
+
+  // Workflow OutputAs
+  private static final Function<Cognisphere, Object> DEFAULT_OUTPUT_FUNCTION = cognisphere -> null;
+
+  protected final WorkflowApplication.Builder workflowExecBuilder;
+  protected final AgentWorkflowBuilder workflowBuilder;
+  protected final Class<T> agentServiceClass;
+
+  protected AbstractAgentService(Class<T> agentServiceClass) {
+    this.workflowBuilder = AgentWorkflowBuilder.workflow().outputAs(DEFAULT_OUTPUT_FUNCTION);
+    this.agentServiceClass = agentServiceClass;
+    this.workflowExecBuilder = WorkflowApplication.builder();
+  }
+
+  @SuppressWarnings("unchecked")
+  public T build() {
+    return (T)
+        Proxy.newProxyInstance(
+            this.agentServiceClass.getClassLoader(),
+            new Class<?>[] {agentServiceClass, AgentSpecification.class, CognisphereOwner.class},
+            new WorkflowInvocationHandler(
+                this.workflowBuilder.build(), this.workflowExecBuilder, this.agentServiceClass));
+  }
+
+  @SuppressWarnings("unchecked")
+  public S beforeCall(Consumer<Cognisphere> beforeCall) {
+    this.workflowBuilder.inputFrom(
+        cog -> {
+          beforeCall.accept(cog);
+          return cog;
+        },
+        Cognisphere.class);
+    return (S) this;
+  }
+
+  @SuppressWarnings("unchecked")
+  public S outputName(String outputName) {
+    Function<DefaultCognisphere, Object> outputFunction = cog -> cog.readState(outputName);
+    this.workflowBuilder.outputAs(outputFunction, DefaultCognisphere.class);
+    this.workflowBuilder.document(
+        d -> d.metadata(m -> m.metadata(META_KEY_OUTPUTNAME, outputName)));
+    return (S) this;
+  }
+
+  @SuppressWarnings("unchecked")
+  public S output(Function<Cognisphere, Object> output) {
+    this.workflowBuilder.outputAs(output, Cognisphere.class);
+    return (S) this;
+  }
+
+  @Override
+  public Workflow getDefinition() {
+    return this.workflowBuilder.build();
+  }
+}

--- a/fluent/agentic-langchain4j/src/main/java/io/serverlessworkflow/fluent/agentic/langchain4j/ConditionalAgentServiceImpl.java
+++ b/fluent/agentic-langchain4j/src/main/java/io/serverlessworkflow/fluent/agentic/langchain4j/ConditionalAgentServiceImpl.java
@@ -15,8 +15,8 @@
  */
 package io.serverlessworkflow.fluent.agentic.langchain4j;
 
-import dev.langchain4j.agentic.cognisphere.Cognisphere;
 import dev.langchain4j.agentic.internal.AgentExecutor;
+import dev.langchain4j.agentic.scope.AgenticScope;
 import dev.langchain4j.agentic.workflow.ConditionalAgentService;
 import java.util.Arrays;
 import java.util.List;
@@ -46,7 +46,7 @@ public class ConditionalAgentServiceImpl<T>
   }
 
   @Override
-  public ConditionalAgentService<T> subAgents(Predicate<Cognisphere> condition, Object... agents) {
+  public ConditionalAgentService<T> subAgents(Predicate<AgenticScope> condition, Object... agents) {
     this.workflowBuilder.tasks(
         t -> Arrays.stream(agents).forEach(agent -> t.when(condition).agent(agent)));
     return this;
@@ -54,13 +54,13 @@ public class ConditionalAgentServiceImpl<T>
 
   @Override
   public ConditionalAgentService<T> subAgents(
-      Predicate<Cognisphere> condition, List<AgentExecutor> agentExecutors) {
+      Predicate<AgenticScope> condition, List<AgentExecutor> agentExecutors) {
     return this.subAgents(condition, agentExecutors.toArray());
   }
 
   @Override
   public ConditionalAgentService<T> subAgent(
-      Predicate<Cognisphere> condition, AgentExecutor agentExecutor) {
+      Predicate<AgenticScope> condition, AgentExecutor agentExecutor) {
     this.workflowBuilder.tasks(t -> t.when(condition).agent(agentExecutor));
     return this;
   }

--- a/fluent/agentic-langchain4j/src/main/java/io/serverlessworkflow/fluent/agentic/langchain4j/ConditionalAgentServiceImpl.java
+++ b/fluent/agentic-langchain4j/src/main/java/io/serverlessworkflow/fluent/agentic/langchain4j/ConditionalAgentServiceImpl.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.fluent.agentic.langchain4j;
+
+import dev.langchain4j.agentic.cognisphere.Cognisphere;
+import dev.langchain4j.agentic.internal.AgentExecutor;
+import dev.langchain4j.agentic.workflow.ConditionalAgentService;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+
+public class ConditionalAgentServiceImpl<T>
+    extends AbstractAgentService<T, ConditionalAgentService<T>>
+    implements ConditionalAgentService<T> {
+
+  private ConditionalAgentServiceImpl(Class<T> agentServiceClass) {
+    super(agentServiceClass);
+  }
+
+  public static <T> ConditionalAgentService<T> builder(Class<T> agentServiceClass) {
+    return new ConditionalAgentServiceImpl<>(agentServiceClass);
+  }
+
+  @Override
+  public ConditionalAgentService<T> subAgents(Object... agents) {
+    this.workflowBuilder.tasks(t -> t.sequence(agents));
+    return this;
+  }
+
+  @Override
+  public ConditionalAgentService<T> subAgents(List<AgentExecutor> agentExecutors) {
+    return this.subAgents(agentExecutors.toArray());
+  }
+
+  @Override
+  public ConditionalAgentService<T> subAgents(Predicate<Cognisphere> condition, Object... agents) {
+    this.workflowBuilder.tasks(
+        t -> Arrays.stream(agents).forEach(agent -> t.when(condition).agent(agent)));
+    return this;
+  }
+
+  @Override
+  public ConditionalAgentService<T> subAgents(
+      Predicate<Cognisphere> condition, List<AgentExecutor> agentExecutors) {
+    return this.subAgents(condition, agentExecutors.toArray());
+  }
+
+  @Override
+  public ConditionalAgentService<T> subAgent(
+      Predicate<Cognisphere> condition, AgentExecutor agentExecutor) {
+    this.workflowBuilder.tasks(t -> t.when(condition).agent(agentExecutor));
+    return this;
+  }
+}

--- a/fluent/agentic-langchain4j/src/main/java/io/serverlessworkflow/fluent/agentic/langchain4j/LC4JWorkflowBuilder.java
+++ b/fluent/agentic-langchain4j/src/main/java/io/serverlessworkflow/fluent/agentic/langchain4j/LC4JWorkflowBuilder.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.fluent.agentic.langchain4j;
+
+import dev.langchain4j.agentic.UntypedAgent;
+import dev.langchain4j.agentic.workflow.ConditionalAgentService;
+import dev.langchain4j.agentic.workflow.LoopAgentService;
+import dev.langchain4j.agentic.workflow.ParallelAgentService;
+import dev.langchain4j.agentic.workflow.SequentialAgentService;
+import dev.langchain4j.agentic.workflow.WorkflowAgentsBuilder;
+
+public class LC4JWorkflowBuilder implements WorkflowAgentsBuilder {
+
+  @Override
+  public SequentialAgentService<UntypedAgent> sequenceBuilder() {
+    return SequentialAgentServiceImpl.builder(UntypedAgent.class);
+  }
+
+  @Override
+  public <T> SequentialAgentService<T> sequenceBuilder(Class<T> agentServiceClass) {
+    return SequentialAgentServiceImpl.builder(agentServiceClass);
+  }
+
+  @Override
+  public ParallelAgentService<UntypedAgent> parallelBuilder() {
+    return ParallelAgentServiceImpl.builder(UntypedAgent.class);
+  }
+
+  @Override
+  public <T> ParallelAgentService<T> parallelBuilder(Class<T> agentServiceClass) {
+    return ParallelAgentServiceImpl.builder(agentServiceClass);
+  }
+
+  @Override
+  public LoopAgentService<UntypedAgent> loopBuilder() {
+    return LoopAgentServiceImpl.builder(UntypedAgent.class);
+  }
+
+  @Override
+  public <T> LoopAgentService<T> loopBuilder(Class<T> agentServiceClass) {
+    return LoopAgentServiceImpl.builder(agentServiceClass);
+  }
+
+  @Override
+  public ConditionalAgentService<UntypedAgent> conditionalBuilder() {
+    return ConditionalAgentServiceImpl.builder(UntypedAgent.class);
+  }
+
+  @Override
+  public <T> ConditionalAgentService<T> conditionalBuilder(Class<T> agentServiceClass) {
+    return ConditionalAgentServiceImpl.builder(agentServiceClass);
+  }
+}

--- a/fluent/agentic-langchain4j/src/main/java/io/serverlessworkflow/fluent/agentic/langchain4j/LoopAgentServiceImpl.java
+++ b/fluent/agentic-langchain4j/src/main/java/io/serverlessworkflow/fluent/agentic/langchain4j/LoopAgentServiceImpl.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.fluent.agentic.langchain4j;
+
+import dev.langchain4j.agentic.cognisphere.Cognisphere;
+import dev.langchain4j.agentic.internal.AgentExecutor;
+import dev.langchain4j.agentic.workflow.LoopAgentService;
+import io.serverlessworkflow.fluent.agentic.LoopAgentsBuilder;
+import java.util.List;
+import java.util.function.Predicate;
+
+public class LoopAgentServiceImpl<T> extends AbstractAgentService<T, LoopAgentService<T>>
+    implements LoopAgentService<T> {
+
+  private final LoopAgentsBuilder loopAgentsBuilder = new LoopAgentsBuilder();
+
+  private LoopAgentServiceImpl(Class<T> agentServiceClass) {
+    super(agentServiceClass);
+  }
+
+  public static <T> LoopAgentService<T> builder(Class<T> agentServiceClass) {
+    return new LoopAgentServiceImpl<>(agentServiceClass);
+  }
+
+  @Override
+  public LoopAgentService<T> maxIterations(int maxIterations) {
+    this.loopAgentsBuilder.maxIterations(maxIterations);
+    return this;
+  }
+
+  @Override
+  public LoopAgentService<T> exitCondition(Predicate<Cognisphere> exitCondition) {
+    this.loopAgentsBuilder.exitCondition(exitCondition);
+    return this;
+  }
+
+  @Override
+  public LoopAgentService<T> subAgents(Object... agents) {
+    this.loopAgentsBuilder.subAgents(agents);
+    this.workflowBuilder.tasks(t -> t.loop(this.loopAgentsBuilder));
+    return this;
+  }
+
+  @Override
+  public LoopAgentService<T> subAgents(List<AgentExecutor> agentExecutors) {
+    this.loopAgentsBuilder.subAgents(agentExecutors.toArray());
+    this.workflowBuilder.tasks(t -> t.loop(this.loopAgentsBuilder));
+    return this;
+  }
+}

--- a/fluent/agentic-langchain4j/src/main/java/io/serverlessworkflow/fluent/agentic/langchain4j/LoopAgentServiceImpl.java
+++ b/fluent/agentic-langchain4j/src/main/java/io/serverlessworkflow/fluent/agentic/langchain4j/LoopAgentServiceImpl.java
@@ -15,8 +15,8 @@
  */
 package io.serverlessworkflow.fluent.agentic.langchain4j;
 
-import dev.langchain4j.agentic.cognisphere.Cognisphere;
 import dev.langchain4j.agentic.internal.AgentExecutor;
+import dev.langchain4j.agentic.scope.AgenticScope;
 import dev.langchain4j.agentic.workflow.LoopAgentService;
 import io.serverlessworkflow.fluent.agentic.LoopAgentsBuilder;
 import java.util.List;
@@ -42,7 +42,7 @@ public class LoopAgentServiceImpl<T> extends AbstractAgentService<T, LoopAgentSe
   }
 
   @Override
-  public LoopAgentService<T> exitCondition(Predicate<Cognisphere> exitCondition) {
+  public LoopAgentService<T> exitCondition(Predicate<AgenticScope> exitCondition) {
     this.loopAgentsBuilder.exitCondition(exitCondition);
     return this;
   }

--- a/fluent/agentic-langchain4j/src/main/java/io/serverlessworkflow/fluent/agentic/langchain4j/ParallelAgentServiceImpl.java
+++ b/fluent/agentic-langchain4j/src/main/java/io/serverlessworkflow/fluent/agentic/langchain4j/ParallelAgentServiceImpl.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.fluent.agentic.langchain4j;
+
+import dev.langchain4j.agentic.internal.AgentExecutor;
+import dev.langchain4j.agentic.workflow.ParallelAgentService;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+public class ParallelAgentServiceImpl<T> extends AbstractAgentService<T, ParallelAgentService<T>>
+    implements ParallelAgentService<T> {
+
+  private ParallelAgentServiceImpl(Class<T> agentServiceClass) {
+    super(agentServiceClass);
+  }
+
+  public static <T> ParallelAgentService<T> builder(Class<T> agentServiceClass) {
+    return new ParallelAgentServiceImpl<>(agentServiceClass);
+  }
+
+  @Override
+  public ParallelAgentService<T> executorService(ExecutorService executorService) {
+    this.workflowExecBuilder.withExecutorFactory(() -> executorService);
+    return this;
+  }
+
+  @Override
+  public ParallelAgentService<T> subAgents(Object... agents) {
+    this.workflowBuilder.tasks(t -> t.parallel(agents));
+    return this;
+  }
+
+  @Override
+  public ParallelAgentService<T> subAgents(List<AgentExecutor> agentExecutors) {
+    return this.subAgents(agentExecutors.toArray());
+  }
+}

--- a/fluent/agentic-langchain4j/src/main/java/io/serverlessworkflow/fluent/agentic/langchain4j/SequentialAgentServiceImpl.java
+++ b/fluent/agentic-langchain4j/src/main/java/io/serverlessworkflow/fluent/agentic/langchain4j/SequentialAgentServiceImpl.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.fluent.agentic.langchain4j;
+
+import dev.langchain4j.agentic.internal.AgentExecutor;
+import dev.langchain4j.agentic.workflow.SequentialAgentService;
+import java.util.List;
+
+public class SequentialAgentServiceImpl<T>
+    extends AbstractAgentService<T, SequentialAgentService<T>>
+    implements SequentialAgentService<T> {
+
+  private SequentialAgentServiceImpl(Class<T> agentServiceClass) {
+    super(agentServiceClass);
+  }
+
+  public static <T> SequentialAgentServiceImpl<T> builder(Class<T> agentServiceClass) {
+    return new SequentialAgentServiceImpl<>(agentServiceClass);
+  }
+
+  @Override
+  public SequentialAgentService<T> subAgents(Object... agents) {
+    this.workflowBuilder.tasks(t -> t.sequence(agents));
+    return this;
+  }
+
+  @Override
+  public SequentialAgentService<T> subAgents(List<AgentExecutor> agentExecutors) {
+    this.subAgents(agentExecutors.toArray());
+    return this;
+  }
+}

--- a/fluent/agentic-langchain4j/src/main/java/io/serverlessworkflow/fluent/agentic/langchain4j/WorkflowDefinitionBuilder.java
+++ b/fluent/agentic-langchain4j/src/main/java/io/serverlessworkflow/fluent/agentic/langchain4j/WorkflowDefinitionBuilder.java
@@ -13,22 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.serverlessworkflow.fluent.agentic;
+package io.serverlessworkflow.fluent.agentic.langchain4j;
 
-import static io.serverlessworkflow.fluent.agentic.Models.BASE_MODEL;
-import static org.mockito.Mockito.spy;
+import io.serverlessworkflow.api.types.Workflow;
 
-import dev.langchain4j.agentic.AgenticServices;
+public interface WorkflowDefinitionBuilder {
 
-public final class AgentsUtils {
+  String META_KEY_OUTPUTNAME = "outputName";
 
-  private AgentsUtils() {}
-
-  public static Agents.MovieExpert newMovieExpert() {
-    return spy(
-        AgenticServices.agentBuilder(Agents.MovieExpert.class)
-            .outputName("movies")
-            .chatModel(BASE_MODEL)
-            .build());
-  }
+  Workflow getDefinition();
 }

--- a/fluent/agentic-langchain4j/src/main/java/io/serverlessworkflow/fluent/agentic/langchain4j/WorkflowInvocationHandler.java
+++ b/fluent/agentic-langchain4j/src/main/java/io/serverlessworkflow/fluent/agentic/langchain4j/WorkflowInvocationHandler.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.fluent.agentic.langchain4j;
+
+import dev.langchain4j.agentic.UntypedAgent;
+import dev.langchain4j.agentic.cognisphere.Cognisphere;
+import dev.langchain4j.agentic.cognisphere.CognisphereAccess;
+import dev.langchain4j.agentic.cognisphere.CognisphereRegistry;
+import dev.langchain4j.agentic.cognisphere.DefaultCognisphere;
+import dev.langchain4j.agentic.cognisphere.ResultWithCognisphere;
+import dev.langchain4j.agentic.internal.AgentInvoker;
+import dev.langchain4j.agentic.internal.AgentSpecification;
+import dev.langchain4j.agentic.internal.CognisphereOwner;
+import dev.langchain4j.service.MemoryId;
+import io.serverlessworkflow.api.types.Workflow;
+import io.serverlessworkflow.impl.WorkflowApplication;
+import io.serverlessworkflow.impl.expressions.agentic.langchain4j.CognisphereRegistryAssessor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+public class WorkflowInvocationHandler implements InvocationHandler, CognisphereOwner {
+
+  private final Workflow workflow;
+  private final WorkflowApplication.Builder workflowApplicationBuilder;
+  private final CognisphereRegistryAssessor cognisphereRegistryAssessor;
+
+  WorkflowInvocationHandler(
+      Workflow workflow,
+      WorkflowApplication.Builder workflowApplicationBuilder,
+      Class<?> agentServiceClass) {
+    this.workflow = workflow;
+    this.workflowApplicationBuilder = workflowApplicationBuilder;
+    this.cognisphereRegistryAssessor = new CognisphereRegistryAssessor(agentServiceClass.getName());
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void writeCognisphereState(Cognisphere cognisphere, Method method, Object[] args) {
+    if (method.getDeclaringClass() == UntypedAgent.class) {
+      cognisphere.writeStates((Map<String, Object>) args[0]);
+    } else {
+      Parameter[] parameters = method.getParameters();
+      for (int i = 0; i < parameters.length; i++) {
+        int index = i;
+        AgentInvoker.optionalParameterName(parameters[i])
+            .ifPresent(argName -> cognisphere.writeState(argName, args[index]));
+      }
+    }
+  }
+
+  private String outputName() {
+    Object outputName =
+        this.workflow
+            .getDocument()
+            .getMetadata()
+            .getAdditionalProperties()
+            .get(WorkflowDefinitionBuilder.META_KEY_OUTPUTNAME);
+    if (outputName != null) {
+      return outputName.toString();
+    }
+    return null;
+  }
+
+  @Override
+  public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+    CognisphereRegistry registry = registry();
+    // outputName
+    if (method.getDeclaringClass() == AgentSpecification.class) {
+      return switch (method.getName()) {
+        case "outputName" -> outputName();
+        default ->
+            throw new UnsupportedOperationException(
+                "Unknown method on AgentInstance class : " + method.getName());
+      };
+    }
+    // withCognisphere
+    if (method.getDeclaringClass() == CognisphereOwner.class) {
+      // Ingest the workflow input as a Cognisphere object
+      // Later, retrieve it and start the workflow with it as input.
+      return switch (method.getName()) {
+        case "withCognisphere" -> this.withCognisphere((DefaultCognisphere) args[0]);
+        case "registry" -> registry;
+        default ->
+            throw new UnsupportedOperationException(
+                "Unknown method on CognisphereOwner class : " + method.getName());
+      };
+    }
+    // getCognisphere
+    // evictCognisphere
+    if (method.getDeclaringClass() == CognisphereAccess.class) {
+      return switch (method.getName()) {
+        case "getCognisphere" -> registry().get(args[0]);
+        case "evictCognisphere" -> registry().evict(args[0]);
+        default ->
+            throw new UnsupportedOperationException(
+                "Unknown method on CognisphereAccess class : " + method.getName());
+      };
+    }
+
+    // invoke
+    return executeWorkflow(currentCognisphere(method, args), method, args);
+  }
+
+  private Object executeWorkflow(DefaultCognisphere cognisphere, Method method, Object[] args) {
+    writeCognisphereState(cognisphere, method, args);
+
+    try (WorkflowApplication app = workflowApplicationBuilder.build()) {
+      // TODO improve result handling
+      DefaultCognisphere output =
+          app.workflowDefinition(workflow)
+              .instance(cognisphere)
+              .start()
+              .get()
+              .as(DefaultCognisphere.class)
+              .orElseThrow(
+                  () ->
+                      new IllegalArgumentException(
+                          "Workflow hasn't returned a Cognisphere object."));
+      Object result = output.readState(outputName());
+
+      return method.getReturnType().equals(ResultWithCognisphere.class)
+          ? new ResultWithCognisphere<>(output, result)
+          : result;
+
+    } catch (ExecutionException | InterruptedException e) {
+      throw new RuntimeException(
+          "Failed to execute workflow: "
+              + workflow.getDocument().getName()
+              + " - Cognisphere: "
+              + cognisphere,
+          e);
+    }
+  }
+
+  private DefaultCognisphere currentCognisphere(Method method, Object[] args) {
+    Object memoryId = memoryId(method, args);
+    this.cognisphereRegistryAssessor.setMemoryId(memoryId);
+    return this.cognisphereRegistryAssessor.getCognisphere();
+  }
+
+  private Object memoryId(Method method, Object[] args) {
+    Parameter[] parameters = method.getParameters();
+    for (int i = 0; i < parameters.length; i++) {
+      if (parameters[i].getAnnotation(MemoryId.class) != null) {
+        return args[i];
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public CognisphereOwner withCognisphere(DefaultCognisphere cognisphere) {
+    this.cognisphereRegistryAssessor.withCognisphere(cognisphere);
+    return this;
+  }
+
+  @Override
+  public CognisphereRegistry registry() {
+    return this.cognisphereRegistryAssessor.registry();
+  }
+}

--- a/fluent/agentic-langchain4j/src/main/java/io/serverlessworkflow/fluent/agentic/langchain4j/WorkflowInvocationHandler.java
+++ b/fluent/agentic-langchain4j/src/main/java/io/serverlessworkflow/fluent/agentic/langchain4j/WorkflowInvocationHandler.java
@@ -16,29 +16,29 @@
 package io.serverlessworkflow.fluent.agentic.langchain4j;
 
 import dev.langchain4j.agentic.UntypedAgent;
-import dev.langchain4j.agentic.cognisphere.Cognisphere;
-import dev.langchain4j.agentic.cognisphere.CognisphereAccess;
-import dev.langchain4j.agentic.cognisphere.CognisphereRegistry;
-import dev.langchain4j.agentic.cognisphere.DefaultCognisphere;
-import dev.langchain4j.agentic.cognisphere.ResultWithCognisphere;
 import dev.langchain4j.agentic.internal.AgentInvoker;
 import dev.langchain4j.agentic.internal.AgentSpecification;
-import dev.langchain4j.agentic.internal.CognisphereOwner;
+import dev.langchain4j.agentic.internal.AgenticScopeOwner;
+import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.agentic.scope.AgenticScopeAccess;
+import dev.langchain4j.agentic.scope.AgenticScopeRegistry;
+import dev.langchain4j.agentic.scope.DefaultAgenticScope;
+import dev.langchain4j.agentic.scope.ResultWithAgenticScope;
 import dev.langchain4j.service.MemoryId;
 import io.serverlessworkflow.api.types.Workflow;
 import io.serverlessworkflow.impl.WorkflowApplication;
-import io.serverlessworkflow.impl.expressions.agentic.langchain4j.CognisphereRegistryAssessor;
+import io.serverlessworkflow.impl.expressions.agentic.langchain4j.AgenticScopeRegistryAssessor;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
-public class WorkflowInvocationHandler implements InvocationHandler, CognisphereOwner {
+public class WorkflowInvocationHandler implements InvocationHandler, AgenticScopeOwner {
 
   private final Workflow workflow;
   private final WorkflowApplication.Builder workflowApplicationBuilder;
-  private final CognisphereRegistryAssessor cognisphereRegistryAssessor;
+  private final AgenticScopeRegistryAssessor agenticScopeRegistryAssessor;
 
   WorkflowInvocationHandler(
       Workflow workflow,
@@ -46,19 +46,21 @@ public class WorkflowInvocationHandler implements InvocationHandler, Cognisphere
       Class<?> agentServiceClass) {
     this.workflow = workflow;
     this.workflowApplicationBuilder = workflowApplicationBuilder;
-    this.cognisphereRegistryAssessor = new CognisphereRegistryAssessor(agentServiceClass.getName());
+    this.agenticScopeRegistryAssessor =
+        new AgenticScopeRegistryAssessor(agentServiceClass.getName());
   }
 
   @SuppressWarnings("unchecked")
-  private static void writeCognisphereState(Cognisphere cognisphere, Method method, Object[] args) {
+  private static void writeAgenticScopeState(
+      AgenticScope agenticScope, Method method, Object[] args) {
     if (method.getDeclaringClass() == UntypedAgent.class) {
-      cognisphere.writeStates((Map<String, Object>) args[0]);
+      agenticScope.writeStates((Map<String, Object>) args[0]);
     } else {
       Parameter[] parameters = method.getParameters();
       for (int i = 0; i < parameters.length; i++) {
         int index = i;
         AgentInvoker.optionalParameterName(parameters[i])
-            .ifPresent(argName -> cognisphere.writeState(argName, args[index]));
+            .ifPresent(argName -> agenticScope.writeState(argName, args[index]));
       }
     }
   }
@@ -78,7 +80,7 @@ public class WorkflowInvocationHandler implements InvocationHandler, Cognisphere
 
   @Override
   public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-    CognisphereRegistry registry = registry();
+    AgenticScopeRegistry registry = registry();
     // outputName
     if (method.getDeclaringClass() == AgentSpecification.class) {
       return switch (method.getName()) {
@@ -89,23 +91,23 @@ public class WorkflowInvocationHandler implements InvocationHandler, Cognisphere
       };
     }
     // withCognisphere
-    if (method.getDeclaringClass() == CognisphereOwner.class) {
-      // Ingest the workflow input as a Cognisphere object
+    if (method.getDeclaringClass() == AgenticScopeOwner.class) {
+      // Ingest the workflow input as a AgenticScope object
       // Later, retrieve it and start the workflow with it as input.
       return switch (method.getName()) {
-        case "withCognisphere" -> this.withCognisphere((DefaultCognisphere) args[0]);
+        case "withAgenticScope" -> this.withAgenticScope((DefaultAgenticScope) args[0]);
         case "registry" -> registry;
         default ->
             throw new UnsupportedOperationException(
                 "Unknown method on CognisphereOwner class : " + method.getName());
       };
     }
-    // getCognisphere
+    // getAgenticScope
     // evictCognisphere
-    if (method.getDeclaringClass() == CognisphereAccess.class) {
+    if (method.getDeclaringClass() == AgenticScopeAccess.class) {
       return switch (method.getName()) {
-        case "getCognisphere" -> registry().get(args[0]);
-        case "evictCognisphere" -> registry().evict(args[0]);
+        case "getAgenticScope" -> registry().get(args[0]);
+        case "evictAgenticScope" -> registry().evict(args[0]);
         default ->
             throw new UnsupportedOperationException(
                 "Unknown method on CognisphereAccess class : " + method.getName());
@@ -116,41 +118,41 @@ public class WorkflowInvocationHandler implements InvocationHandler, Cognisphere
     return executeWorkflow(currentCognisphere(method, args), method, args);
   }
 
-  private Object executeWorkflow(DefaultCognisphere cognisphere, Method method, Object[] args) {
-    writeCognisphereState(cognisphere, method, args);
+  private Object executeWorkflow(DefaultAgenticScope agenticScope, Method method, Object[] args) {
+    writeAgenticScopeState(agenticScope, method, args);
 
     try (WorkflowApplication app = workflowApplicationBuilder.build()) {
       // TODO improve result handling
-      DefaultCognisphere output =
+      DefaultAgenticScope output =
           app.workflowDefinition(workflow)
-              .instance(cognisphere)
+              .instance(agenticScope)
               .start()
               .get()
-              .as(DefaultCognisphere.class)
+              .as(DefaultAgenticScope.class)
               .orElseThrow(
                   () ->
                       new IllegalArgumentException(
                           "Workflow hasn't returned a Cognisphere object."));
       Object result = output.readState(outputName());
 
-      return method.getReturnType().equals(ResultWithCognisphere.class)
-          ? new ResultWithCognisphere<>(output, result)
+      return method.getReturnType().equals(ResultWithAgenticScope.class)
+          ? new ResultWithAgenticScope<>(output, result)
           : result;
 
     } catch (ExecutionException | InterruptedException e) {
       throw new RuntimeException(
           "Failed to execute workflow: "
               + workflow.getDocument().getName()
-              + " - Cognisphere: "
-              + cognisphere,
+              + " - AgenticScope: "
+              + agenticScope,
           e);
     }
   }
 
-  private DefaultCognisphere currentCognisphere(Method method, Object[] args) {
+  private DefaultAgenticScope currentCognisphere(Method method, Object[] args) {
     Object memoryId = memoryId(method, args);
-    this.cognisphereRegistryAssessor.setMemoryId(memoryId);
-    return this.cognisphereRegistryAssessor.getCognisphere();
+    this.agenticScopeRegistryAssessor.setMemoryId(memoryId);
+    return this.agenticScopeRegistryAssessor.getAgenticScope();
   }
 
   private Object memoryId(Method method, Object[] args) {
@@ -164,13 +166,13 @@ public class WorkflowInvocationHandler implements InvocationHandler, Cognisphere
   }
 
   @Override
-  public CognisphereOwner withCognisphere(DefaultCognisphere cognisphere) {
-    this.cognisphereRegistryAssessor.withCognisphere(cognisphere);
+  public AgenticScopeOwner withAgenticScope(DefaultAgenticScope agenticScope) {
+    this.agenticScopeRegistryAssessor.withAgenticScope(agenticScope);
     return this;
   }
 
   @Override
-  public CognisphereRegistry registry() {
-    return this.cognisphereRegistryAssessor.registry();
+  public AgenticScopeRegistry registry() {
+    return this.agenticScopeRegistryAssessor.registry();
   }
 }

--- a/fluent/agentic-langchain4j/src/test/java/io/serverlessworkflow/fluent/agentic/langchain4j/Agents.java
+++ b/fluent/agentic-langchain4j/src/test/java/io/serverlessworkflow/fluent/agentic/langchain4j/Agents.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.fluent.agentic.langchain4j;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.cognisphere.CognisphereAccess;
+import dev.langchain4j.agentic.cognisphere.ResultWithCognisphere;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import java.util.List;
+
+public class Agents {
+
+  public interface ExpertRouterAgent {
+
+    @Agent
+    String ask(@V("request") String request);
+  }
+
+  public interface ExpertRouterAgentWithMemory extends CognisphereAccess {
+
+    @Agent
+    String ask(@MemoryId String memoryId, @V("request") String request);
+  }
+
+  public interface CategoryRouter {
+
+    @UserMessage(
+        """
+            Analyze the following user request and categorize it as 'legal', 'medical' or 'technical'.
+            In case the request doesn't belong to any of those categories categorize it as 'unknown'.
+            Reply with only one of those words and nothing else.
+            The user request is: '{{request}}'.
+            """)
+    @Agent("Categorize a user request")
+    RequestCategory classify(@V("request") String request);
+  }
+
+  public enum RequestCategory {
+    LEGAL,
+    MEDICAL,
+    TECHNICAL,
+    UNKNOWN
+  }
+
+  public interface RouterAgent {
+
+    @UserMessage(
+        """
+            Analyze the following user request and categorize it as 'legal', 'medical' or 'technical',
+            then forward the request as it is to the corresponding expert provided as a tool.
+            Finally return the answer that you received from the expert without any modification.
+
+            The user request is: '{{it}}'.
+            """)
+    @Agent
+    String askToExpert(String request);
+  }
+
+  public interface MedicalExpert {
+
+    @UserMessage(
+        """
+            You are a medical expert.
+            Analyze the following user request under a medical point of view and provide the best possible answer.
+            The user request is {{request}}.
+            """)
+    @Tool("A medical expert")
+    @Agent("A medical expert")
+    String medical(@V("request") String request);
+  }
+
+  public interface MedicalExpertWithMemory {
+
+    @UserMessage(
+        """
+            You are a medical expert.
+            Analyze the following user request under a medical point of view and provide the best possible answer.
+            The user request is {{request}}.
+            """)
+    @Tool("A medical expert")
+    @Agent("A medical expert")
+    String medical(@MemoryId String memoryId, @V("request") String request);
+  }
+
+  public interface LegalExpert {
+
+    @UserMessage(
+        """
+            You are a legal expert.
+            Analyze the following user request under a legal point of view and provide the best possible answer.
+            The user request is {{request}}.
+            """)
+    @Tool("A legal expert")
+    @Agent("A legal expert")
+    String legal(@V("request") String request);
+  }
+
+  public interface LegalExpertWithMemory {
+
+    @UserMessage(
+        """
+            You are a legal expert.
+            Analyze the following user request under a legal point of view and provide the best possible answer.
+            The user request is {{request}}.
+            """)
+    @Tool("A legal expert")
+    @Agent("A legal expert")
+    String legal(@MemoryId String memoryId, @V("request") String request);
+  }
+
+  public interface TechnicalExpert {
+
+    @UserMessage(
+        """
+            You are a technical expert.
+            Analyze the following user request under a technical point of view and provide the best possible answer.
+            The user request is {{request}}.
+            """)
+    @Tool("A technical expert")
+    @Agent("A technical expert")
+    String technical(@V("request") String request);
+  }
+
+  public interface TechnicalExpertWithMemory {
+
+    @UserMessage(
+        """
+            You are a technical expert.
+            Analyze the following user request under a technical point of view and provide the best possible answer.
+            The user request is {{request}}.
+            """)
+    @Tool("A technical expert")
+    @Agent("A technical expert")
+    String technical(@MemoryId String memoryId, @V("request") String request);
+  }
+
+  public interface CreativeWriter {
+
+    @UserMessage(
+        """
+                You are a creative writer.
+                Generate a draft of a story long no more than 3 sentence around the given topic.
+                Return only the story and nothing else.
+                The topic is {{topic}}.
+                """)
+    @Agent("Generate a story based on the given topic")
+    String generateStory(@V("topic") String topic);
+  }
+
+  public interface AudienceEditor {
+
+    @UserMessage(
+        """
+            You are a professional editor.
+            Analyze and rewrite the following story to better align with the target audience of {{audience}}.
+            Return only the story and nothing else.
+            The story is "{{story}}".
+            """)
+    @Agent("Edit a story to better fit a given audience")
+    String editStory(@V("story") String story, @V("audience") String audience);
+  }
+
+  public interface StyleEditor {
+
+    @UserMessage(
+        """
+                You are a professional editor.
+                Analyze and rewrite the following story to better fit and be more coherent with the {{style}} style.
+                Return only the story and nothing else.
+                The story is "{{story}}".
+                """)
+    @Agent("Edit a story to better fit a given style")
+    String editStory(@V("story") String story, @V("style") String style);
+  }
+
+  public interface StyleScorer {
+
+    @UserMessage(
+        """
+                You are a critical reviewer.
+                Give a review score between 0.0 and 1.0 for the following story based on how well it aligns with the style '{{style}}'.
+                Return only the score and nothing else.
+
+                The story is: "{{story}}"
+                """)
+    @Agent("Score a story based on how well it aligns with a given style")
+    double scoreStyle(@V("story") String story, @V("style") String style);
+  }
+
+  public interface StyleReviewLoop {
+
+    @Agent("Review the given story to ensure it aligns with the specified style")
+    String scoreAndReview(@V("story") String story, @V("style") String style);
+  }
+
+  public interface StyledWriter extends CognisphereAccess {
+
+    @Agent
+    ResultWithCognisphere<String> writeStoryWithStyle(
+        @V("topic") String topic, @V("style") String style);
+  }
+
+  public interface FoodExpert {
+
+    @UserMessage(
+        """
+            You are a great evening planner.
+            Propose a list of 3 meals matching the given mood.
+            The mood is {{mood}}.
+            For each meal, just give the name of the meal.
+            Provide a list with the 3 items and nothing else.
+            """)
+    @Agent
+    List<String> findMeal(@V("mood") String mood);
+  }
+
+  public interface MovieExpert {
+
+    @UserMessage(
+        """
+            You are a great evening planner.
+            Propose a list of 3 movies matching the given mood.
+            The mood is {mood}.
+            Provide a list with the 3 items and nothing else.
+            """)
+    @Agent
+    List<String> findMovie(@V("mood") String mood);
+  }
+
+  public record EveningPlan(String movie, String meal) {}
+
+  public interface EveningPlannerAgent {
+
+    @Agent
+    List<EveningPlan> plan(@V("mood") String mood);
+  }
+}

--- a/fluent/agentic-langchain4j/src/test/java/io/serverlessworkflow/fluent/agentic/langchain4j/Agents.java
+++ b/fluent/agentic-langchain4j/src/test/java/io/serverlessworkflow/fluent/agentic/langchain4j/Agents.java
@@ -17,8 +17,8 @@ package io.serverlessworkflow.fluent.agentic.langchain4j;
 
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agentic.Agent;
-import dev.langchain4j.agentic.cognisphere.CognisphereAccess;
-import dev.langchain4j.agentic.cognisphere.ResultWithCognisphere;
+import dev.langchain4j.agentic.scope.AgenticScopeAccess;
+import dev.langchain4j.agentic.scope.ResultWithAgenticScope;
 import dev.langchain4j.service.MemoryId;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
@@ -32,7 +32,7 @@ public class Agents {
     String ask(@V("request") String request);
   }
 
-  public interface ExpertRouterAgentWithMemory extends CognisphereAccess {
+  public interface ExpertRouterAgentWithMemory extends AgenticScopeAccess {
 
     @Agent
     String ask(@MemoryId String memoryId, @V("request") String request);
@@ -209,10 +209,10 @@ public class Agents {
     String scoreAndReview(@V("story") String story, @V("style") String style);
   }
 
-  public interface StyledWriter extends CognisphereAccess {
+  public interface StyledWriter extends AgenticScopeAccess {
 
     @Agent
-    ResultWithCognisphere<String> writeStoryWithStyle(
+    ResultWithAgenticScope<String> writeStoryWithStyle(
         @V("topic") String topic, @V("style") String style);
   }
 

--- a/fluent/agentic-langchain4j/src/test/java/io/serverlessworkflow/fluent/agentic/langchain4j/Models.java
+++ b/fluent/agentic-langchain4j/src/test/java/io/serverlessworkflow/fluent/agentic/langchain4j/Models.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.fluent.agentic.langchain4j;
+
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.ollama.OllamaChatModel;
+import java.time.Duration;
+
+public class Models {
+
+  private static final String OLLAMA_DEFAULT_URL = "http://127.0.0.1:11434";
+  public static final String OLLAMA_ENV_URL = System.getenv("OLLAMA_BASE_URL");
+
+  private static final String OLLAMA_BASE_URL =
+      OLLAMA_ENV_URL != null ? OLLAMA_ENV_URL : OLLAMA_DEFAULT_URL;
+
+  public static final ChatModel BASE_MODEL =
+      OllamaChatModel.builder()
+          .baseUrl(OLLAMA_BASE_URL)
+          .modelName("qwen2.5:7b")
+          .timeout(Duration.ofMinutes(10))
+          .temperature(0.0)
+          .logRequests(true)
+          .logResponses(true)
+          .build();
+
+  public static final ChatModel PLANNER_MODEL =
+      OllamaChatModel.builder()
+          .baseUrl(OLLAMA_BASE_URL)
+          .modelName("qwen3:8b")
+          .timeout(Duration.ofMinutes(10))
+          .temperature(0.0)
+          .logRequests(true)
+          .logResponses(true)
+          .build();
+}

--- a/fluent/agentic-langchain4j/src/test/java/io/serverlessworkflow/fluent/agentic/langchain4j/SequentialAgentServiceImplTest.java
+++ b/fluent/agentic-langchain4j/src/test/java/io/serverlessworkflow/fluent/agentic/langchain4j/SequentialAgentServiceImplTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.fluent.agentic.langchain4j;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.langchain4j.agentic.cognisphere.Cognisphere;
+import io.serverlessworkflow.api.types.Workflow;
+import io.serverlessworkflow.api.types.func.CallJava;
+import io.serverlessworkflow.api.types.func.OutputAsFunction;
+import io.serverlessworkflow.fluent.agentic.AgentsUtils;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+
+class SequentialAgentServiceImplTest {
+  @Test
+  void shouldBuildEmptyWorkflow_byDefault() {
+    // given
+    SequentialAgentServiceImpl<DummyAgent> service =
+        SequentialAgentServiceImpl.builder(DummyAgent.class);
+
+    // when
+    Workflow wf = service.getDefinition();
+
+    // then
+    assertNotNull(wf, "Workflow definition should not be null");
+    assertTrue(wf.getDo().isEmpty(), "There should be no tasks by default");
+  }
+
+  @Test
+  void shouldApplyBeforeCallConsumer_toInput() {
+    // given
+    SequentialAgentServiceImpl<DummyAgent> service =
+        (SequentialAgentServiceImpl<DummyAgent>)
+            SequentialAgentServiceImpl.builder(DummyAgent.class)
+                .beforeCall(ctx -> ctx.writeState("foo", "bar"));
+
+    // when
+    Workflow wf = service.getDefinition();
+
+    // then
+    assertNotNull(wf.getInput(), "Input should not be null");
+  }
+
+  @Test
+  void shouldSetOutputName_inDocumentMetadata() {
+    // given
+    String outputName = "myOutputName";
+    SequentialAgentServiceImpl<DummyAgent> service =
+        (SequentialAgentServiceImpl<DummyAgent>)
+            SequentialAgentServiceImpl.builder(DummyAgent.class).outputName(outputName);
+
+    // when
+    Workflow wf = service.getDefinition();
+
+    // then
+    assertNotNull(wf.getDocument().getName(), "Workflow name should not be null");
+    assertNotNull(wf.getOutput().getAs(), "Workflow outputAs should not be null");
+    assertInstanceOf(OutputAsFunction.class, wf.getOutput().getAs());
+  }
+
+  @Test
+  void shouldSetOutputFunction_extension() {
+    // given
+    Function<Cognisphere, Object> fn = ctx -> 42;
+    SequentialAgentServiceImpl<DummyAgent> service =
+        (SequentialAgentServiceImpl<DummyAgent>)
+            SequentialAgentServiceImpl.builder(DummyAgent.class).output(fn);
+
+    // when
+    Workflow wf = service.getDefinition();
+
+    // then
+    assertNotNull(wf.getOutput(), "Output should not be null");
+  }
+
+  @Test
+  void shouldBuildSequenceTasks_withSubAgents() {
+    // given
+    Object agentA = AgentsUtils.newMovieExpert();
+    Object agentB = AgentsUtils.newMovieExpert();
+    SequentialAgentServiceImpl<DummyAgent> service =
+        (SequentialAgentServiceImpl<DummyAgent>)
+            SequentialAgentServiceImpl.builder(DummyAgent.class).subAgents(agentA, agentB);
+
+    // when
+    Workflow wf = service.getDefinition();
+
+    // then
+    assertEquals(2, wf.getDo().size(), "There should be exactly two tasks");
+
+    wf.getDo()
+        .forEach(
+            t -> {
+              assertNotNull(t, "Task should not be null");
+              Object task = t.getTask().getCallTask().get();
+              assertInstanceOf(
+                  CallJava.CallJavaFunction.class, task, "Task should be a CallTaskJava");
+            });
+  }
+
+  static class DummyAgent {}
+}

--- a/fluent/agentic-langchain4j/src/test/java/io/serverlessworkflow/fluent/agentic/langchain4j/SequentialAgentServiceImplTest.java
+++ b/fluent/agentic-langchain4j/src/test/java/io/serverlessworkflow/fluent/agentic/langchain4j/SequentialAgentServiceImplTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import dev.langchain4j.agentic.cognisphere.Cognisphere;
+import dev.langchain4j.agentic.scope.AgenticScope;
 import io.serverlessworkflow.api.types.Workflow;
 import io.serverlessworkflow.api.types.func.CallJava;
 import io.serverlessworkflow.api.types.func.OutputAsFunction;
@@ -78,7 +78,7 @@ class SequentialAgentServiceImplTest {
   @Test
   void shouldSetOutputFunction_extension() {
     // given
-    Function<Cognisphere, Object> fn = ctx -> 42;
+    Function<AgenticScope, Object> fn = ctx -> 42;
     SequentialAgentServiceImpl<DummyAgent> service =
         (SequentialAgentServiceImpl<DummyAgent>)
             SequentialAgentServiceImpl.builder(DummyAgent.class).output(fn);

--- a/fluent/agentic-langchain4j/src/test/java/io/serverlessworkflow/fluent/agentic/langchain4j/WorkflowAgentsIT.java
+++ b/fluent/agentic-langchain4j/src/test/java/io/serverlessworkflow/fluent/agentic/langchain4j/WorkflowAgentsIT.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.fluent.agentic.langchain4j;
+
+import static io.serverlessworkflow.fluent.agentic.langchain4j.Agents.AudienceEditor;
+import static io.serverlessworkflow.fluent.agentic.langchain4j.Agents.CreativeWriter;
+import static io.serverlessworkflow.fluent.agentic.langchain4j.Agents.StyleEditor;
+import static io.serverlessworkflow.fluent.agentic.langchain4j.Models.BASE_MODEL;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import dev.langchain4j.agentic.AgenticServices;
+import dev.langchain4j.agentic.UntypedAgent;
+import dev.langchain4j.agentic.workflow.WorkflowAgentsBuilder;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class WorkflowAgentsIT {
+
+  @Test
+  void sequential_agents_tests() {
+    WorkflowAgentsBuilder builder = new LC4JWorkflowBuilder();
+
+    CreativeWriter creativeWriter =
+        spy(
+            AgenticServices.agentBuilder(CreativeWriter.class)
+                .chatModel(BASE_MODEL)
+                .outputName("story")
+                .build());
+
+    AudienceEditor audienceEditor =
+        spy(
+            AgenticServices.agentBuilder(AudienceEditor.class)
+                .chatModel(BASE_MODEL)
+                .outputName("story")
+                .build());
+
+    StyleEditor styleEditor =
+        spy(
+            AgenticServices.agentBuilder(StyleEditor.class)
+                .chatModel(BASE_MODEL)
+                .outputName("story")
+                .build());
+
+    UntypedAgent novelCreator =
+        builder
+            .sequenceBuilder()
+            .subAgents(creativeWriter, audienceEditor, styleEditor)
+            .outputName("story")
+            .build();
+
+    Map<String, Object> input =
+        Map.of(
+            "topic", "dragons and wizards",
+            "style", "fantasy",
+            "audience", "young adults");
+
+    String story = (String) novelCreator.invoke(input);
+    System.out.println(story);
+
+    verify(creativeWriter).generateStory("dragons and wizards");
+    verify(audienceEditor).editStory(any(), eq("young adults"));
+    verify(styleEditor).editStory(any(), eq("fantasy"));
+  }
+}

--- a/fluent/agentic/src/main/java/io/serverlessworkflow/fluent/agentic/AgentAdapters.java
+++ b/fluent/agentic/src/main/java/io/serverlessworkflow/fluent/agentic/AgentAdapters.java
@@ -18,8 +18,9 @@ package io.serverlessworkflow.fluent.agentic;
 import static dev.langchain4j.agentic.internal.AgentUtil.agentsToExecutors;
 
 import dev.langchain4j.agentic.cognisphere.Cognisphere;
+import dev.langchain4j.agentic.cognisphere.DefaultCognisphere;
 import dev.langchain4j.agentic.internal.AgentExecutor;
-import dev.langchain4j.agentic.internal.AgentInstance;
+import dev.langchain4j.agentic.internal.AgentSpecification;
 import io.serverlessworkflow.impl.expressions.LoopPredicateIndex;
 import java.util.List;
 import java.util.function.Function;
@@ -31,11 +32,11 @@ public final class AgentAdapters {
   private AgentAdapters() {}
 
   public static List<AgentExecutor> toExecutors(Object... agents) {
-    return agentsToExecutors(Stream.of(agents).map(AgentInstance.class::cast).toArray());
+    return agentsToExecutors(Stream.of(agents).map(AgentSpecification.class::cast).toArray());
   }
 
-  public static Function<Cognisphere, Object> toFunction(AgentExecutor exec) {
-    return exec::invoke;
+  public static Function<DefaultCognisphere, Object> toFunction(AgentExecutor exec) {
+    return exec::execute;
   }
 
   public static LoopPredicateIndex<Cognisphere, Object> toWhile(Predicate<Cognisphere> exit) {

--- a/fluent/agentic/src/main/java/io/serverlessworkflow/fluent/agentic/AgentAdapters.java
+++ b/fluent/agentic/src/main/java/io/serverlessworkflow/fluent/agentic/AgentAdapters.java
@@ -17,10 +17,10 @@ package io.serverlessworkflow.fluent.agentic;
 
 import static dev.langchain4j.agentic.internal.AgentUtil.agentsToExecutors;
 
-import dev.langchain4j.agentic.cognisphere.Cognisphere;
-import dev.langchain4j.agentic.cognisphere.DefaultCognisphere;
 import dev.langchain4j.agentic.internal.AgentExecutor;
 import dev.langchain4j.agentic.internal.AgentSpecification;
+import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.agentic.scope.DefaultAgenticScope;
 import io.serverlessworkflow.impl.expressions.LoopPredicateIndex;
 import java.util.List;
 import java.util.function.Function;
@@ -35,11 +35,11 @@ public final class AgentAdapters {
     return agentsToExecutors(Stream.of(agents).map(AgentSpecification.class::cast).toArray());
   }
 
-  public static Function<DefaultCognisphere, Object> toFunction(AgentExecutor exec) {
+  public static Function<DefaultAgenticScope, Object> toFunction(AgentExecutor exec) {
     return exec::execute;
   }
 
-  public static LoopPredicateIndex<Cognisphere, Object> toWhile(Predicate<Cognisphere> exit) {
+  public static LoopPredicateIndex<AgenticScope, Object> toWhile(Predicate<AgenticScope> exit) {
     return (model, item, idx) -> !exit.test(model);
   }
 }

--- a/fluent/agentic/src/main/java/io/serverlessworkflow/fluent/agentic/AgentDoTaskBuilder.java
+++ b/fluent/agentic/src/main/java/io/serverlessworkflow/fluent/agentic/AgentDoTaskBuilder.java
@@ -58,6 +58,12 @@ public class AgentDoTaskBuilder
   }
 
   @Override
+  public AgentDoTaskBuilder loop(String name, LoopAgentsBuilder builder) {
+    this.listBuilder().loop(name, builder);
+    return self();
+  }
+
+  @Override
   public AgentDoTaskBuilder parallel(String name, Object... agents) {
     this.listBuilder().parallel(name, agents);
     return self();

--- a/fluent/agentic/src/main/java/io/serverlessworkflow/fluent/agentic/AgentTaskItemListBuilder.java
+++ b/fluent/agentic/src/main/java/io/serverlessworkflow/fluent/agentic/AgentTaskItemListBuilder.java
@@ -15,8 +15,8 @@
  */
 package io.serverlessworkflow.fluent.agentic;
 
-import dev.langchain4j.agentic.cognisphere.DefaultCognisphere;
 import dev.langchain4j.agentic.internal.AgentExecutor;
+import dev.langchain4j.agentic.scope.DefaultAgenticScope;
 import io.serverlessworkflow.api.types.Task;
 import io.serverlessworkflow.api.types.TaskItem;
 import io.serverlessworkflow.fluent.agentic.spi.AgentDoFluent;
@@ -58,7 +58,7 @@ public class AgentTaskItemListBuilder extends BaseTaskItemListBuilder<AgentTaskI
             exec ->
                 this.delegate.callFn(
                     name,
-                    fn -> fn.function(AgentAdapters.toFunction(exec), DefaultCognisphere.class)));
+                    fn -> fn.function(AgentAdapters.toFunction(exec), DefaultAgenticScope.class)));
     return self();
   }
 
@@ -93,7 +93,9 @@ public class AgentTaskItemListBuilder extends BaseTaskItemListBuilder<AgentTaskI
           for (int i = 0; i < execs.size(); i++) {
             AgentExecutor ex = execs.get(i);
             fork.branch(
-                "branch-" + i + "-" + name, AgentAdapters.toFunction(ex), DefaultCognisphere.class);
+                "branch-" + i + "-" + name,
+                AgentAdapters.toFunction(ex),
+                DefaultAgenticScope.class);
           }
         });
     return self();

--- a/fluent/agentic/src/main/java/io/serverlessworkflow/fluent/agentic/AgentTaskItemListBuilder.java
+++ b/fluent/agentic/src/main/java/io/serverlessworkflow/fluent/agentic/AgentTaskItemListBuilder.java
@@ -15,7 +15,7 @@
  */
 package io.serverlessworkflow.fluent.agentic;
 
-import dev.langchain4j.agentic.cognisphere.Cognisphere;
+import dev.langchain4j.agentic.cognisphere.DefaultCognisphere;
 import dev.langchain4j.agentic.internal.AgentExecutor;
 import io.serverlessworkflow.api.types.Task;
 import io.serverlessworkflow.api.types.TaskItem;
@@ -57,7 +57,8 @@ public class AgentTaskItemListBuilder extends BaseTaskItemListBuilder<AgentTaskI
         .forEach(
             exec ->
                 this.delegate.callFn(
-                    name, fn -> fn.function(AgentAdapters.toFunction(exec), Cognisphere.class)));
+                    name,
+                    fn -> fn.function(AgentAdapters.toFunction(exec), DefaultCognisphere.class)));
     return self();
   }
 
@@ -73,6 +74,12 @@ public class AgentTaskItemListBuilder extends BaseTaskItemListBuilder<AgentTaskI
   public AgentTaskItemListBuilder loop(String name, Consumer<LoopAgentsBuilder> consumer) {
     final LoopAgentsBuilder builder = new LoopAgentsBuilder();
     consumer.accept(builder);
+    this.loop(name, builder);
+    return self();
+  }
+
+  @Override
+  public AgentTaskItemListBuilder loop(String name, LoopAgentsBuilder builder) {
     this.addTaskItem(new TaskItem(name, new Task().withForTask(builder.build())));
     return self();
   }
@@ -86,7 +93,7 @@ public class AgentTaskItemListBuilder extends BaseTaskItemListBuilder<AgentTaskI
           for (int i = 0; i < execs.size(); i++) {
             AgentExecutor ex = execs.get(i);
             fork.branch(
-                "branch-" + i + "-" + name, AgentAdapters.toFunction(ex), Cognisphere.class);
+                "branch-" + i + "-" + name, AgentAdapters.toFunction(ex), DefaultCognisphere.class);
           }
         });
     return self();

--- a/fluent/agentic/src/main/java/io/serverlessworkflow/fluent/agentic/AgentWorkflowBuilder.java
+++ b/fluent/agentic/src/main/java/io/serverlessworkflow/fluent/agentic/AgentWorkflowBuilder.java
@@ -15,12 +15,13 @@
  */
 package io.serverlessworkflow.fluent.agentic;
 
+import io.serverlessworkflow.fluent.func.spi.FuncTransformations;
 import io.serverlessworkflow.fluent.spec.BaseWorkflowBuilder;
 import java.util.UUID;
 
 public class AgentWorkflowBuilder
-    extends BaseWorkflowBuilder<
-        AgentWorkflowBuilder, AgentDoTaskBuilder, AgentTaskItemListBuilder> {
+    extends BaseWorkflowBuilder<AgentWorkflowBuilder, AgentDoTaskBuilder, AgentTaskItemListBuilder>
+    implements FuncTransformations<AgentWorkflowBuilder> {
 
   AgentWorkflowBuilder(final String name, final String namespace, final String version) {
     super(name, namespace, version);

--- a/fluent/agentic/src/main/java/io/serverlessworkflow/fluent/agentic/LoopAgentsBuilder.java
+++ b/fluent/agentic/src/main/java/io/serverlessworkflow/fluent/agentic/LoopAgentsBuilder.java
@@ -31,7 +31,7 @@ public class LoopAgentsBuilder {
   private final FuncTaskItemListBuilder funcDelegate;
   private final ForTaskFunction forTask;
 
-  LoopAgentsBuilder() {
+  public LoopAgentsBuilder() {
     this.forTask = new ForTaskFunction();
     this.forTask.setFor(new ForTaskConfiguration());
     this.funcDelegate = new FuncTaskItemListBuilder();

--- a/fluent/agentic/src/main/java/io/serverlessworkflow/fluent/agentic/LoopAgentsBuilder.java
+++ b/fluent/agentic/src/main/java/io/serverlessworkflow/fluent/agentic/LoopAgentsBuilder.java
@@ -15,8 +15,8 @@
  */
 package io.serverlessworkflow.fluent.agentic;
 
-import dev.langchain4j.agentic.cognisphere.Cognisphere;
 import dev.langchain4j.agentic.internal.AgentExecutor;
+import dev.langchain4j.agentic.scope.AgenticScope;
 import io.serverlessworkflow.api.types.ForTaskConfiguration;
 import io.serverlessworkflow.api.types.func.ForTaskFunction;
 import io.serverlessworkflow.fluent.func.FuncTaskItemListBuilder;
@@ -60,8 +60,8 @@ public class LoopAgentsBuilder {
     return this;
   }
 
-  public LoopAgentsBuilder exitCondition(Predicate<Cognisphere> exitCondition) {
-    this.forTask.withWhile(AgentAdapters.toWhile(exitCondition), Cognisphere.class);
+  public LoopAgentsBuilder exitCondition(Predicate<AgenticScope> exitCondition) {
+    this.forTask.withWhile(AgentAdapters.toWhile(exitCondition), AgenticScope.class);
     return this;
   }
 

--- a/fluent/agentic/src/main/java/io/serverlessworkflow/fluent/agentic/spi/AgentDoFluent.java
+++ b/fluent/agentic/src/main/java/io/serverlessworkflow/fluent/agentic/spi/AgentDoFluent.java
@@ -40,6 +40,12 @@ public interface AgentDoFluent<SELF extends AgentDoFluent<SELF>> extends FuncDoF
     return loop("loop-" + UUID.randomUUID(), builder);
   }
 
+  SELF loop(String name, LoopAgentsBuilder builder);
+
+  default SELF loop(LoopAgentsBuilder builder) {
+    return loop("loop-" + UUID.randomUUID(), builder);
+  }
+
   SELF parallel(String name, Object... agents);
 
   default SELF parallel(Object... agents) {

--- a/fluent/agentic/src/test/java/io/serverlessworkflow/fluent/agentic/AgentWorkflowBuilderTest.java
+++ b/fluent/agentic/src/test/java/io/serverlessworkflow/fluent/agentic/AgentWorkflowBuilderTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.spy;
 
-import dev.langchain4j.agentic.AgentServices;
+import dev.langchain4j.agentic.AgenticServices;
 import dev.langchain4j.agentic.cognisphere.Cognisphere;
 import io.serverlessworkflow.api.types.ForkTask;
 import io.serverlessworkflow.api.types.Task;
@@ -43,7 +43,7 @@ class AgentWorkflowBuilderTest {
   public void verifyAgentCall() {
     Agents.MovieExpert movieExpert =
         spy(
-            AgentServices.agentBuilder(Agents.MovieExpert.class)
+            AgenticServices.agentBuilder(Agents.MovieExpert.class)
                 .outputName("movies")
                 .chatModel(BASE_MODEL)
                 .build());

--- a/fluent/agentic/src/test/java/io/serverlessworkflow/fluent/agentic/AgentWorkflowBuilderTest.java
+++ b/fluent/agentic/src/test/java/io/serverlessworkflow/fluent/agentic/AgentWorkflowBuilderTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.spy;
 
 import dev.langchain4j.agentic.AgenticServices;
-import dev.langchain4j.agentic.cognisphere.Cognisphere;
+import dev.langchain4j.agentic.scope.AgenticScope;
 import io.serverlessworkflow.api.types.ForkTask;
 import io.serverlessworkflow.api.types.Task;
 import io.serverlessworkflow.api.types.TaskItem;
@@ -117,7 +117,7 @@ class AgentWorkflowBuilderTest {
     Agents.MovieExpert expert = newMovieExpert();
 
     AtomicInteger max = new AtomicInteger(4);
-    Predicate<Cognisphere> exit =
+    Predicate<AgenticScope> exit =
         cog -> {
           // stop when we already have at least one movie picked in state
           var movies = cog.readState("movies", null);
@@ -189,7 +189,7 @@ class AgentWorkflowBuilderTest {
   @Test
   @DisplayName("workflow callFn with Java DSL guard attaches predicate")
   void testWorkflowCallFnWithPredicate() {
-    Predicate<Cognisphere> guard = cog -> true;
+    Predicate<AgenticScope> guard = cog -> true;
 
     Workflow wf =
         AgentWorkflowBuilder.workflow()

--- a/fluent/agentic/src/test/java/io/serverlessworkflow/fluent/agentic/Agents.java
+++ b/fluent/agentic/src/test/java/io/serverlessworkflow/fluent/agentic/Agents.java
@@ -16,7 +16,7 @@
 package io.serverlessworkflow.fluent.agentic;
 
 import dev.langchain4j.agentic.Agent;
-import dev.langchain4j.agentic.internal.AgentInstance;
+import dev.langchain4j.agentic.internal.AgentSpecification;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
 import java.util.List;
@@ -36,7 +36,7 @@ public interface Agents {
     List<String> findMovie(@V("mood") String mood);
   }
 
-  interface SettingAgent extends AgentInstance {
+  interface SettingAgent extends AgentSpecification {
 
     @UserMessage(
         """
@@ -49,7 +49,7 @@ public interface Agents {
     String invoke(@V("style") String style);
   }
 
-  interface HeroAgent extends AgentInstance {
+  interface HeroAgent extends AgentSpecification {
 
     @UserMessage(
         """
@@ -60,7 +60,7 @@ public interface Agents {
     String invoke(@V("style") String style);
   }
 
-  interface ConflictAgent extends AgentInstance {
+  interface ConflictAgent extends AgentSpecification {
 
     @UserMessage(
         """
@@ -72,7 +72,7 @@ public interface Agents {
     String invoke(@V("style") String style);
   }
 
-  interface FactAgent extends AgentInstance {
+  interface FactAgent extends AgentSpecification {
 
     @UserMessage(
         """
@@ -82,7 +82,7 @@ public interface Agents {
     String invoke(@V("fact") String fact);
   }
 
-  interface CultureAgent extends AgentInstance {
+  interface CultureAgent extends AgentSpecification {
 
     @UserMessage(
         """
@@ -94,7 +94,7 @@ public interface Agents {
     List<String> invoke(@V("fact") String fact);
   }
 
-  interface TechnologyAgent extends AgentInstance {
+  interface TechnologyAgent extends AgentSpecification {
 
     @UserMessage(
         """
@@ -106,7 +106,7 @@ public interface Agents {
     List<String> invoke(@V("fact") String fact);
   }
 
-  interface StorySeedAgent extends AgentInstance {
+  interface StorySeedAgent extends AgentSpecification {
 
     @UserMessage(
         """
@@ -117,7 +117,7 @@ public interface Agents {
     String invoke(@V("title") String title);
   }
 
-  interface PlotAgent extends AgentInstance {
+  interface PlotAgent extends AgentSpecification {
 
     @UserMessage(
         """
@@ -129,7 +129,7 @@ public interface Agents {
     String invoke(@V("premise") String premise);
   }
 
-  interface SceneAgent extends AgentInstance {
+  interface SceneAgent extends AgentSpecification {
 
     @UserMessage(
         """
@@ -141,7 +141,7 @@ public interface Agents {
     String invoke(@V("plot") String plot);
   }
 
-  interface MeetingInvitationDraft extends AgentInstance {
+  interface MeetingInvitationDraft extends AgentSpecification {
 
     @UserMessage(
         """
@@ -161,7 +161,7 @@ public interface Agents {
         @V("agenda") String agenda);
   }
 
-  interface MeetingInvitationStyle extends AgentInstance {
+  interface MeetingInvitationStyle extends AgentSpecification {
 
     @UserMessage(
         """

--- a/fluent/agentic/src/test/java/io/serverlessworkflow/fluent/agentic/WorkflowTests.java
+++ b/fluent/agentic/src/test/java/io/serverlessworkflow/fluent/agentic/WorkflowTests.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import dev.langchain4j.agentic.AgenticServices;
-import dev.langchain4j.agentic.cognisphere.DefaultCognisphere;
+import dev.langchain4j.agentic.scope.DefaultAgenticScope;
 import dev.langchain4j.agentic.workflow.HumanInTheLoop;
 import io.serverlessworkflow.api.types.Workflow;
 import io.serverlessworkflow.impl.WorkflowApplication;
@@ -53,12 +53,12 @@ class WorkflowTests {
     topic.put("title", "A Great Story");
 
     try (WorkflowApplication app = WorkflowApplication.builder().build()) {
-      DefaultCognisphere result =
+      DefaultAgenticScope result =
           app.workflowDefinition(workflow)
               .instance(topic)
               .start()
               .get()
-              .as(DefaultCognisphere.class)
+              .as(DefaultAgenticScope.class)
               .orElseThrow();
 
       assertEquals("storySeedAgent", result.readState("premise"));
@@ -93,12 +93,12 @@ class WorkflowTests {
     topic.put("title", "A Great Story");
 
     try (WorkflowApplication app = WorkflowApplication.builder().build()) {
-      DefaultCognisphere result =
+      DefaultAgenticScope result =
           app.workflowDefinition(workflow)
               .instance(topic)
               .start()
               .get()
-              .as(DefaultCognisphere.class)
+              .as(DefaultAgenticScope.class)
               .orElseThrow();
 
       assertEquals("sceneAgent", result.readState("story"));
@@ -129,12 +129,12 @@ class WorkflowTests {
     topic.put("title", "A Great Story");
 
     try (WorkflowApplication app = WorkflowApplication.builder().build()) {
-      DefaultCognisphere result =
+      DefaultAgenticScope result =
           app.workflowDefinition(workflow)
               .instance(topic)
               .start()
               .get()
-              .as(DefaultCognisphere.class)
+              .as(DefaultAgenticScope.class)
               .orElseThrow();
 
       assertEquals("sceneAgent", result.readState("story"));
@@ -166,12 +166,12 @@ class WorkflowTests {
     topic.put("style", "sci-fi");
 
     try (WorkflowApplication app = WorkflowApplication.builder().build()) {
-      DefaultCognisphere result =
+      DefaultAgenticScope result =
           app.workflowDefinition(workflow)
               .instance(topic)
               .start()
               .get()
-              .as(DefaultCognisphere.class)
+              .as(DefaultAgenticScope.class)
               .orElseThrow();
 
       assertEquals("Fake conflict response", result.readState("setting"));
@@ -212,12 +212,12 @@ class WorkflowTests {
     topic.put("fact", "alien");
 
     try (WorkflowApplication app = WorkflowApplication.builder().build()) {
-      DefaultCognisphere result =
+      DefaultAgenticScope result =
           app.workflowDefinition(workflow)
               .instance(topic)
               .start()
               .get()
-              .as(DefaultCognisphere.class)
+              .as(DefaultAgenticScope.class)
               .orElseThrow();
 
       assertEquals(cultureTraits, result.readState("culture"));
@@ -274,12 +274,12 @@ class WorkflowTests {
     initialValues.put("agenda", "Discuss project updates");
 
     try (WorkflowApplication app = WorkflowApplication.builder().build()) {
-      DefaultCognisphere result =
+      DefaultAgenticScope result =
           app.workflowDefinition(workflow)
               .instance(initialValues)
               .start()
               .get()
-              .as(DefaultCognisphere.class)
+              .as(DefaultAgenticScope.class)
               .orElseThrow();
 
       assertEquals("Styled meeting invitation for John Doe", result.readState("styled"));

--- a/fluent/pom.xml
+++ b/fluent/pom.xml
@@ -16,11 +16,6 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-        <!-- Experimental modules from langchain4j -->
-        <version.dev.langchain4j.beta>1.3.0-beta9</version.dev.langchain4j.beta>
-        <!-- Base langchain4j version -->
-        <version.dev.langchain4j>1.3.0</version.dev.langchain4j>
     </properties>
 
     <dependencyManagement>
@@ -71,11 +66,6 @@
                 <version>${project.version}</version>
                 <type>test-jar</type>
                 <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>dev.langchain4j</groupId>
-                <artifactId>langchain4j-agentic</artifactId>
-                <version>${version.dev.langchain4j.beta}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/fluent/pom.xml
+++ b/fluent/pom.xml
@@ -17,9 +17,10 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <!-- For some reason the dev branch has two different versions -->
-        <version.dev.langchain4j.agentic>1.3.0-beta9-SNAPSHOT</version.dev.langchain4j.agentic>
-        <version.dev.langchain4j>1.3.0-SNAPSHOT</version.dev.langchain4j>
+        <!-- Experimental modules from langchain4j -->
+        <version.dev.langchain4j.beta>1.3.0-beta9</version.dev.langchain4j.beta>
+        <!-- Base langchain4j version -->
+        <version.dev.langchain4j>1.3.0</version.dev.langchain4j>
     </properties>
 
     <dependencyManagement>
@@ -74,7 +75,7 @@
             <dependency>
                 <groupId>dev.langchain4j</groupId>
                 <artifactId>langchain4j-agentic</artifactId>
-                <version>${version.dev.langchain4j.agentic}</version>
+                <version>${version.dev.langchain4j.beta}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/fluent/pom.xml
+++ b/fluent/pom.xml
@@ -16,6 +16,10 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- For some reason the dev branch has two different versions -->
+        <version.dev.langchain4j.agentic>1.3.0-beta9-SNAPSHOT</version.dev.langchain4j.agentic>
+        <version.dev.langchain4j>1.3.0-SNAPSHOT</version.dev.langchain4j>
     </properties>
 
     <dependencyManagement>
@@ -40,6 +44,38 @@
                 <artifactId>serverlessworkflow-fluent-func</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.serverlessworkflow</groupId>
+                <artifactId>serverlessworkflow-fluent-agentic</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.serverlessworkflow</groupId>
+                <artifactId>serverlessworkflow-fluent-agentic-langchain4j</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.serverlessworkflow</groupId>
+                <artifactId>serverlessworkflow-experimental-agentic</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.serverlessworkflow</groupId>
+                <artifactId>serverlessworkflow-experimental-lambda</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.serverlessworkflow</groupId>
+                <artifactId>serverlessworkflow-fluent-agentic</artifactId>
+                <version>${project.version}</version>
+                <type>test-jar</type>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-agentic</artifactId>
+                <version>${version.dev.langchain4j.agentic}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -47,6 +83,7 @@
         <module>spec</module>
         <module>func</module>
         <module>agentic</module>
+        <module>agentic-langchain4j</module>
     </modules>
 
 </project>

--- a/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/BaseWorkflowBuilder.java
+++ b/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/BaseWorkflowBuilder.java
@@ -21,6 +21,7 @@ import io.serverlessworkflow.api.types.Input;
 import io.serverlessworkflow.api.types.Output;
 import io.serverlessworkflow.api.types.Workflow;
 import io.serverlessworkflow.fluent.spec.spi.TransformationHandlers;
+import java.util.UUID;
 import java.util.function.Consumer;
 
 public abstract class BaseWorkflowBuilder<
@@ -42,6 +43,9 @@ public abstract class BaseWorkflowBuilder<
     this.document.setNamespace(namespace);
     this.document.setVersion(version);
     this.document.setDsl(DSL);
+    if (this.document.getName() == null || this.document.getName().isEmpty()) {
+      this.document.setName(UUID.randomUUID().toString());
+    }
     this.workflow = new Workflow();
     this.workflow.setDocument(this.document);
   }

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,11 @@
         <version.org.slf4j>2.0.17</version.org.slf4j>
         <version.org.hibernate.validator>9.0.1.Final</version.org.hibernate.validator>
         <version.org.glassfish.expressly>6.0.0</version.org.glassfish.expressly>
-        <version.dev.langchain4j>1.3.0-beta9-SNAPSHOT</version.dev.langchain4j>
+        <!-- Experimental modules from langchain4j -->
+        <version.dev.langchain4j.beta>1.3.0-beta9</version.dev.langchain4j.beta>
+        <!-- Base langchain4j version -->
+        <version.dev.langchain4j>1.3.0</version.dev.langchain4j>
+
         <!-- Checkstyle props -->
         <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
         <checkstyle.header.template><![CDATA[
@@ -228,7 +232,7 @@
             <dependency>
               <groupId>dev.langchain4j</groupId>
               <artifactId>langchain4j-agentic</artifactId>
-              <version>${version.dev.langchain4j}</version>
+              <version>${version.dev.langchain4j.beta}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,8 @@
         </checkstyle.header.template>
         <checkstyle.header.extensions>java</checkstyle.header.extensions>
         <checkstyle.logViolationsToConsole>true</checkstyle.logViolationsToConsole>
+
+        <integration-tests.includes>**/*IT.java</integration-tests.includes>
     </properties>
 
     <dependencyManagement>
@@ -442,6 +444,9 @@
                     <version>${version.surefire.plugin}</version>
                     <configuration>
                         <argLine>-Xmx1024m -XX:+IgnoreUnrecognizedVMOptions -XX:MaxPermSize=256m</argLine>
+                        <excludes>
+                            <exclude>${integration-tests.includes}</exclude>
+                        </excludes>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -450,6 +455,9 @@
                     <version>${version.failsafe.plugin}</version>
                     <configuration>
                         <argLine>-Xmx1024m -XX:+IgnoreUnrecognizedVMOptions -XX:MaxPermSize=256m</argLine>
+                        <includes>
+                            <include>${integration-tests.includes}</include>
+                        </includes>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -558,6 +566,29 @@
                                 <phase>package</phase>
                                 <goals>
                                     <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>integration-tests</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>run-integration-tests</id>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
                                 </goals>
                             </execution>
                         </executions>


### PR DESCRIPTION
Depends on https://github.com/langchain4j/langchain4j/pull/3458

In this PR:

- Add a new `serverlessworkflow-fluent-agentic-langchain4j` module to implement `langchain4j-agentic` SPI. So that we can use our workflow engine to run Agentic use cases via LC4J Workflow SPI.
- Adjust `serverlessworkflow-experimental-agentic` to handle `AgenticScope` in the workflow context
- Add a new CI to run solely Integration Tests since now we depend on Ollama to run Agentic use cases on this new module.

Later, I'll add more integration tests, adjust the CI to install Ollama, and the docs.
