### PR TITLE
[NO-ISSUE] Introduce AbstractForkTaskBuilder

### DIFF
--- a/experimental/fluent/func/src/main/java/io/serverlessworkflow/fluent/func/FuncForkTaskBuilder.java
+++ b/experimental/fluent/func/src/main/java/io/serverlessworkflow/fluent/func/FuncForkTaskBuilder.java
@@ -15,40 +15,36 @@
  */
 package io.serverlessworkflow.fluent.func;
 
-import io.serverlessworkflow.api.types.DoTask;
 import io.serverlessworkflow.api.types.ForkTask;
-import io.serverlessworkflow.api.types.ForkTaskConfiguration;
 import io.serverlessworkflow.api.types.Task;
 import io.serverlessworkflow.api.types.TaskItem;
 import io.serverlessworkflow.api.types.func.CallJava;
 import io.serverlessworkflow.api.types.func.CallTaskJava;
 import io.serverlessworkflow.fluent.func.spi.ConditionalTaskBuilder;
 import io.serverlessworkflow.fluent.func.spi.FuncTaskTransformations;
-import io.serverlessworkflow.fluent.spec.TaskBaseBuilder;
+import io.serverlessworkflow.fluent.spec.AbstractForkTaskBuilder;
 import io.serverlessworkflow.fluent.spec.spi.ForkTaskFluent;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-public class FuncForkTaskBuilder extends TaskBaseBuilder<FuncForkTaskBuilder>
