### PR TITLE
no-issue: fix JavaFilterFunctionCallExecutor missing from context

### DIFF
--- a/experimental/lambda/src/main/java/io/serverlessworkflow/impl/executors/func/JavaFilterFunctionCallExecutor.java
+++ b/experimental/lambda/src/main/java/io/serverlessworkflow/impl/executors/func/JavaFilterFunctionCallExecutor.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.impl.executors.func;
+
+import io.serverlessworkflow.api.types.TaskBase;
+import io.serverlessworkflow.api.types.func.CallJava;
+import io.serverlessworkflow.api.types.func.JavaFilterFunction;
+import io.serverlessworkflow.impl.TaskContext;
+import io.serverlessworkflow.impl.WorkflowContext;
+import io.serverlessworkflow.impl.WorkflowDefinition;
+import io.serverlessworkflow.impl.WorkflowModel;
+import io.serverlessworkflow.impl.WorkflowModelFactory;
+import io.serverlessworkflow.impl.executors.CallableTask;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+public class JavaFilterFunctionCallExecutor<T, V>
+    implements CallableTask<CallJava.CallJavaFilterFunction<T, V>> {
+
+  private JavaFilterFunction<T, V> function;
+  private Optional<Class<T>> inputClass = Optional.empty();
+
+  @Override
+  public void init(CallJava.CallJavaFilterFunction<T, V> task, WorkflowDefinition definition) {
+    this.function = task.function();
+    this.inputClass = task.inputClass();
+  }
+
+  @Override
+  public CompletableFuture<WorkflowModel> apply(
+      WorkflowContext workflowContext, TaskContext taskContext, WorkflowModel input) {
+    WorkflowModelFactory mf = workflowContext.definition().application().modelFactory();
+    T typedIn = JavaFuncUtils.convertT(input, inputClass);
+    V out = function.apply(typedIn, workflowContext, taskContext);
+    return CompletableFuture.completedFuture(mf.fromAny(input, out));
+  }
+
+  @Override
+  public boolean accept(Class<? extends TaskBase> clazz) {
+    return CallJava.CallJavaFilterFunction.class.isAssignableFrom(clazz);
+  }
+}

--- a/experimental/lambda/src/main/resources/META-INF/services/io.serverlessworkflow.impl.executors.CallableTask
+++ b/experimental/lambda/src/main/resources/META-INF/services/io.serverlessworkflow.impl.executors.CallableTask
@@ -3,3 +3,4 @@ io.serverlessworkflow.impl.executors.func.JavaLoopFunctionCallExecutor
 io.serverlessworkflow.impl.executors.func.JavaFunctionCallExecutor
 io.serverlessworkflow.impl.executors.func.JavaConsumerCallExecutor
 io.serverlessworkflow.impl.executors.func.JavaContextFunctionCallExecutor
+io.serverlessworkflow.impl.executors.func.JavaFilterFunctionCallExecutor


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

If we use the new JavaFilterFunction, it blows:

```
Caused by: java.lang.UnsupportedOperationException: io.serverlessworkflow.api.types.func.CallJava$CallJavaFilterFunction not supported yet
	at io.serverlessworkflow.impl.executors.DefaultTaskExecutorFactory.lambda$findCallTask$1(DefaultTaskExecutorFactory.java:94)
	at java.base/java.util.Optional.orElseThrow(Optional.java:403)
	at io.serverlessworkflow.impl.executors.DefaultTaskExecutorFactory.findCallTask(DefaultTaskExecutorFactory.java:93)
	at io.serverlessworkflow.impl.executors.DefaultTaskExecutorFactory.getTaskExecutor(DefaultTaskExecutorFactory.java:58)
	at io.serverlessworkflow.impl.executors.func.JavaTaskExecutorFactory.getTaskExecutor(JavaTaskExecutorFactory.java:36)
	at io.serverlessworkflow.impl.executors.TaskExecutorHelper.createExecutorBuilderList(TaskExecutorHelper.java:93)
	at io.serverlessworkflow.impl.executors.TaskExecutorHelper.createExecutorList(TaskExecutorHelper.java:65)
	at io.serverlessworkflow.impl.WorkflowDefinition.<init>(WorkflowDefinition.java:77)
	at io.serverlessworkflow.impl.WorkflowDefinition.of(WorkflowDefinition.java:90)
	at io.serverlessworkflow.impl.WorkflowDefinition.of(WorkflowDefinition.java:82)
	at io.serverlessworkflow.impl.WorkflowApplication.lambda$workflowDefinition$0(WorkflowApplication.java:342)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1708)
	at io.serverlessworkflow.impl.WorkflowApplication.workflowDefinition(WorkflowApplication.java:341)
	at io.serverlessworkflow.impl.WorkflowApplication_EqdNfE-Bt0x5yK9E0H_Ln8SwgMs_Synthetic_ClientProxy.workflowDefinition(Unknown Source)
	at io.quarkiverse.flow.recorders.WorkflowDefinitionRecorder.lambda$workflowDefinitionSupplier$0(WorkflowDefinitionRecorder.java:30)
	... 31 more
``` 

I believe we will need a patch version to add this fix to 7.5.0.

**Special notes for reviewers**:

**Additional information (if needed):**