### PR TITLE
Fixing issue with type pom

### DIFF
--- a/examples/events/pom.xml
+++ b/examples/events/pom.xml
@@ -21,6 +21,7 @@
         <dependency>
             <groupId>io.serverlessworkflow</groupId>
             <artifactId>serverlessworkflow-impl-jackson</artifactId>
+            <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -27,6 +27,7 @@
                 <groupId>io.serverlessworkflow</groupId>
                 <artifactId>serverlessworkflow-impl-jackson</artifactId>
                 <version>${project.version}</version>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/examples/simpleGet/pom.xml
+++ b/examples/simpleGet/pom.xml
@@ -20,6 +20,7 @@
         <dependency>
             <groupId>io.serverlessworkflow</groupId>
             <artifactId>serverlessworkflow-impl-jackson</artifactId>
+            <type>pom</type>
         </dependency>
         <dependency>
             <groupId>io.serverlessworkflow</groupId>

--- a/experimental/fluent/agentic/pom.xml
+++ b/experimental/fluent/agentic/pom.xml
@@ -64,6 +64,8 @@
             <groupId>io.serverlessworkflow</groupId>
             <artifactId>serverlessworkflow-impl-jackson</artifactId>
             <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/impl/README.md
+++ b/impl/README.md
@@ -110,6 +110,7 @@ Links below.
 <dependency>
   <groupId>io.serverlessworkflow</groupId>
   <artifactId>serverlessworkflow-impl-jackson</artifactId>
+  <type>pom</type>
 </dependency>
 
 <!-- Add if you use HTTP Call tasks -->

--- a/impl/jwt-impl/pom.xml
+++ b/impl/jwt-impl/pom.xml
@@ -17,7 +17,7 @@
         </dependency>
         <dependency>
             <groupId>io.serverlessworkflow</groupId>
-            <artifactId>serverlessworkflow-impl-jackson</artifactId>
+            <artifactId>serverlessworkflow-impl-json</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -81,6 +81,7 @@
                 <groupId>io.serverlessworkflow</groupId>
                 <artifactId>serverlessworkflow-impl-jackson</artifactId>
                 <version>${project.version}</version>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>io.serverlessworkflow</groupId>
@@ -128,11 +129,11 @@
         <module>jwt-impl</module>
         <module>persistence</module>
         <module>openapi</module>
-        <module>test</module>
         <module>jq</module>
         <module>json-utils</module>
         <module>model</module>
         <module>lifecycleevent</module>
         <module>validation</module>
+        <module>test</module>
     </modules>
 </project>

--- a/impl/test/pom.xml
+++ b/impl/test/pom.xml
@@ -11,7 +11,8 @@
         <dependency>
             <groupId>io.serverlessworkflow</groupId>
             <artifactId>serverlessworkflow-impl-jackson</artifactId>
-        </dependency>
+            <type>pom</type>
+          </dependency>
         <dependency>
             <groupId>io.serverlessworkflow</groupId>
             <artifactId>serverlessworkflow-api</artifactId>


### PR DESCRIPTION
Recently jackson-impl was made a pom (agregation of dependencies) This implies that when used as dependency, you should add `<type>pom</type>`
