### PR TITLE
chore: do not wait for artifacts to be published

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -275,7 +275,7 @@
                 <configuration>
                     <publishingServerId>central</publishingServerId>
                     <autoPublish>true</autoPublish>
-                    <waitUntil>published</waitUntil>
+                    <waitUntil>uploaded</waitUntil>
                 </configuration>
             </plugin>
             <!-- Set properties containing the scm revision -->


### PR DESCRIPTION
Our last release failed because we were waiting for Central to publish it in 30 minutes. That will not always happen, so we just wait until we upload the artifacts.