### PR TITLE
If model is not convertible from Json, try to convert anyway

### DIFF
--- a/impl/json-utils/src/main/java/io/serverlessworkflow/impl/jackson/JsonUtils.java
+++ b/impl/json-utils/src/main/java/io/serverlessworkflow/impl/jackson/JsonUtils.java
@@ -136,12 +136,7 @@ public class JsonUtils {
   public static JsonNode modelToJson(WorkflowModel model) {
     return model == null
         ? NullNode.instance
-        : model
-            .as(JsonNode.class)
-            .orElseThrow(
-                () ->
-                    new IllegalArgumentException(
-                        "Unable to convert model " + model + " to JsonNode"));
+        : model.as(JsonNode.class).orElseGet(() -> JsonUtils.fromValue(model.asJavaObject()));
   }
 
   public static Object toJavaValue(Object object) {


### PR DESCRIPTION
This PR allows JQExpression to work with models which are not supporting explicity conversion to JsonNode. 