### PR TITLE
We should be able to use an agentic loop without explicitly specifyin…

### DIFF
--- a/experimental/fluent/agentic/src/main/java/io/serverlessworkflow/fluent/agentic/LoopAgentsBuilder.java
+++ b/experimental/fluent/agentic/src/main/java/io/serverlessworkflow/fluent/agentic/LoopAgentsBuilder.java
@@ -31,6 +31,8 @@ public class LoopAgentsBuilder {
   private final FuncTaskItemListBuilder funcDelegate;
   private final ForTaskFunction forTask;
 
+  private int maxIterations = 1024;
+
   public LoopAgentsBuilder() {
     this.forTask = new ForTaskFunction();
     this.forTask.setFor(new ForTaskConfiguration());
@@ -56,7 +58,7 @@ public class LoopAgentsBuilder {
   }
 
   public LoopAgentsBuilder maxIterations(int maxIterations) {
-    this.forTask.withCollection(ignored -> IntStream.range(0, maxIterations).boxed().toList());
+    this.maxIterations = maxIterations;
     return this;
   }
 
@@ -67,6 +69,7 @@ public class LoopAgentsBuilder {
 
   public ForTaskFunction build() {
     this.forTask.setDo(this.funcDelegate.build());
+    this.forTask.withCollection(ignored -> IntStream.range(0, maxIterations).boxed().toList());
     return this.forTask;
   }
 }


### PR DESCRIPTION
…g maxIterations

During the construction ForTaskFunction at LoopAgentsBuilder we must explicitly pass .withCollection, in other case we get the exception:

Caused by: java.lang.NullPointerException: Cannot invoke "java.util.Optional.isPresent()" because the return value of "io.serverlessworkflow.api.types.func.ForTaskFunction.getForClass()" is null
	at io.serverlessworkflow.impl.executors.func.JavaForExecutorBuilder.collectionFilterObject(JavaForExecutorBuilder.java:70)
	at io.serverlessworkflow.impl.executors.func.JavaForExecutorBuilder.buildCollectionFilter(JavaForExecutorBuilder.java:65)
	at io.serverlessworkflow.impl.executors.ForExecutor$ForExecutorBuilder.<init>(ForExecutor.java:47)
	at io.serverlessworkflow.impl.executors.func.JavaForExecutorBuilder.<init>(JavaForExecutorBuilder.java:37)
	at io.serverlessworkflow.impl.executors.func.JavaTaskExecutorFactory.getTaskExecutor(JavaTaskExecutorFactory.java:30)
	at io.serverlessworkflow.impl.executors.TaskExecutorHelper.createExecutorBuilderList(TaskExecutorHelper.java:93)
	at io.serverlessworkflow.impl.executors.TaskExecutorHelper.createExecutorList(TaskExecutorHelper.java:65)
	at io.serverlessworkflow.impl.WorkflowDefinition.<init>(WorkflowDefinition.java:59)
	at io.serverlessworkflow.impl.WorkflowDefinition.of(WorkflowDefinition.java:69)
	at io.serverlessworkflow.impl.WorkflowDefinition.of(WorkflowDefinition.java:64)
	at io.serverlessworkflow.impl.WorkflowApplication.lambda$workflowDefinition$0(WorkflowApplication.java:259)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1708)
	at io.serverlessworkflow.impl.WorkflowApplication.workflowDefinition(WorkflowApplication.java:258)
	at io.serverlessworkflow.fluent.agentic.AgenticServices$AgentInvocationHandler.invoke(AgenticServices.java:119)

