### PR TITLE
use agent name as branch name

### DIFF
--- a/experimental/fluent/agentic/src/main/java/io/serverlessworkflow/fluent/agentic/AgentTaskItemListBuilder.java
+++ b/experimental/fluent/agentic/src/main/java/io/serverlessworkflow/fluent/agentic/AgentTaskItemListBuilder.java
@@ -92,10 +92,9 @@ public class AgentTaskItemListBuilder extends BaseTaskItemListBuilder<AgentTaskI
           List<AgentExecutor> execs = AgentAdapters.toExecutors(agents);
           for (int i = 0; i < execs.size(); i++) {
             AgentExecutor ex = execs.get(i);
-            fork.branch(
-                "branch-" + i + "-" + name,
-                AgentAdapters.toFunction(ex),
-                DefaultAgenticScope.class);
+            String agentName = ex.agentName() != null ? ex.agentName() : "branch-" + i + "-" + name;
+
+            fork.branch(agentName, AgentAdapters.toFunction(ex), DefaultAgenticScope.class);
           }
         });
     return self();

--- a/experimental/fluent/agentic/src/test/java/io/serverlessworkflow/fluent/agentic/AgentDslWorkflowTest.java
+++ b/experimental/fluent/agentic/src/test/java/io/serverlessworkflow/fluent/agentic/AgentDslWorkflowTest.java
@@ -101,7 +101,7 @@ class AgentDslWorkflowTest {
   @Test
   void dslParallelAgents() {
     var a1 = AgentsUtils.newMovieExpert();
-    var a2 = AgentsUtils.newMovieExpert();
+    var a2 = AgentsUtils.newMovieExpert2();
 
     Workflow wf = workflow("forkFlow").parallel("fanout", a1, a2).build();
 
@@ -112,8 +112,8 @@ class AgentDslWorkflowTest {
     // two branches created
     assertThat(fork.getFork().getBranches()).hasSize(2);
     // branch names follow "branch-{index}-{name}"
-    assertThat(fork.getFork().getBranches().get(0).getName()).isEqualTo("branch-0-fanout");
-    assertThat(fork.getFork().getBranches().get(1).getName()).isEqualTo("branch-1-fanout");
+    assertThat(fork.getFork().getBranches().get(0).getName()).isEqualTo("findMovie");
+    assertThat(fork.getFork().getBranches().get(1).getName()).isEqualTo("findMovie2");
   }
 
   @Test

--- a/experimental/fluent/agentic/src/test/java/io/serverlessworkflow/fluent/agentic/AgentsUtils.java
+++ b/experimental/fluent/agentic/src/test/java/io/serverlessworkflow/fluent/agentic/AgentsUtils.java
@@ -32,6 +32,15 @@ public final class AgentsUtils {
             .build());
   }
 
+  public static Agents.MovieExpert newMovieExpert2() {
+    return spy(
+        AgenticServices.agentBuilder(Agents.MovieExpert.class)
+            .outputName("movies")
+            .name("findMovie2")
+            .chatModel(BASE_MODEL)
+            .build());
+  }
+
   public static Agents.CreativeWriter newCreativeWriter() {
     return spy(
         AgenticServices.agentBuilder(Agents.CreativeWriter.class)


### PR DESCRIPTION
I propose changing the branch naming when executing agentic parallel tasks.
Since the agent’s name will be used (or the method name if the agent’s name is not specified), the naming of execution results in the context will be strictly deterministic, which will significantly simplify further work with the results.

Drawbacks: if multiple instances of the same agent with identical names are used in a parallel task, the results of the later executions will overwrite the results of the earlier ones.