### PR TITLE
chore: remove examples from release

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,6 +4,7 @@
         <groupId>io.serverlessworkflow</groupId>
         <artifactId>serverlessworkflow-parent</artifactId>
         <version>8.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
     <name>Serverless Workflow :: Examples</name>
     <artifactId>serverlessworkflow-examples</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -276,10 +276,6 @@
                     <publishingServerId>central</publishingServerId>
                     <autoPublish>true</autoPublish>
                     <waitUntil>published</waitUntil>
-                    <excludeArtifacts>
-                        <excludeArtifact>serverlessworkflow-examples-events</excludeArtifact>
-                        <excludeArtifact>serverlessworkflow-examples-simpleGet</excludeArtifact>
-                    </excludeArtifacts>
                 </configuration>
             </plugin>
             <!-- Set properties containing the scm revision -->
@@ -472,7 +468,8 @@
                     <artifactId>maven-release-plugin</artifactId>
                     <version>${version.release.plugin}</version>
                     <configuration>
-                        <preparationGoals>clean install</preparationGoals>
+                        <preparationGoals>clean install -DperformRelease</preparationGoals>
+                        <arguments>-Prelease -DperformRelease</arguments>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <tagNameFormat>@{project.version}</tagNameFormat>
                         <pushChanges>false</pushChanges>


### PR DESCRIPTION
Necessary for the release. Internally, the release plugin was running the example module.