### PR TITLE
Fix PersistenceApplicationBuilder

### DIFF
--- a/impl/persistence/api/src/main/java/io/serverlessworkflow/impl/persistence/PersistenceApplicationBuilder.java
+++ b/impl/persistence/api/src/main/java/io/serverlessworkflow/impl/persistence/PersistenceApplicationBuilder.java
@@ -25,16 +25,14 @@ public class PersistenceApplicationBuilder {
     return new PersistenceApplicationBuilder(builder, writer);
   }
 
-  private final PersistenceInstanceWriter writer;
   private final WorkflowApplication.Builder appBuilder;
 
   protected PersistenceApplicationBuilder(Builder appBuilder, PersistenceInstanceWriter writer) {
     this.appBuilder = appBuilder;
-    this.writer = writer;
+    appBuilder.withListener(new WorkflowPersistenceListener(writer));
   }
 
   public WorkflowApplication build() {
-    appBuilder.withListener(new WorkflowPersistenceListener(writer));
     return appBuilder.build();
   }
 }


### PR DESCRIPTION
If build call is performed over the WorkflowApplication.Builder, the persitence listener is not added
