### PR TITLE
Decrease Java model priority

### DIFF
--- a/experimental/model/src/main/java/io/serverlessworkflow/impl/model/func/JavaModelFactory.java
+++ b/experimental/model/src/main/java/io/serverlessworkflow/impl/model/func/JavaModelFactory.java
@@ -82,4 +82,9 @@ public class JavaModelFactory implements WorkflowModelFactory {
   public WorkflowModel fromOther(Object obj) {
     return new JavaModel(obj);
   }
+
+  @Override
+  public int priority() {
+    return DEFAULT_PRIORITY + 10;
+  }
 }


### PR DESCRIPTION
This way when both jackson model and java model are in the classpath, the jackson model will take preference.