### PR TITLE
Allowing passing WorkflowModel as function input parameter

### DIFF
--- a/experimental/lambda/src/main/java/io/serverlessworkflow/impl/expressions/func/JavaModel.java
+++ b/experimental/lambda/src/main/java/io/serverlessworkflow/impl/expressions/func/JavaModel.java
@@ -94,6 +94,9 @@ public class JavaModel implements WorkflowModel {
 
   @Override
   public <T> Optional<T> as(Class<T> clazz) {
+    if (WorkflowModel.class.isAssignableFrom(clazz)) {
+      return Optional.of(clazz.cast(this));
+    }
     return object != null && clazz.isAssignableFrom(object.getClass())
         ? Optional.of(clazz.cast(object))
         : Optional.empty();


### PR DESCRIPTION
Users can declare functions to accept a WorkflowModel.
Please note they can already return one. 