### PR TITLE
Rename DSL.workflow to DSL.subflow

### DIFF
--- a/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/dsl/DSL.java
+++ b/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/dsl/DSL.java
@@ -653,7 +653,7 @@ public final class DSL {
     return list -> list.openapi(configurer);
   }
 
-  public static TasksConfigurer workflow(WorkflowConfigurer configurer) {
+  public static TasksConfigurer subflow(WorkflowConfigurer configurer) {
     return list -> list.workflow(configurer);
   }
 

--- a/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/dsl/DSL.java
+++ b/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/dsl/DSL.java
@@ -653,6 +653,21 @@ public final class DSL {
     return list -> list.openapi(configurer);
   }
 
+  /**
+   * Create a {@link TasksConfigurer} that adds a sub-workflow call task using a {@link
+   * WorkflowConfigurer}.
+   *
+   * <p>
+   *
+   * <pre>{@code
+   * tasks(
+   *  subflow(workflow("org.acme", "sub-workflow", "0.1.0").input(...)
+   * );
+   * }</pre>
+   *
+   * @param configurer
+   * @return
+   */
   public static TasksConfigurer subflow(WorkflowConfigurer configurer) {
     return list -> list.workflow(configurer);
   }

--- a/fluent/spec/src/test/java/io/serverlessworkflow/fluent/spec/dsl/DSLTest.java
+++ b/fluent/spec/src/test/java/io/serverlessworkflow/fluent/spec/dsl/DSLTest.java
@@ -25,6 +25,7 @@ import static io.serverlessworkflow.fluent.spec.dsl.DSL.http;
 import static io.serverlessworkflow.fluent.spec.dsl.DSL.openapi;
 import static io.serverlessworkflow.fluent.spec.dsl.DSL.produced;
 import static io.serverlessworkflow.fluent.spec.dsl.DSL.secrets;
+import static io.serverlessworkflow.fluent.spec.dsl.DSL.subflow;
 import static io.serverlessworkflow.fluent.spec.dsl.DSL.to;
 import static io.serverlessworkflow.fluent.spec.dsl.DSL.workflow;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -308,7 +309,7 @@ public class DSLTest {
     Workflow wf =
         WorkflowBuilder.workflow("parent", "ns", "1")
             .tasks(
-                workflow(
+                subflow(
                     workflow("child.ns", "child-flow", "2.3.4")
                         .input("id", 99)
                         .await(false)
@@ -330,7 +331,7 @@ public class DSLTest {
     Workflow wf =
         WorkflowBuilder.workflow("parent", "ns", "1")
             .tasks(
-                workflow(
+                subflow(
                     workflow("child.ns", "child-flow", "2.3.4")
                         .input(Map.of("id", 7, "region", "eu"))
                         .input("extra", true)

--- a/impl/test/src/test/java/io/serverlessworkflow/impl/test/SubWorkflowTest.java
+++ b/impl/test/src/test/java/io/serverlessworkflow/impl/test/SubWorkflowTest.java
@@ -148,7 +148,7 @@ public class SubWorkflowTest {
     Workflow parent =
         WorkflowBuilder.workflow("parentFlow", "org.acme", "1.0.0")
             .tasks(
-                DSL.workflow(
+                DSL.subflow(
                     DSL.workflow("org.acme", "childFlow", "1.0.0")
                         .input(Map.of("id", 42, "region", "us-east"))))
             .build();


### PR DESCRIPTION
# Changes

This pull request aims to change the `workflow` to `subflow`, it proposes a clear and intuitive DSL when creating subflows using Java DSL, avoind `workflow(workflow`.


Closes #1310