### PR TITLE
Add guardrails to GPG keys; Fix impl-jackson module

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
       MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
       MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
       MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      MAVEN_GPG_FINGERPRINT: ${{ secrets.GPG_FINGERPRINT }}
 
     steps:
       - uses: radcortez/project-metadata-action@main
@@ -42,6 +43,14 @@ jobs:
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: GPG sanity check
+        run: |
+          gpg --list-secret-keys --keyid-format LONG
+          echo "test" | gpg --batch --yes --pinentry-mode loopback \
+          --passphrase "$MAVEN_GPG_PASSPHRASE" \
+          --local-user "$MAVEN_GPG_FINGERPRINT" \
+          --clearsign > /dev/null
 
       - name: Configure Git author
         run: |


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
When releasing we were getting:

```
Error: [ERROR] Failed to execute goal on project serverlessworkflow-impl-jackson-jwt: Could not resolve dependencies for project io.serverlessworkflow:serverlessworkflow-impl-jackson-jwt:jar:7.3.0.Final
Error: [ERROR] dependency: io.serverlessworkflow:serverlessworkflow-impl-jackson:jar:7.3.0.Final (compile)
Error: [ERROR] 	Could not find artifact io.serverlessworkflow:serverlessworkflow-impl-jackson:jar:7.3.0.Final in central (https://repo.maven.apache.org/maven2)
Error: [ERROR] -> [Help 1]
Error: [ERROR] 
Error: [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
Error: [ERROR] Re-run Maven using the -X switch to enable full debug logging.
Error: [ERROR] 
Error: [ERROR] For more information about the errors and possible solutions, please read the following articles:
Error: [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
Error: [ERROR] 
Error: [ERROR] After correcting the problems, you can resume the build with the command
Error: [ERROR]   mvn <args> -rf :serverlessworkflow-impl-jackson-jwt
```

This is because `impl-jackson` was a POM, not a JAR, but was still being imported as a JAR by submodules.

In the future, we can introduce `starters` packages a lá SpringBoot for other bundles we plan to distribute.

**Special notes for reviewers**:
Need this to release.

**Additional information (if needed):**
Additionally, we add a small guardrail for the release process to check our GPG keys. It was failing before because the keys had expired.