### PR TITLE
Refactor experimental fluent dependencies

### DIFF
--- a/experimental/fluent/func/pom.xml
+++ b/experimental/fluent/func/pom.xml
@@ -45,17 +45,5 @@
             <version>${version.org.mockito}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.serverlessworkflow</groupId>
-            <artifactId>serverlessworkflow-impl-model</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.serverlessworkflow</groupId>
-            <artifactId>serverlessworkflow-impl-jackson</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/experimental/fluent/func/src/test/java/io/serverlessworkflow/fluent/func/FuncDSLTest.java
+++ b/experimental/fluent/func/src/test/java/io/serverlessworkflow/fluent/func/FuncDSLTest.java
@@ -23,6 +23,7 @@ import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.get;
 import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.http;
 import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.listen;
 import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.toOne;
+import static io.serverlessworkflow.fluent.spec.dsl.DSL.auth;
 import static io.serverlessworkflow.fluent.spec.dsl.DSL.use;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -41,8 +42,6 @@ import io.serverlessworkflow.api.types.func.JavaFilterFunction;
 import io.serverlessworkflow.fluent.func.dsl.FuncDSL;
 import io.serverlessworkflow.fluent.func.dsl.FuncEmitSpec;
 import io.serverlessworkflow.fluent.func.dsl.FuncListenSpec;
-import io.serverlessworkflow.impl.WorkflowApplication;
-import io.serverlessworkflow.impl.WorkflowDefinition;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -432,22 +431,5 @@ class FuncDSLTest {
             .getAuthenticationPolicyReference()
             .getUse());
     assertEquals(Map.of("foo", "bar"), http.getWith().getBody());
-  }
-
-  @Test
-  void set_with_map() {
-    try (WorkflowApplication app = WorkflowApplication.builder().build()) {
-      Workflow workflow =
-          FuncWorkflowBuilder.workflow()
-              .tasks(f -> f.set(s -> s.expr(Map.of("message", "hello world!"))))
-              .build();
-
-      WorkflowDefinition workflowDefinition = app.workflowDefinition(workflow);
-
-      Map<String, Object> output =
-          workflowDefinition.instance(Map.of()).start().join().asMap().orElseThrow();
-
-      assertEquals(Map.of("message", "hello world!"), output);
-    }
   }
 }

--- a/experimental/lambda/src/test/java/io/serverless/workflow/impl/executors/func/FluentDSLCallTest.java
+++ b/experimental/lambda/src/test/java/io/serverless/workflow/impl/executors/func/FluentDSLCallTest.java
@@ -17,6 +17,7 @@ package io.serverless.workflow.impl.executors.func;
 
 import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.function;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.serverlessworkflow.api.types.FlowDirectiveEnum;
 import io.serverlessworkflow.api.types.Workflow;
@@ -26,6 +27,7 @@ import io.serverlessworkflow.impl.WorkflowDefinition;
 import io.serverlessworkflow.impl.WorkflowInstance;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
 
@@ -110,6 +112,23 @@ public class FluentDSLCallTest {
       WorkflowDefinition definition = app.workflowDefinition(workflow);
       assertThat(definition.instance(3).start().get().asNumber().orElseThrow()).isEqualTo(3);
       assertThat(definition.instance(4).start().get().asNumber().orElseThrow()).isEqualTo(0);
+    }
+  }
+
+  @Test
+  void set_with_map() {
+    try (WorkflowApplication app = WorkflowApplication.builder().build()) {
+      Workflow workflow =
+          FuncWorkflowBuilder.workflow()
+              .tasks(f -> f.set(s -> s.expr(Map.of("message", "hello world!"))))
+              .build();
+
+      WorkflowDefinition workflowDefinition = app.workflowDefinition(workflow);
+
+      Map<String, Object> output =
+          workflowDefinition.instance(Map.of()).start().join().asMap().orElseThrow();
+
+      assertEquals(Map.of("message", "hello world!"), output);
     }
   }
 }


### PR DESCRIPTION
It is better to keep the dsl test as they were and put the model test in the lambda module

