### PR TITLE
Enable workflow restoration for WAITING status

### DIFF
--- a/impl/persistence/api/src/main/java/io/serverlessworkflow/impl/persistence/AbstractPersistenceInstanceWriter.java
+++ b/impl/persistence/api/src/main/java/io/serverlessworkflow/impl/persistence/AbstractPersistenceInstanceWriter.java
@@ -77,6 +77,12 @@ public abstract class AbstractPersistenceInstanceWriter implements PersistenceIn
   }
 
   @Override
+  public CompletableFuture<Void> statusChanged(
+      WorkflowContextData workflowContext, WorkflowStatus status) {
+    return doTransaction(t -> t.writeStatus(workflowContext, status), workflowContext);
+  }
+
+  @Override
   public void close() throws Exception {}
 
   protected abstract CompletableFuture<Void> doTransaction(

--- a/impl/persistence/api/src/main/java/io/serverlessworkflow/impl/persistence/PersistenceInstanceWriter.java
+++ b/impl/persistence/api/src/main/java/io/serverlessworkflow/impl/persistence/PersistenceInstanceWriter.java
@@ -17,6 +17,7 @@ package io.serverlessworkflow.impl.persistence;
 
 import io.serverlessworkflow.impl.TaskContextData;
 import io.serverlessworkflow.impl.WorkflowContextData;
+import io.serverlessworkflow.impl.WorkflowStatus;
 import java.util.concurrent.CompletableFuture;
 
 public interface PersistenceInstanceWriter extends AutoCloseable {
@@ -32,6 +33,11 @@ public interface PersistenceInstanceWriter extends AutoCloseable {
   CompletableFuture<Void> suspended(WorkflowContextData workflowContext);
 
   CompletableFuture<Void> resumed(WorkflowContextData workflowContext);
+
+  default CompletableFuture<Void> statusChanged(
+      WorkflowContextData workflowContext, WorkflowStatus status) {
+    return CompletableFuture.completedFuture(null);
+  }
 
   CompletableFuture<Void> taskRetried(
       WorkflowContextData workflowContext, TaskContextData taskContext);

--- a/impl/persistence/api/src/main/java/io/serverlessworkflow/impl/persistence/WorkflowPersistenceInstance.java
+++ b/impl/persistence/api/src/main/java/io/serverlessworkflow/impl/persistence/WorkflowPersistenceInstance.java
@@ -40,6 +40,8 @@ public class WorkflowPersistenceInstance extends WorkflowMutableInstance {
         () -> {
           if (info.status() == WorkflowStatus.SUSPENDED) {
             internalSuspend();
+          } else if (info.status() == WorkflowStatus.WAITING) {
+            status(WorkflowStatus.WAITING);
           }
         });
   }

--- a/impl/persistence/api/src/main/java/io/serverlessworkflow/impl/persistence/WorkflowPersistenceListener.java
+++ b/impl/persistence/api/src/main/java/io/serverlessworkflow/impl/persistence/WorkflowPersistenceListener.java
@@ -15,6 +15,7 @@
  */
 package io.serverlessworkflow.impl.persistence;
 
+import io.serverlessworkflow.impl.WorkflowStatus;
 import io.serverlessworkflow.impl.lifecycle.TaskCompletedEvent;
 import io.serverlessworkflow.impl.lifecycle.TaskRetriedEvent;
 import io.serverlessworkflow.impl.lifecycle.TaskStartedEvent;
@@ -24,6 +25,7 @@ import io.serverlessworkflow.impl.lifecycle.WorkflowExecutionListener;
 import io.serverlessworkflow.impl.lifecycle.WorkflowFailedEvent;
 import io.serverlessworkflow.impl.lifecycle.WorkflowResumedEvent;
 import io.serverlessworkflow.impl.lifecycle.WorkflowStartedEvent;
+import io.serverlessworkflow.impl.lifecycle.WorkflowStatusEvent;
 import io.serverlessworkflow.impl.lifecycle.WorkflowSuspendedEvent;
 
 public class WorkflowPersistenceListener implements WorkflowExecutionListener {
@@ -77,5 +79,13 @@ public class WorkflowPersistenceListener implements WorkflowExecutionListener {
   @Override
   public void onTaskRetried(TaskRetriedEvent ev) {
     persistenceWriter.taskRetried(ev.workflowContext(), ev.taskContext());
+  }
+
+  @Override
+  public void onWorkflowStatusChanged(WorkflowStatusEvent ev) {
+    if (ev.status() == WorkflowStatus.WAITING) {
+      // Only persist WAITING for now
+      persistenceWriter.statusChanged(ev.workflowContext(), ev.status());
+    }
   }
 }


### PR DESCRIPTION
This pull request introduces support for handling workflow status changes, specifically persisting the `WAITING` status, in the workflow persistence layer. It does so by extending the persistence writer and listener interfaces and implementations to handle status change events. The most important changes are grouped below:

**Persistence API Enhancements:**

* Added a new `statusChanged` method to the `PersistenceInstanceWriter` interface, allowing the persistence layer to handle workflow status updates.
* Implemented the `statusChanged` method in `AbstractPersistenceInstanceWriter`, which writes the new status using a transaction.

**Workflow Status Handling:**

* Updated `WorkflowPersistenceListener` to listen for `WorkflowStatusEvent` and persist the `WAITING` status via the new `statusChanged` method. [[1]](diffhunk://#diff-05ebbf45a98011e26cd31d3d7c616f26dca0ed6dd8397b5be1277880bed5aa8cR28) [[2]](diffhunk://#diff-05ebbf45a98011e26cd31d3d7c616f26dca0ed6dd8397b5be1277880bed5aa8cR83-R90)
* Modified `WorkflowPersistenceInstance` to explicitly persist the `WAITING` status when starting a workflow, ensuring the status is accurately reflected.