### PR TITLE
[Fix #863] Adding WorkflowContext and TaskContext as additional params

### DIFF
--- a/experimental/lambda/src/main/java/io/serverlessworkflow/impl/expressions/func/JavaExpressionFactory.java
+++ b/experimental/lambda/src/main/java/io/serverlessworkflow/impl/expressions/func/JavaExpressionFactory.java
@@ -18,8 +18,12 @@ package io.serverlessworkflow.impl.expressions.func;
 import io.cloudevents.CloudEventData;
 import io.serverlessworkflow.api.types.TaskBase;
 import io.serverlessworkflow.api.types.TaskMetadata;
+import io.serverlessworkflow.api.types.func.JavaContextFunction;
+import io.serverlessworkflow.api.types.func.JavaFilterFunction;
 import io.serverlessworkflow.api.types.func.TaskMetadataKeys;
 import io.serverlessworkflow.api.types.func.TypedFunction;
+import io.serverlessworkflow.api.types.func.TypedJavaContextFunction;
+import io.serverlessworkflow.api.types.func.TypedJavaFilterFunction;
 import io.serverlessworkflow.api.types.func.TypedPredicate;
 import io.serverlessworkflow.impl.WorkflowModelFactory;
 import io.serverlessworkflow.impl.WorkflowPredicate;
@@ -44,6 +48,14 @@ public class JavaExpressionFactory extends AbstractExpressionFactory {
       return (w, t, n) -> func.apply(n.asJavaObject());
     } else if (value instanceof TypedFunction func) {
       return (w, t, n) -> func.function().apply(n.as(func.argClass()).orElseThrow());
+    } else if (value instanceof JavaFilterFunction func) {
+      return (w, t, n) -> func.apply(n.asJavaObject(), w, t);
+    } else if (value instanceof TypedJavaFilterFunction func) {
+      return (w, t, n) -> func.function().apply(n.as(func.argClass()).orElseThrow(), w, t);
+    } else if (value instanceof JavaContextFunction func) {
+      return (w, t, n) -> func.apply(n.asJavaObject(), w);
+    } else if (value instanceof TypedJavaContextFunction func) {
+      return (w, t, n) -> func.function().apply(n.as(func.argClass()).orElseThrow(), w);
     } else {
       return (w, t, n) -> value;
     }

--- a/experimental/lambda/src/test/java/io/serverless/workflow/impl/JavaFunctions.java
+++ b/experimental/lambda/src/test/java/io/serverless/workflow/impl/JavaFunctions.java
@@ -15,6 +15,8 @@
  */
 package io.serverless.workflow.impl;
 
+import io.serverlessworkflow.impl.TaskContextData;
+import io.serverlessworkflow.impl.WorkflowContextData;
 import java.util.Map;
 
 public class JavaFunctions {
@@ -25,6 +27,15 @@ public class JavaFunctions {
 
   static String getName(Person person) {
     return person.name() + " Javierito";
+  }
+
+  static String getFilterName(
+      Person person, WorkflowContextData workflowContext, TaskContextData taskContext) {
+    return person.name() + "_" + workflowContext.instanceData().id() + "_" + taskContext.taskName();
+  }
+
+  static String getContextName(Person person, WorkflowContextData workflowContext) {
+    return person.name() + "_" + workflowContext.instanceData().id();
   }
 
   static Map<String, Object> addJavierito(Map<String, Object> map) {

--- a/experimental/types/pom.xml
+++ b/experimental/types/pom.xml
@@ -12,5 +12,9 @@
         <groupId>io.serverlessworkflow</groupId>
         <artifactId>serverlessworkflow-types</artifactId>
     </dependency>
+     <dependency>
+        <groupId>io.serverlessworkflow</groupId>
+        <artifactId>serverlessworkflow-impl-core</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/experimental/types/src/main/java/io/serverlessworkflow/api/types/func/ExportAsFunction.java
+++ b/experimental/types/src/main/java/io/serverlessworkflow/api/types/func/ExportAsFunction.java
@@ -31,4 +31,24 @@ public class ExportAsFunction extends ExportAs {
     setObject(new TypedFunction<>(value, argClass));
     return this;
   }
+
+  public <T, V> ExportAs withFunction(JavaFilterFunction<T, V> value) {
+    setObject(value);
+    return this;
+  }
+
+  public <T, V> ExportAs withFunction(JavaFilterFunction<T, V> value, Class<T> argClass) {
+    setObject(new TypedJavaFilterFunction<>(value, argClass));
+    return this;
+  }
+
+  public <T, V> ExportAs withFunction(JavaContextFunction<T, V> value) {
+    setObject(value);
+    return this;
+  }
+
+  public <T, V> ExportAs withFunction(JavaContextFunction<T, V> value, Class<T> argClass) {
+    setObject(new TypedJavaContextFunction<>(value, argClass));
+    return this;
+  }
 }

--- a/experimental/types/src/main/java/io/serverlessworkflow/api/types/func/InputFromFunction.java
+++ b/experimental/types/src/main/java/io/serverlessworkflow/api/types/func/InputFromFunction.java
@@ -31,4 +31,24 @@ public class InputFromFunction extends InputFrom {
     setObject(new TypedFunction<>(value, argClass));
     return this;
   }
+
+  public <T, V> InputFrom withFunction(JavaFilterFunction<T, V> value) {
+    setObject(value);
+    return this;
+  }
+
+  public <T, V> InputFrom withFunction(JavaFilterFunction<T, V> value, Class<T> argClass) {
+    setObject(new TypedJavaFilterFunction<>(value, argClass));
+    return this;
+  }
+
+  public <T, V> InputFrom withFunction(JavaContextFunction<T, V> value) {
+    setObject(value);
+    return this;
+  }
+
+  public <T, V> InputFrom withFunction(JavaContextFunction<T, V> value, Class<T> argClass) {
+    setObject(new TypedJavaContextFunction<>(value, argClass));
+    return this;
+  }
 }

--- a/experimental/types/src/main/java/io/serverlessworkflow/api/types/func/JavaContextFunction.java
+++ b/experimental/types/src/main/java/io/serverlessworkflow/api/types/func/JavaContextFunction.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.api.types.func;
+
+import io.serverlessworkflow.impl.WorkflowContextData;
+
+@FunctionalInterface
+public interface JavaContextFunction<T, R> {
+  R apply(T object, WorkflowContextData workflowContext);
+}

--- a/experimental/types/src/main/java/io/serverlessworkflow/api/types/func/JavaFilterFunction.java
+++ b/experimental/types/src/main/java/io/serverlessworkflow/api/types/func/JavaFilterFunction.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.api.types.func;
+
+import io.serverlessworkflow.impl.TaskContextData;
+import io.serverlessworkflow.impl.WorkflowContextData;
+
+@FunctionalInterface
+public interface JavaFilterFunction<T, R> {
+  R apply(T object, WorkflowContextData workflowContext, TaskContextData taskContext);
+}

--- a/experimental/types/src/main/java/io/serverlessworkflow/api/types/func/OutputAsFunction.java
+++ b/experimental/types/src/main/java/io/serverlessworkflow/api/types/func/OutputAsFunction.java
@@ -31,4 +31,24 @@ public class OutputAsFunction extends OutputAs {
     setObject(new TypedFunction<>(value, argClass));
     return this;
   }
+
+  public <T, V> OutputAs withFunction(JavaFilterFunction<T, V> value) {
+    setObject(value);
+    return this;
+  }
+
+  public <T, V> OutputAs withFunction(JavaFilterFunction<T, V> value, Class<T> argClass) {
+    setObject(new TypedJavaFilterFunction<>(value, argClass));
+    return this;
+  }
+
+  public <T, V> OutputAs withFunction(JavaContextFunction<T, V> value) {
+    setObject(value);
+    return this;
+  }
+
+  public <T, V> OutputAs withFunction(JavaContextFunction<T, V> value, Class<T> argClass) {
+    setObject(new TypedJavaContextFunction<>(value, argClass));
+    return this;
+  }
 }

--- a/experimental/types/src/main/java/io/serverlessworkflow/api/types/func/TypedJavaContextFunction.java
+++ b/experimental/types/src/main/java/io/serverlessworkflow/api/types/func/TypedJavaContextFunction.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.api.types.func;
+
+public record TypedJavaContextFunction<T, V>(
+    JavaContextFunction<T, V> function, Class<T> argClass) {}

--- a/experimental/types/src/main/java/io/serverlessworkflow/api/types/func/TypedJavaFilterFunction.java
+++ b/experimental/types/src/main/java/io/serverlessworkflow/api/types/func/TypedJavaFilterFunction.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.api.types.func;
+
+public record TypedJavaFilterFunction<T, V>(JavaFilterFunction<T, V> function, Class<T> argClass) {}


### PR DESCRIPTION
User can now specify java filter functions that accepts WorkflowContext and TaskContext in their signature.

Fix https://github.com/serverlessworkflow/sdk-java/issues/863