### PR TITLE
[Fix #844] Allow disable life cycle events per publisher

### DIFF
--- a/impl/core/src/main/java/io/serverlessworkflow/impl/events/EventPublisher.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/events/EventPublisher.java
@@ -20,4 +20,9 @@ import java.util.concurrent.CompletableFuture;
 
 public interface EventPublisher extends AutoCloseable {
   CompletableFuture<Void> publish(CloudEvent event);
+
+  /*override this method and leave it empty  to ignore life cycle events*/
+  default void publishLifeCycle(CloudEvent event) {
+    publish(event);
+  }
 }

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/lifecycle/ce/AbstractLifeCyclePublisher.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/lifecycle/ce/AbstractLifeCyclePublisher.java
@@ -328,7 +328,7 @@ public abstract class AbstractLifeCyclePublisher implements WorkflowExecutionLis
    * using application event publishers. That might be changed if needed by children by overriding this method
    */
   protected void publish(WorkflowApplication application, CloudEvent ce) {
-    application.eventPublishers().forEach(p -> p.publish(ce));
+    application.eventPublishers().forEach(p -> p.publishLifeCycle(ce));
   }
 
   private static <T> CloudEventData cloudEventData(T data, ToBytes<T> toBytes) {


### PR DESCRIPTION
Fix https://github.com/serverlessworkflow/sdk-java/issues/844