### PR TITLE
[Fix #1141] Perform conversion for completable future

### DIFF
--- a/experimental/lambda/src/main/java/io/serverlessworkflow/impl/executors/func/AbstractJavaCallExecutor.java
+++ b/experimental/lambda/src/main/java/io/serverlessworkflow/impl/executors/func/AbstractJavaCallExecutor.java
@@ -38,10 +38,11 @@ public abstract class AbstractJavaCallExecutor<T> implements CallableTask {
   @Override
   public CompletableFuture<WorkflowModel> apply(
       WorkflowContext workflowContext, TaskContext taskContext, WorkflowModel input) {
-    Object result = callJavaFunction(workflowContext, taskContext, model2Input(input));
+    Object result =
+        convertResponse(callJavaFunction(workflowContext, taskContext, model2Input(input)));
     WorkflowModelFactory modelFactory = workflowContext.definition().application().modelFactory();
     return result instanceof CompletableFuture future
-        ? future.thenApply(v -> output2Model(modelFactory, input, v))
+        ? future.thenApply(v -> output2Model(modelFactory, input, convertResponse(v)))
         : CompletableFuture.completedFuture(output2Model(modelFactory, input, result));
   }
 
@@ -60,6 +61,6 @@ public abstract class AbstractJavaCallExecutor<T> implements CallableTask {
 
   protected WorkflowModel output2Model(
       WorkflowModelFactory modelFactory, WorkflowModel input, Object result) {
-    return modelFactory.fromAny(input, convertResponse(result));
+    return modelFactory.fromAny(input, result);
   }
 }


### PR DESCRIPTION
Always perform conversion for the value returned. If the value returned after conversion is completable future, perform additional conversion once the value is returned.

