### PR TITLE
Refactored FuncDSL by renaming clazz to inputClass 

### DIFF
--- a/experimental/fluent/func/src/main/java/io/serverlessworkflow/fluent/func/dsl/FuncDSL.java
+++ b/experimental/fluent/func/src/main/java/io/serverlessworkflow/fluent/func/dsl/FuncDSL.java
@@ -534,7 +534,8 @@ public final class FuncDSL {
    * @param <R> output type
    * @return a named call step
    */
-  public static <T, R> FuncCallStep<T, R> function(String name, Function<T, R> fn, Class<T> inputClass) {
+  public static <T, R> FuncCallStep<T, R> function(
+      String name, Function<T, R> fn, Class<T> inputClass) {
     return new FuncCallStep<>(name, fn, inputClass);
   }
 
@@ -624,7 +625,8 @@ public final class FuncDSL {
    * @param <T> input type
    * @return an {@link EmitStep}
    */
-  public static <T> EmitStep emit(String type, Function<T, byte[]> serializer, Class<T> inputClass) {
+  public static <T> EmitStep emit(
+      String type, Function<T, byte[]> serializer, Class<T> inputClass) {
     return new EmitStep(null, eventBytes(type, serializer, inputClass));
   }
 


### PR DESCRIPTION
Fixes #1199

## Summary
Renamed the `clazz` parameter to `inputClass` in `FuncDSL` to improve clarity and make the semantics of `inputFrom` and `outputAs` easier to understand.

## Changes
- Renamed `clazz` parameter to `inputClass` in `FuncDSL`

## Checklist
- [x] mvn -DskipTests spotless:check checkstyle:check passes locally
- [ ] Unit/integration tests updated 
- [ ] Public API changes documented/Javadoc updated 
- [x] No unrelated formatting churn

**Note:** The API module still has a test failure. This PR does not change the API module; that issue is separate.