### PR TITLE
[Fix #840] Allow setting ObjectMapper before JsonUtils is initialized

### DIFF
--- a/impl/jackson/src/main/java/io/serverlessworkflow/impl/jackson/JsonUtils.java
+++ b/impl/jackson/src/main/java/io/serverlessworkflow/impl/jackson/JsonUtils.java
@@ -54,7 +54,7 @@ import java.util.stream.Collector;
 
 public class JsonUtils {
 
-  private static ObjectMapper mapper = new ObjectMapper();
+  private static ObjectMapper mapper = ObjectMapperFactoryProvider.instance().get().get();
 
   public static ObjectMapper mapper() {
     return mapper;

--- a/impl/jackson/src/main/java/io/serverlessworkflow/impl/jackson/ObjectMapperFactory.java
+++ b/impl/jackson/src/main/java/io/serverlessworkflow/impl/jackson/ObjectMapperFactory.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.impl.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.function.Supplier;
+
+public interface ObjectMapperFactory extends Supplier<ObjectMapper> {}

--- a/impl/jackson/src/main/java/io/serverlessworkflow/impl/jackson/ObjectMapperFactoryProvider.java
+++ b/impl/jackson/src/main/java/io/serverlessworkflow/impl/jackson/ObjectMapperFactoryProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.impl.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Objects;
+import java.util.ServiceLoader;
+import java.util.function.Supplier;
+
+public class ObjectMapperFactoryProvider implements Supplier<ObjectMapperFactory> {
+
+  private static ObjectMapperFactoryProvider instance = new ObjectMapperFactoryProvider();
+
+  public static ObjectMapperFactoryProvider instance() {
+    return instance;
+  }
+
+  private ObjectMapperFactory objectMapperFactory;
+
+  private ObjectMapperFactoryProvider() {}
+
+  public void setFactory(ObjectMapperFactory objectMapperFactory) {
+    this.objectMapperFactory = Objects.requireNonNull(objectMapperFactory);
+  }
+
+  @Override
+  public ObjectMapperFactory get() {
+    return objectMapperFactory != null
+        ? objectMapperFactory
+        : ServiceLoader.load(ObjectMapperFactory.class)
+            .findFirst()
+            .orElseGet(() -> () -> new ObjectMapper().findAndRegisterModules());
+  }
+}


### PR DESCRIPTION
Fix https://github.com/serverlessworkflow/sdk-java/issues/840
Alternative implementation to https://github.com/serverlessworkflow/sdk-java/pull/845
In this case the ObjectMapperFactory does not need to be singleton internally because it just invoked once, but it has to be set before JsonUtils is invoked, so it can only be initialized at application startup (which is probably desirable, but just in case)