### PR TITLE
Fixing Swagger 2.1.36 CVE

### DIFF
--- a/impl/openapi/pom.xml
+++ b/impl/openapi/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.serverlessworkflow</groupId>
@@ -7,6 +8,13 @@
     </parent>
     <artifactId>serverlessworkflow-impl-openapi</artifactId>
     <name>Serverless Workflow :: Impl :: OpenAPI</name>
+
+    <properties>
+        <version.org.mozilla.rhino>1.7.15.1</version.org.mozilla.rhino>
+        <version.org.apache.commons.lang3>3.20.0</version.org.apache.commons.lang3>
+        <version.commons.codec>1.20.0</version.commons.codec>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
@@ -25,6 +33,25 @@
             <artifactId>swagger-parser</artifactId>
             <version>${version.io.swagger.parser.v3}</version>
         </dependency>
+
+        <!-- Swagger Parser brings a few dependencies with CVE, we are breaking them here -->
+        <!-- Once they upgrade, we can remove -->
+        <dependency>
+            <groupId>org.mozilla</groupId>
+            <artifactId>rhino</artifactId>
+            <version>${version.org.mozilla.rhino}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${version.org.apache.commons.lang3}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${version.commons.codec}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>


### PR DESCRIPTION
A few libraries from Swagger has CVEs and the upstream project has not upgraded yet. Once they do, we can remove the forced deps.