### PR TITLE
Improving HTTP WorkflowError

### DIFF
--- a/impl/http/src/main/java/io/serverlessworkflow/impl/executors/http/HttpModelConverter.java
+++ b/impl/http/src/main/java/io/serverlessworkflow/impl/executors/http/HttpModelConverter.java
@@ -31,16 +31,16 @@ public interface HttpModelConverter {
 
   default WorkflowError.Builder errorFromResponse(
       WorkflowError.Builder errorBuilder, Response response) {
+    errorBuilder.title(response.getStatusInfo().getReasonPhrase());
     try {
-      Object title = response.readEntity(responseType());
-      if (title != null) {
-        errorBuilder.title(title.toString());
+      Object details = response.readEntity(responseType());
+      if (details != null) {
+        errorBuilder.details(details.toString());
       }
     } catch (Exception ex) {
       LoggerFactory.getLogger(HttpModelConverter.class)
-          .warn("Problem extracting error from http response", ex);
+          .debug("Problem extracting error from http response", ex);
     }
-
     return errorBuilder;
   }
 }


### PR DESCRIPTION
The content of the error response, it can be parsed according to the response type, it is set as details

The title is set to HTTP reason phrase

