### PR TITLE
Use ulid library safe for graalvm native compilation

### DIFF
--- a/impl/core/pom.xml
+++ b/impl/core/pom.xml
@@ -21,8 +21,8 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.f4b6a3</groupId>
-            <artifactId>ulid-creator</artifactId>
+            <groupId>de.huxhorn.sulky</groupId>
+            <artifactId>de.huxhorn.sulky.ulid</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/UlidWorkflowInstanceIdFactory.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/UlidWorkflowInstanceIdFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.impl;
+
+import de.huxhorn.sulky.ulid.ULID;
+import java.security.SecureRandom;
+
+/**
+ * A {@link WorkflowInstanceIdFactory} implementation that generates ULIDs as workflow instance IDs.
+ */
+public class UlidWorkflowInstanceIdFactory implements WorkflowInstanceIdFactory {
+
+  private final SecureRandom random = new SecureRandom();
+  private final ULID ulid = new ULID(random);
+
+  @Override
+  public String get() {
+    return ulid.nextULID();
+  }
+}

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/WorkflowApplication.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/WorkflowApplication.java
@@ -15,7 +15,6 @@
  */
 package io.serverlessworkflow.impl;
 
-import com.github.f4b6a3.ulid.UlidCreator;
 import io.serverlessworkflow.api.types.SchemaInline;
 import io.serverlessworkflow.api.types.Workflow;
 import io.serverlessworkflow.impl.events.EventConsumer;
@@ -31,6 +30,7 @@ import io.serverlessworkflow.impl.resources.ResourceLoaderFactory;
 import io.serverlessworkflow.impl.resources.StaticResource;
 import io.serverlessworkflow.impl.schema.SchemaValidator;
 import io.serverlessworkflow.impl.schema.SchemaValidatorFactory;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -141,7 +141,8 @@ public class WorkflowApplication implements AutoCloseable {
     private ResourceLoaderFactory resourceLoaderFactory = DefaultResourceLoaderFactory.get();
     private SchemaValidatorFactory schemaValidatorFactory;
     private WorkflowPositionFactory positionFactory = () -> new QueueWorkflowPosition();
-    private WorkflowInstanceIdFactory idFactory = () -> UlidCreator.getMonotonicUlid().toString();
+    private final SecureRandom secureRandom = new SecureRandom();
+    private WorkflowInstanceIdFactory idFactory = new UlidWorkflowInstanceIdFactory();
     private ExecutorServiceFactory executorFactory = new DefaultExecutorServiceFactory();
     private EventConsumer<?, ?> eventConsumer;
     private Collection<EventPublisher> eventPublishers = new ArrayList<>();

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -9,10 +9,10 @@
     <name>Serverless Workflow :: Impl</name>
     <packaging>pom</packaging>
     <properties>
-        <version.org.glassfish.jersey>3.1.11</version.org.glassfish.jersey>
-        <version.net.thisptr>1.6.0</version.net.thisptr>
-        <version.com.github.f4b6a3>5.2.3</version.com.github.f4b6a3>
+        <version.de.huxhorn.sulky>8.3.0</version.de.huxhorn.sulky>
         <version.jakarta.ws.rs>4.0.0</version.jakarta.ws.rs>
+        <version.net.thisptr>1.6.0</version.net.thisptr>
+        <version.org.glassfish.jersey>3.1.11</version.org.glassfish.jersey>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -42,9 +42,9 @@
                 <version>${version.net.thisptr}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.f4b6a3</groupId>
-                <artifactId>ulid-creator</artifactId>
-                <version>${version.com.github.f4b6a3}</version>
+                <groupId>de.huxhorn.sulky</groupId>
+                <artifactId>de.huxhorn.sulky.ulid</artifactId>
+                <version>${version.de.huxhorn.sulky}</version>
             </dependency>
             <dependency>
               <groupId>jakarta.ws.rs</groupId>


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

* Remove the  `com.github.f4b6a3:ulid-creator` dependency.
* Add a new dependency `de.huxhorn.sulky:de.huxhorn.sulky.ulid` for ULID generation.
* Add a default `WorkflowInstanceIdFactory` implementation (`UlidWorkflowInstanceIdFactory`)

Closes #812 