### PR TITLE
[Fix #1240] Avoiding duplicate listeners

### DIFF
--- a/impl/core/pom.xml
+++ b/impl/core/pom.xml
@@ -38,5 +38,10 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/WorkflowApplication.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/WorkflowApplication.java
@@ -49,6 +49,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -96,7 +97,7 @@ public class WorkflowApplication implements AutoCloseable {
     this.idFactory = builder.idFactory;
     this.runtimeDescriptorFactory = builder.descriptorFactory;
     this.executorFactory = builder.executorFactory;
-    this.listeners = builder.listeners;
+    this.listeners = new LinkedHashSet<>(builder.listeners);
     this.definitions = new ConcurrentHashMap<>();
     this.eventConsumer = builder.eventConsumer;
     this.eventPublishers = builder.eventPublishers;

--- a/impl/core/src/test/java/io/serverlessworkflow/impl/LowestPriorityListener.java
+++ b/impl/core/src/test/java/io/serverlessworkflow/impl/LowestPriorityListener.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.impl;
+
+import io.serverlessworkflow.impl.lifecycle.WorkflowExecutionListener;
+
+public class LowestPriorityListener implements WorkflowExecutionListener {
+  public int priority() {
+    return DEFAULT_PRIORITY + 1;
+  }
+}

--- a/impl/core/src/test/java/io/serverlessworkflow/impl/MediumPriorityListener.java
+++ b/impl/core/src/test/java/io/serverlessworkflow/impl/MediumPriorityListener.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.impl;
+
+import io.serverlessworkflow.impl.lifecycle.WorkflowExecutionListener;
+import java.util.Objects;
+
+public class MediumPriorityListener implements WorkflowExecutionListener {
+
+  private final String id;
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (obj == null) return false;
+    if (getClass() != obj.getClass()) return false;
+    MediumPriorityListener other = (MediumPriorityListener) obj;
+    return Objects.equals(id, other.id);
+  }
+
+  public MediumPriorityListener(String id) {
+    super();
+    this.id = id;
+  }
+}

--- a/impl/core/src/test/java/io/serverlessworkflow/impl/TopPriorityListener.java
+++ b/impl/core/src/test/java/io/serverlessworkflow/impl/TopPriorityListener.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.impl;
+
+import io.serverlessworkflow.impl.lifecycle.WorkflowExecutionListener;
+
+public class TopPriorityListener implements WorkflowExecutionListener {
+  public int priority() {
+    return DEFAULT_PRIORITY - 1;
+  }
+}

--- a/impl/core/src/test/java/io/serverlessworkflow/impl/WorkflowListenerTest.java
+++ b/impl/core/src/test/java/io/serverlessworkflow/impl/WorkflowListenerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.serverlessworkflow.impl.lifecycle.WorkflowExecutionListener;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class WorkflowListenerTest {
+
+  private WorkflowModelFactory modelFactory;
+
+  @BeforeEach
+  void setup() {
+    modelFactory = Mockito.mock(WorkflowModelFactory.class);
+  }
+
+  @Test
+  void testSorted() {
+    WorkflowExecutionListener mediumPrio = new MediumPriorityListener("javi");
+    WorkflowExecutionListener lowestPrio = new LowestPriorityListener();
+    WorkflowExecutionListener topPrio = new TopPriorityListener();
+    WorkflowExecutionListener anotherMediumPrio = new MediumPriorityListener("javier");
+
+    WorkflowApplication app =
+        WorkflowApplication.builder()
+            .withModelFactory(modelFactory)
+            .withListener(mediumPrio)
+            .withListener(lowestPrio)
+            .withListener(topPrio)
+            .withListener(anotherMediumPrio)
+            .build();
+
+    assertThat(app.listeners()).hasSize(5);
+    assertThat(app.listeners())
+        .startsWith(topPrio, mediumPrio, anotherMediumPrio, app.schedulerListener(), lowestPrio);
+  }
+
+  @Test
+  void testNotDuplicated() {
+    WorkflowExecutionListener mediumPrio = new MediumPriorityListener("javi");
+    WorkflowExecutionListener lowestPrio = new LowestPriorityListener();
+    WorkflowExecutionListener topPrio = new TopPriorityListener();
+    WorkflowExecutionListener anotherMediumPrio = new MediumPriorityListener("javi");
+
+    WorkflowApplication app =
+        WorkflowApplication.builder()
+            .withModelFactory(modelFactory)
+            .withListener(mediumPrio)
+            .withListener(lowestPrio)
+            .withListener(topPrio)
+            .withListener(anotherMediumPrio)
+            .build();
+
+    assertThat(app.listeners()).hasSize(4);
+    assertThat(app.listeners())
+        .startsWith(topPrio, mediumPrio, app.schedulerListener(), lowestPrio);
+  }
+}


### PR DESCRIPTION
If a listener implemen equals, it will be honored.
Fix https://github.com/serverlessworkflow/sdk-java/issues/1240