### PR TITLE
Add automatic URI detection for OpenAPI document configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+# Bob-Shell
+.bob/notes/

--- a/experimental/fluent/func/src/test/java/io/serverlessworkflow/fluent/func/FuncDSLTest.java
+++ b/experimental/fluent/func/src/test/java/io/serverlessworkflow/fluent/func/FuncDSLTest.java
@@ -266,7 +266,13 @@ class FuncDSLTest {
     assertEquals("GET", http.getWith().getMethod());
     assertEquals(
         "http://service/api/users",
-        http.getWith().getEndpoint().getUriTemplate().getLiteralUri().toString(),
+        http.getWith()
+            .getEndpoint()
+            .getEndpointConfiguration()
+            .getUri()
+            .getLiteralEndpointURI()
+            .getLiteralUri()
+            .toString(),
         "endpoint should be set from get(name, endpoint, auth)");
 
     assertNotNull(
@@ -304,7 +310,13 @@ class FuncDSLTest {
     assertEquals("GET", http.getWith().getMethod());
     assertEquals(
         endpoint.toString(),
-        http.getWith().getEndpoint().getUriTemplate().getLiteralUri().toString(),
+        http.getWith()
+            .getEndpoint()
+            .getEndpointConfiguration()
+            .getUri()
+            .getLiteralEndpointURI()
+            .getLiteralUri()
+            .toString(),
         "endpoint should be derived from URI");
 
     assertNotNull(http.getWith().getEndpoint().getEndpointConfiguration().getAuthentication());
@@ -371,7 +383,13 @@ class FuncDSLTest {
     assertEquals("POST", http.getWith().getMethod());
     assertEquals(
         "https://orders.example.com/api/orders",
-        http.getWith().getEndpoint().getUriTemplate().getLiteralUri().toString());
+        http.getWith()
+            .getEndpoint()
+            .getEndpointConfiguration()
+            .getUri()
+            .getLiteralEndpointURI()
+            .getLiteralUri()
+            .toString());
     assertEquals(body, http.getWith().getBody());
 
     assertNotNull(http.getWith().getEndpoint().getEndpointConfiguration().getAuthentication());
@@ -409,7 +427,13 @@ class FuncDSLTest {
     assertEquals("POST", http.getWith().getMethod());
     assertEquals(
         "http://service/api",
-        http.getWith().getEndpoint().getUriTemplate().getLiteralUri().toString());
+        http.getWith()
+            .getEndpoint()
+            .getEndpointConfiguration()
+            .getUri()
+            .getLiteralEndpointURI()
+            .getLiteralUri()
+            .toString());
     assertEquals(
         "svc-auth",
         http.getWith()

--- a/experimental/test/pom.xml
+++ b/experimental/test/pom.xml
@@ -71,6 +71,13 @@
         <dependency>
             <groupId>io.serverlessworkflow</groupId>
             <artifactId>serverlessworkflow-impl-jq</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.serverlessworkflow</groupId>
+            <artifactId>serverlessworkflow-impl-openapi</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>

--- a/experimental/test/src/test/java/io/serverlessworkflow/fluent/test/FuncOpenAPITest.java
+++ b/experimental/test/src/test/java/io/serverlessworkflow/fluent/test/FuncOpenAPITest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.fluent.test;
+
+import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.openapi;
+
+import io.serverlessworkflow.fluent.func.FuncWorkflowBuilder;
+import io.serverlessworkflow.impl.WorkflowApplication;
+import io.serverlessworkflow.impl.WorkflowDefinition;
+import io.serverlessworkflow.impl.WorkflowInstance;
+import io.serverlessworkflow.impl.WorkflowModel;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import okhttp3.Headers;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class FuncOpenAPITest {
+
+  private static MockWebServer mockWebServer;
+
+  @BeforeEach
+  public void setup() throws IOException {
+    mockWebServer = new MockWebServer();
+    mockWebServer.start(0);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    mockWebServer.close();
+  }
+
+  @Test
+  void test_openapi_document_with_non_jq_uri_string() {
+    String mockedSwaggerDoc =
+        """
+                {
+                  "swagger": "2.0",
+                  "info": { "version": "1.0.0", "title": "Mock Petstore" },
+                  "host": "localhost:%d",
+                  "basePath": "/v2",
+                  "schemes": [ "http" ],
+                  "paths": {
+                    "/pet/findByStatus": {
+                      "get": {
+                        "operationId": "findPetsByStatus",
+                        "parameters": [
+                          {
+                            "name": "status",
+                            "in": "query",
+                            "required": true,
+                            "type": "string"
+                          }
+                        ],
+                        "responses": { "200": { "description": "OK" } }
+                      }
+                    }
+                  }
+                }
+                """
+            .formatted(mockWebServer.getPort());
+
+    mockWebServer.enqueue(
+        new MockResponse(200, Headers.of("Content-Type", "application/json"), mockedSwaggerDoc));
+    mockWebServer.enqueue(
+        new MockResponse(
+            200,
+            Headers.of("Content-Type", "application/json"),
+            """
+                { "description": "OK" }
+                """));
+    var w =
+        FuncWorkflowBuilder.workflow("openapi-call-workflow")
+            .tasks(
+                openapi()
+                    .document(URI.create(mockWebServer.url("/v2/swagger.json").toString()))
+                    .operation("findPetsByStatus")
+                    .parameters(Map.of("status", "available")))
+            .build();
+
+    try (WorkflowApplication app = WorkflowApplication.builder().build()) {
+
+      WorkflowDefinition def = app.workflowDefinition(w);
+      WorkflowInstance instance = def.instance(Map.of());
+      WorkflowModel model = instance.start().join();
+
+      SoftAssertions.assertSoftly(
+          softly -> {
+            softly.assertThat(model).isNotNull();
+            softly.assertThat(model.asMap()).contains(Map.of("description", "OK"));
+          });
+    }
+  }
+}

--- a/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/spi/CallHttpTaskFluent.java
+++ b/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/spi/CallHttpTaskFluent.java
@@ -50,6 +50,12 @@ public interface CallHttpTaskFluent<SELF extends TaskBaseBuilder<SELF>> {
     return self();
   }
 
+  /**
+   * Sets the endpoint URI for the HTTP call.
+   *
+   * @param endpoint the URI to call
+   * @return this builder instance for method chaining
+   */
   default SELF endpoint(URI endpoint) {
     ((CallHTTP) this.self().getTask())
         .getWith()
@@ -57,10 +63,16 @@ public interface CallHttpTaskFluent<SELF extends TaskBaseBuilder<SELF>> {
     return self();
   }
 
+  /**
+   * Sets the endpoint URI for the HTTP call with authentication configuration.
+   *
+   * @param endpoint the URI to call
+   * @param auth consumer to configure authentication policy
+   * @return this builder instance for method chaining
+   */
   default SELF endpoint(URI endpoint, Consumer<ReferenceableAuthenticationPolicyBuilder> auth) {
     final ReferenceableAuthenticationPolicyBuilder policy =
         new ReferenceableAuthenticationPolicyBuilder();
-    final UriTemplate uriTemplate = new UriTemplate().withLiteralUri(endpoint);
     auth.accept(policy);
     ((CallHTTP) this.self().getTask())
         .getWith()
@@ -68,39 +80,59 @@ public interface CallHttpTaskFluent<SELF extends TaskBaseBuilder<SELF>> {
             new Endpoint()
                 .withEndpointConfiguration(
                     new EndpointConfiguration()
-                        .withUri(new EndpointUri().withLiteralEndpointURI(uriTemplate))
-                        .withAuthentication(policy.build()))
-                .withUriTemplate(uriTemplate));
+                        .withUri(
+                            new EndpointUri()
+                                .withLiteralEndpointURI(new UriTemplate().withLiteralUri(endpoint)))
+                        .withAuthentication(policy.build())));
     return self();
   }
 
+  /**
+   * Sets the endpoint using a runtime expression or URI string.
+   *
+   * @param expr the runtime expression or URI string for the endpoint
+   * @return this builder instance for method chaining
+   */
   default SELF endpoint(String expr) {
     ((CallHTTP) this.self().getTask()).getWith().setEndpoint(EndpointUtil.fromString(expr));
     return self();
   }
 
+  /**
+   * Sets the endpoint using a runtime expression or URI string with authentication configuration.
+   *
+   * @param expr the runtime expression or URI string for the endpoint
+   * @param auth consumer to configure authentication policy
+   * @return this builder instance for method chaining
+   */
   default SELF endpoint(String expr, Consumer<ReferenceableAuthenticationPolicyBuilder> auth) {
     final ReferenceableAuthenticationPolicyBuilder policy =
         new ReferenceableAuthenticationPolicyBuilder();
     auth.accept(policy);
 
-    final Endpoint endpoint = EndpointUtil.fromString(expr);
-    endpoint.setEndpointConfiguration(
-        new EndpointConfiguration().withAuthentication(policy.build()));
-
-    ((CallHTTP) this.self().getTask()).getWith().setEndpoint(endpoint);
+    ((CallHTTP) this.self().getTask())
+        .getWith()
+        .setEndpoint(EndpointUtil.fromString(expr, policy.build()));
     return self();
   }
 
+  /**
+   * Sets the endpoint using a runtime expression or URI string with authentication policy
+   * reference.
+   *
+   * @param expr the runtime expression or URI string for the endpoint
+   * @param authUse the name of the authentication policy to reference
+   * @return this builder instance for method chaining
+   */
   default SELF endpoint(String expr, String authUse) {
-    final Endpoint endpoint = EndpointUtil.fromString(expr);
-    endpoint.withEndpointConfiguration(
-        new EndpointConfiguration()
-            .withAuthentication(
+    ((CallHTTP) this.self().getTask())
+        .getWith()
+        .setEndpoint(
+            EndpointUtil.fromString(
+                expr,
                 new ReferenceableAuthenticationPolicy()
                     .withAuthenticationPolicyReference(
                         new AuthenticationPolicyReference(authUse))));
-    ((CallHTTP) this.self().getTask()).getWith().setEndpoint(endpoint);
     return self();
   }
 

--- a/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/spi/CallOpenAPITaskFluent.java
+++ b/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/spi/CallOpenAPITaskFluent.java
@@ -21,6 +21,7 @@ import io.serverlessworkflow.api.types.EndpointConfiguration;
 import io.serverlessworkflow.api.types.EndpointUri;
 import io.serverlessworkflow.api.types.ExternalResource;
 import io.serverlessworkflow.api.types.OpenAPIArguments;
+import io.serverlessworkflow.api.types.ReferenceableAuthenticationPolicy;
 import io.serverlessworkflow.api.types.UriTemplate;
 import io.serverlessworkflow.fluent.spec.ReferenceableAuthenticationPolicyBuilder;
 import io.serverlessworkflow.fluent.spec.TaskBaseBuilder;
@@ -40,11 +41,19 @@ public interface CallOpenAPITaskFluent<SELF extends TaskBaseBuilder<SELF>> {
 
   SELF self();
 
+  /**
+   * Sets the OpenAPI document location. This method automatically detects whether the provided
+   * string is a literal URI or a JQ runtime expression.
+   *
+   * @param uri the OpenAPI document location as either a literal URI string or a JQ expression
+   * @return this builder instance for method chaining
+   * @see #document(URI) for setting a literal URI directly
+   * @see #document(String, AuthenticationConfigurer) for setting a document with authentication
+   */
   default SELF document(String uri) {
     ((CallOpenAPI) this.self().getTask())
         .getWith()
-        .withDocument(
-            new ExternalResource().withEndpoint(new Endpoint().withRuntimeExpression(uri)));
+        .setDocument(new ExternalResource().withEndpoint(EndpointUtil.fromString(uri)));
     return self();
   }
 
@@ -62,18 +71,11 @@ public interface CallOpenAPITaskFluent<SELF extends TaskBaseBuilder<SELF>> {
     final ReferenceableAuthenticationPolicyBuilder policy =
         new ReferenceableAuthenticationPolicyBuilder();
     authenticationConfigurer.accept(policy);
-    ((CallOpenAPI) this.self().getTask()).getWith().setAuthentication(policy.build());
+    ReferenceableAuthenticationPolicy auth = policy.build();
+    ((CallOpenAPI) this.self().getTask()).getWith().setAuthentication(auth);
     ((CallOpenAPI) this.self().getTask())
         .getWith()
-        .setDocument(
-            new ExternalResource()
-                .withEndpoint(
-                    new Endpoint()
-                        .withRuntimeExpression(uri)
-                        .withEndpointConfiguration(
-                            new EndpointConfiguration()
-                                .withUri(new EndpointUri().withExpressionEndpointURI(uri))
-                                .withAuthentication(policy.build()))));
+        .setDocument(new ExternalResource().withEndpoint(EndpointUtil.fromString(uri, auth)));
     return self();
   }
 
@@ -81,22 +83,21 @@ public interface CallOpenAPITaskFluent<SELF extends TaskBaseBuilder<SELF>> {
     final ReferenceableAuthenticationPolicyBuilder policy =
         new ReferenceableAuthenticationPolicyBuilder();
     authenticationConfigurer.accept(policy);
-
-    ((CallOpenAPI) this.self().getTask()).getWith().setAuthentication(policy.build());
+    ReferenceableAuthenticationPolicy auth = policy.build();
+    ((CallOpenAPI) this.self().getTask()).getWith().setAuthentication(auth);
     ((CallOpenAPI) this.self().getTask())
         .getWith()
         .setDocument(
             new ExternalResource()
                 .withEndpoint(
                     new Endpoint()
-                        .withUriTemplate(new UriTemplate().withLiteralUri(uri))
                         .withEndpointConfiguration(
                             new EndpointConfiguration()
                                 .withUri(
                                     new EndpointUri()
                                         .withLiteralEndpointURI(
                                             new UriTemplate().withLiteralUri(uri)))
-                                .withAuthentication(policy.build()))));
+                                .withAuthentication(auth))));
     return self();
   }
 

--- a/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/spi/EndpointUtil.java
+++ b/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/spi/EndpointUtil.java
@@ -16,6 +16,9 @@
 package io.serverlessworkflow.fluent.spec.spi;
 
 import io.serverlessworkflow.api.types.Endpoint;
+import io.serverlessworkflow.api.types.EndpointConfiguration;
+import io.serverlessworkflow.api.types.EndpointUri;
+import io.serverlessworkflow.api.types.ReferenceableAuthenticationPolicy;
 import io.serverlessworkflow.api.types.UriTemplate;
 import java.net.URI;
 import java.util.Objects;
@@ -24,25 +27,46 @@ public final class EndpointUtil {
 
   private EndpointUtil() {}
 
-  public static Endpoint fromString(String expr) {
-    Objects.requireNonNull(expr, "Endpoint expression cannot be null");
-    String trimmed = expr.trim();
-    Endpoint endpoint = new Endpoint();
-    if (isUrlLike(trimmed)) {
-      UriTemplate template = new UriTemplate();
-      if (trimmed.indexOf('{') >= 0 || trimmed.indexOf('}') >= 0) {
-        template.setLiteralUriTemplate(trimmed);
-      } else {
-        template.setLiteralUri(URI.create(trimmed));
-      }
-      endpoint.setUriTemplate(template);
-      return endpoint;
-    }
+  public static Endpoint fromString(String uri) {
+    return fromString(uri, null);
+  }
 
-    // Let the runtime engine to verify if it's a valid jq expression since ${} it's not the only
-    // way of checking it.
-    endpoint.setRuntimeExpression(expr);
+  public static Endpoint fromString(String uri, ReferenceableAuthenticationPolicy auth) {
+    Objects.requireNonNull(uri, "Endpoint URI cannot be null");
+    String trimmed = uri.trim();
+    Endpoint endpoint = new Endpoint();
+
+    if (auth != null) {
+      endpoint.setEndpointConfiguration(
+          new EndpointConfiguration(buildEndpointUri(trimmed)).withAuthentication(auth));
+    } else if (isUrlLike(trimmed)) {
+      endpoint.setUriTemplate(buildUriTemplate(trimmed));
+    } else {
+      // Let the runtime engine to verify if it's a valid jq expression since ${} it's not the only
+      // way of checking it.
+      endpoint.setRuntimeExpression(uri);
+    }
     return endpoint;
+  }
+
+  private static EndpointUri buildEndpointUri(String uri) {
+    EndpointUri endpointUri = new EndpointUri();
+    if (isUrlLike(uri)) {
+      endpointUri.setLiteralEndpointURI(buildUriTemplate(uri));
+    } else {
+      endpointUri.setExpressionEndpointURI(uri);
+    }
+    return endpointUri;
+  }
+
+  private static UriTemplate buildUriTemplate(String trimmed) {
+    UriTemplate template = new UriTemplate();
+    if (trimmed.indexOf('{') >= 0 || trimmed.indexOf('}') >= 0) {
+      template.setLiteralUriTemplate(trimmed);
+    } else {
+      template.setLiteralUri(URI.create(trimmed));
+    }
+    return template;
   }
 
   private static boolean isUrlLike(String value) {

--- a/fluent/spec/src/test/java/io/serverlessworkflow/fluent/spec/dsl/CallHttpAuthDslTest.java
+++ b/fluent/spec/src/test/java/io/serverlessworkflow/fluent/spec/dsl/CallHttpAuthDslTest.java
@@ -47,7 +47,8 @@ public class CallHttpAuthDslTest {
     assertThat(wf.getDo().get(0).getTask().getCallTask().get()).isNotNull();
 
     // Endpoint expression is set
-    assertThat(args.getEndpoint().getRuntimeExpression()).isEqualTo(EXPR_ENDPOINT);
+    assertThat(args.getEndpoint().getEndpointConfiguration().getUri().getExpressionEndpointURI())
+        .isEqualTo(EXPR_ENDPOINT);
 
     // Auth populated: BASIC (others null)
     var auth =
@@ -83,7 +84,8 @@ public class CallHttpAuthDslTest {
 
     var args = wf.getDo().get(0).getTask().getCallTask().getCallHTTP().getWith();
 
-    assertThat(args.getEndpoint().getRuntimeExpression()).isEqualTo(EXPR_ENDPOINT);
+    assertThat(args.getEndpoint().getEndpointConfiguration().getUri().getExpressionEndpointURI())
+        .isEqualTo(EXPR_ENDPOINT);
 
     var auth =
         args.getEndpoint().getEndpointConfiguration().getAuthentication().getAuthenticationPolicy();
@@ -112,7 +114,8 @@ public class CallHttpAuthDslTest {
 
     var args = wf.getDo().get(0).getTask().getCallTask().getCallHTTP().getWith();
 
-    assertThat(args.getEndpoint().getRuntimeExpression()).isEqualTo(EXPR_ENDPOINT);
+    assertThat(args.getEndpoint().getEndpointConfiguration().getUri().getExpressionEndpointURI())
+        .isEqualTo(EXPR_ENDPOINT);
 
     var auth =
         args.getEndpoint().getEndpointConfiguration().getAuthentication().getAuthenticationPolicy();
@@ -158,7 +161,8 @@ public class CallHttpAuthDslTest {
 
     var args = wf.getDo().get(0).getTask().getCallTask().getCallHTTP().getWith();
 
-    assertThat(args.getEndpoint().getRuntimeExpression()).isEqualTo(EXPR_ENDPOINT);
+    assertThat(args.getEndpoint().getEndpointConfiguration().getUri().getExpressionEndpointURI())
+        .isEqualTo(EXPR_ENDPOINT);
 
     var auth =
         args.getEndpoint().getEndpointConfiguration().getAuthentication().getAuthenticationPolicy();
@@ -203,7 +207,8 @@ public class CallHttpAuthDslTest {
 
     var args = wf.getDo().get(0).getTask().getCallTask().getCallHTTP().getWith();
 
-    assertThat(args.getEndpoint().getRuntimeExpression()).isEqualTo(EXPR_ENDPOINT);
+    assertThat(args.getEndpoint().getEndpointConfiguration().getUri().getExpressionEndpointURI())
+        .isEqualTo(EXPR_ENDPOINT);
 
     var auth =
         args.getEndpoint().getEndpointConfiguration().getAuthentication().getAuthenticationPolicy();
@@ -237,7 +242,13 @@ public class CallHttpAuthDslTest {
 
     var args = wf.getDo().get(0).getTask().getCallTask().getCallHTTP().getWith();
 
-    assertThat(args.getEndpoint().getUriTemplate().getLiteralUri().toString())
+    assertThat(
+            args.getEndpoint()
+                .getEndpointConfiguration()
+                .getUri()
+                .getLiteralEndpointURI()
+                .getLiteralUri()
+                .toString())
         .isEqualTo("https://api.example.com/v1/resource");
 
     var auth =

--- a/fluent/spec/src/test/java/io/serverlessworkflow/fluent/spec/dsl/CallOpenApiDslTest.java
+++ b/fluent/spec/src/test/java/io/serverlessworkflow/fluent/spec/dsl/CallOpenApiDslTest.java
@@ -55,7 +55,13 @@ public class CallOpenApiDslTest {
     // Document and endpoint expression
     assertThat(with.getDocument()).isNotNull();
     assertThat(with.getDocument().getEndpoint()).isNotNull();
-    assertThat(with.getDocument().getEndpoint().getRuntimeExpression()).isEqualTo(EXPR_DOCUMENT);
+    assertThat(
+            with.getDocument()
+                .getEndpoint()
+                .getEndpointConfiguration()
+                .getUri()
+                .getExpressionEndpointURI())
+        .isEqualTo(EXPR_DOCUMENT);
 
     // Endpoint configuration URI expression
     var endpointConfig = with.getDocument().getEndpoint().getEndpointConfiguration();


### PR DESCRIPTION
# Changes

- Enhanced CallOpenAPITaskFluent.document(String) to automatically detect whether the input is a literal URI or a JQ runtime expression
- Added EndpointUtil.isJqExpr() helper method to identify JQ expressions (strings starting with "${" )
- Added comprehensive test coverage with FuncOpenAPITest using MockWebServer
- Added serverlessworkflow-impl-openapi dependency to experimental/test module
- Updated .gitignore to exclude Bob-Shell notes directory

The document() method now intelligently handles both:
  - Literal URI strings (e.g., "http://example.com/swagger.json")
  - JQ runtime expressions (e.g., "${.openapi.url}")

This improves the developer experience by eliminating the need to choose between document(String) and document(URI) methods based on the input type.

Closes #1303