+public class FuncForkTaskBuilder
+    extends AbstractForkTaskBuilder<FuncForkTaskBuilder, FuncTaskItemListBuilder>
     implements FuncTaskTransformations<FuncForkTaskBuilder>,
         ConditionalTaskBuilder<FuncForkTaskBuilder>,
         ForkTaskFluent<FuncForkTaskBuilder, FuncTaskItemListBuilder> {
 
-  private final ForkTask forkTask;
-  private final List<TaskItem> items;
-
   FuncForkTaskBuilder() {
-    this.forkTask = new ForkTask();
-    this.forkTask.setFork(new ForkTaskConfiguration());
-    this.items = new ArrayList<>();
-    this.setTask(forkTask);
+    super();
   }
 
   @Override
   protected FuncForkTaskBuilder self() {
     return this;
+  }
+
+  @Override
+  protected FuncTaskItemListBuilder newTaskItemListBuilder(int listOffsetSize) {
+    return new FuncTaskItemListBuilder(listOffsetSize);
   }
 
   public <T, V> FuncForkTaskBuilder branch(String name, Function<T, V> function) {
@@ -62,23 +58,14 @@ public class FuncForkTaskBuilder extends TaskBaseBuilder<FuncForkTaskBuilder>
 
   @Override
   public FuncForkTaskBuilder branch(String name, Consumer<FuncTaskItemListBuilder> branchConsumer) {
-    if (name == null || name.isBlank()) {
-      name = "branch-" + this.items.size();
-    }
-    final FuncTaskItemListBuilder branchItems = new FuncTaskItemListBuilder(this.items);
-    this.items.add(
-        new TaskItem(name, new Task().withDoTask(new DoTask().withDo(branchItems.build()))));
-    return this;
+    return super.branch(name, branchConsumer);
   }
 
   public <T, V> FuncForkTaskBuilder branch(
       String name, Function<T, V> function, Class<T> argParam, Class<V> returnClass) {
-    if (name == null || name.isBlank()) {
-      name = "branch-" + this.items.size();
-    }
-    this.items.add(
+    this.appendBranch(
         new TaskItem(
-            name,
+            this.defaultBranchName(name, this.currentOffset()),
             new Task()
                 .withCallTask(
                     new CallTaskJava(CallJava.function(function, argParam, returnClass)))));
@@ -91,21 +78,11 @@ public class FuncForkTaskBuilder extends TaskBaseBuilder<FuncForkTaskBuilder>
 
   @Override
   public FuncForkTaskBuilder branches(Consumer<FuncTaskItemListBuilder> consumer) {
-    final FuncTaskItemListBuilder builder = new FuncTaskItemListBuilder(this.items.size());
-    consumer.accept(builder);
-    this.items.addAll(builder.build());
-    return this;
-  }
-
-  @Override
-  public FuncForkTaskBuilder compete(boolean compete) {
-    this.forkTask.getFork().setCompete(compete);
-    return this;
+    return super.branches(consumer);
   }
 
   @Override
   public ForkTask build() {
-    this.forkTask.getFork().setBranches(this.items);
-    return forkTask;
+    return super.build();
   }
 }

--- a/experimental/fluent/func/src/main/java/io/serverlessworkflow/fluent/func/FuncForkTaskBuilder.java
+++ b/experimental/fluent/func/src/main/java/io/serverlessworkflow/fluent/func/FuncForkTaskBuilder.java
@@ -15,7 +15,6 @@
  */
 package io.serverlessworkflow.fluent.func;
 
-import io.serverlessworkflow.api.types.ForkTask;
 import io.serverlessworkflow.api.types.Task;
 import io.serverlessworkflow.api.types.TaskItem;
 import io.serverlessworkflow.api.types.func.CallJava;
@@ -56,11 +55,6 @@ public class FuncForkTaskBuilder
     return branch(name, function, argParam, null);
   }
 
-  @Override
-  public FuncForkTaskBuilder branch(String name, Consumer<FuncTaskItemListBuilder> branchConsumer) {
-    return super.branch(name, branchConsumer);
-  }
-
   public <T, V> FuncForkTaskBuilder branch(
       String name, Function<T, V> function, Class<T> argParam, Class<V> returnClass) {
     this.appendBranch(
@@ -79,10 +73,5 @@ public class FuncForkTaskBuilder
   @Override
   public FuncForkTaskBuilder branches(Consumer<FuncTaskItemListBuilder> consumer) {
     return super.branches(consumer);
-  }
-
-  @Override
-  public ForkTask build() {
-    return super.build();
   }
 }

--- a/experimental/fluent/func/src/main/java/io/serverlessworkflow/fluent/func/FuncForkTaskBuilder.java
+++ b/experimental/fluent/func/src/main/java/io/serverlessworkflow/fluent/func/FuncForkTaskBuilder.java
@@ -23,7 +23,6 @@ import io.serverlessworkflow.fluent.func.spi.ConditionalTaskBuilder;
 import io.serverlessworkflow.fluent.func.spi.FuncTaskTransformations;
 import io.serverlessworkflow.fluent.spec.AbstractForkTaskBuilder;
 import io.serverlessworkflow.fluent.spec.spi.ForkTaskFluent;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 public class FuncForkTaskBuilder
@@ -68,10 +67,5 @@ public class FuncForkTaskBuilder
 
   public <T, V> FuncForkTaskBuilder branch(Function<T, V> function) {
     return this.branch(null, function);
-  }
-
-  @Override
-  public FuncForkTaskBuilder branches(Consumer<FuncTaskItemListBuilder> consumer) {
-    return super.branches(consumer);
   }
 }

--- a/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/AbstractForkTaskBuilder.java
+++ b/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/AbstractForkTaskBuilder.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.fluent.spec;
+
+import io.serverlessworkflow.api.types.DoTask;
+import io.serverlessworkflow.api.types.ForkTask;
+import io.serverlessworkflow.api.types.ForkTaskConfiguration;
+import io.serverlessworkflow.api.types.Task;
+import io.serverlessworkflow.api.types.TaskItem;
+import io.serverlessworkflow.fluent.spec.spi.ForkTaskFluent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+public abstract class AbstractForkTaskBuilder<
+        SELF extends AbstractForkTaskBuilder<SELF, L>, L extends BaseTaskItemListBuilder<L>>
+    extends TaskBaseBuilder<SELF> implements ForkTaskFluent<SELF, L> {
+
+  protected final ForkTask forkTask;
+  protected final ForkTaskConfiguration forkTaskConfiguration;
+
+  protected AbstractForkTaskBuilder() {
+    this.forkTask = new ForkTask();
+    this.forkTaskConfiguration = new ForkTaskConfiguration();
+    super.setTask(this.forkTask);
+  }
+
+  protected abstract L newTaskItemListBuilder(int listOffsetSize);
+
+  protected String defaultBranchName(String name, int currentOffset) {
+    return (name == null || name.isBlank()) ? "branch-" + currentOffset : name;
+  }
+
+  protected TaskItem createDoBranchTaskItem(String name, List<TaskItem> items) {
+    return new TaskItem(name, new Task().withDoTask(new DoTask().withDo(items)));
+  }
+
+  protected int currentOffset() {
+    List<TaskItem> existingBranches = this.forkTaskConfiguration.getBranches();
+    return (existingBranches == null) ? 0 : existingBranches.size();
+  }
+
+  protected void appendBranches(List<TaskItem> newBranches) {
+    List<TaskItem> existingBranches = this.forkTaskConfiguration.getBranches();
+    if (existingBranches == null || existingBranches.isEmpty()) {
+      this.forkTaskConfiguration.setBranches(newBranches);
+    } else {
+      List<TaskItem> merged = new ArrayList<>(existingBranches);
+      merged.addAll(newBranches);
+      this.forkTaskConfiguration.setBranches(merged);
+    }
+  }
+
+  protected void appendBranch(TaskItem branch) {
+    appendBranches(List.of(branch));
+  }
+
+  @Override
+  public SELF compete(final boolean compete) {
+    this.forkTaskConfiguration.setCompete(compete);
+    return self();
+  }
+
+  @Override
+  public SELF branches(Consumer<L> branchesConsumer) {
+    Objects.requireNonNull(branchesConsumer, "branches consumer must not be null");
+
+    final L builder = newTaskItemListBuilder(currentOffset());
+    branchesConsumer.accept(builder);
+    appendBranches(builder.build());
+
+    return self();
+  }
+
+  @Override
+  public SELF branch(String name, Consumer<L> branchConsumer) {
+    Objects.requireNonNull(branchConsumer, "branch consumer must not be null");
+
+    String branchName = defaultBranchName(name, currentOffset());
+    L branchItems = newTaskItemListBuilder(0);
+    branchConsumer.accept(branchItems);
+
+    appendBranch(createDoBranchTaskItem(branchName, branchItems.build()));
+    return self();
+  }
+
+  @Override
+  public ForkTask build() {
+    return this.forkTask.withFork(this.forkTaskConfiguration);
+  }
+}

--- a/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/AbstractForkTaskBuilder.java
+++ b/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/AbstractForkTaskBuilder.java
@@ -42,7 +42,7 @@ public abstract class AbstractForkTaskBuilder<
   protected abstract L newTaskItemListBuilder(int listOffsetSize);
 
   protected String defaultBranchName(String name, int currentOffset) {
-    return (name == null || name.isBlank()) ? "branch-" + currentOffset : name;
+    return name == null || name.isBlank() ? "branch-" + currentOffset : name;
   }
 
   protected TaskItem createDoBranchTaskItem(String name, List<TaskItem> items) {
@@ -51,7 +51,7 @@ public abstract class AbstractForkTaskBuilder<
 
   protected int currentOffset() {
     List<TaskItem> existingBranches = this.forkTaskConfiguration.getBranches();
-    return (existingBranches == null) ? 0 : existingBranches.size();
+    return existingBranches == null ? 0 : existingBranches.size();
   }
 
   protected void appendBranches(List<TaskItem> newBranches) {

--- a/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/ForkTaskBuilder.java
+++ b/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/ForkTaskBuilder.java
@@ -20,10 +20,6 @@ import io.serverlessworkflow.fluent.spec.spi.ForkTaskFluent;
 public class ForkTaskBuilder extends AbstractForkTaskBuilder<ForkTaskBuilder, TaskItemListBuilder>
     implements ForkTaskFluent<ForkTaskBuilder, TaskItemListBuilder> {
 
-  ForkTaskBuilder() {
-    super();
-  }
-
   @Override
   protected ForkTaskBuilder self() {
     return this;

--- a/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/ForkTaskBuilder.java
+++ b/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/ForkTaskBuilder.java
@@ -15,27 +15,13 @@
  */
 package io.serverlessworkflow.fluent.spec;
 
-import io.serverlessworkflow.api.types.DoTask;
-import io.serverlessworkflow.api.types.ForkTask;
-import io.serverlessworkflow.api.types.ForkTaskConfiguration;
-import io.serverlessworkflow.api.types.Task;
-import io.serverlessworkflow.api.types.TaskItem;
 import io.serverlessworkflow.fluent.spec.spi.ForkTaskFluent;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.function.Consumer;
 
-public class ForkTaskBuilder extends TaskBaseBuilder<ForkTaskBuilder>
+public class ForkTaskBuilder extends AbstractForkTaskBuilder<ForkTaskBuilder, TaskItemListBuilder>
     implements ForkTaskFluent<ForkTaskBuilder, TaskItemListBuilder> {
 
-  private final ForkTask forkTask;
-  private final ForkTaskConfiguration forkTaskConfiguration;
-
   ForkTaskBuilder() {
-    this.forkTask = new ForkTask();
-    this.forkTaskConfiguration = new ForkTaskConfiguration();
-    super.setTask(this.forkTask);
+    super();
   }
 
   @Override
@@ -44,59 +30,7 @@ public class ForkTaskBuilder extends TaskBaseBuilder<ForkTaskBuilder>
   }
 
   @Override
-  public ForkTaskBuilder compete(final boolean compete) {
-    this.forkTaskConfiguration.setCompete(compete);
-    return this;
-  }
-
-  @Override
-  public ForkTaskBuilder branches(Consumer<TaskItemListBuilder> branchesConsumer) {
-    List<TaskItem> existingBranches = this.forkTaskConfiguration.getBranches();
-
-    int currentOffset = (existingBranches == null) ? 0 : existingBranches.size();
-
-    final TaskItemListBuilder doTaskBuilder = new TaskItemListBuilder(currentOffset);
-    branchesConsumer.accept(doTaskBuilder);
-
-    List<TaskItem> newBranches = doTaskBuilder.build();
-    if (existingBranches == null || existingBranches.isEmpty()) {
-      this.forkTaskConfiguration.setBranches(newBranches);
-    } else {
-      List<TaskItem> merged = new ArrayList<>(existingBranches);
-      merged.addAll(newBranches);
-      this.forkTaskConfiguration.setBranches(merged);
-    }
-
-    return this;
-  }
-
-  @Override
-  public ForkTaskBuilder branch(String name, Consumer<TaskItemListBuilder> branchConsumer) {
-    Objects.requireNonNull(branchConsumer, "Branch consumer must not be null");
-
-    List<TaskItem> existingBranches = this.forkTaskConfiguration.getBranches();
-    int currentOffset = (existingBranches == null) ? 0 : existingBranches.size();
-    String branchName = (name == null || name.isBlank()) ? "branch-" + currentOffset : name;
-
-    TaskItemListBuilder branchItems = new TaskItemListBuilder(0);
-    branchConsumer.accept(branchItems);
-
-    TaskItem branchItem =
-        new TaskItem(branchName, new Task().withDoTask(new DoTask().withDo(branchItems.build())));
-
-    if (existingBranches == null || existingBranches.isEmpty()) {
-      this.forkTaskConfiguration.setBranches(List.of(branchItem));
-    } else {
-      List<TaskItem> merged = new ArrayList<>(existingBranches);
-      merged.add(branchItem);
-      this.forkTaskConfiguration.setBranches(merged);
-    }
-
-    return this;
-  }
-
-  @Override
-  public ForkTask build() {
-    return this.forkTask.withFork(this.forkTaskConfiguration);
+  protected TaskItemListBuilder newTaskItemListBuilder(int listOffsetSize) {
+    return new TaskItemListBuilder(listOffsetSize);
   }
 }


### PR DESCRIPTION
# Changes

This pull request introduces `AbstractForkTaskBuilder`, it centralized the fork logic having the same base implementation for `experimental` and `spec` implementations.

