### PR TITLE
Skiping Agentic modules

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Verify with Maven
         run: |
           mvn -B -f pom.xml clean install verify \
-            -pl ",!fluent/agentic" \
+            -pl ",!fluent/agentic" -pl ",!experimental/agentic" \
             -am
 
       - name: Verify Examples with Maven


### PR DESCRIPTION
Temporary skip to have a green CI again. We will revert as soon as we get a LC4j snaphsot available.