### PR TITLE
[NO-ISSUE] Add instance() method with no argument

### DIFF
--- a/impl/core/src/main/java/io/serverlessworkflow/impl/WorkflowDefinition.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/WorkflowDefinition.java
@@ -130,7 +130,7 @@ public class WorkflowDefinition implements AutoCloseable, WorkflowDefinitionData
   }
 
   public WorkflowInstance instance() {
-    return instance(Map.of());
+    return instance(null);
   }
 
   Optional<SchemaValidator> inputSchemaValidator() {

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/WorkflowDefinition.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/WorkflowDefinition.java
@@ -129,6 +129,10 @@ public class WorkflowDefinition implements AutoCloseable, WorkflowDefinitionData
     return new WorkflowMutableInstance(this, application().idFactory().get(), inputModel);
   }
 
+  public WorkflowInstance instance() {
+    return instance(Map.of());
+  }
+
   Optional<SchemaValidator> inputSchemaValidator() {
     return inputSchemaValidator;
   }

--- a/impl/test/src/test/java/io/serverlessworkflow/impl/test/OpenAPITest.java
+++ b/impl/test/src/test/java/io/serverlessworkflow/impl/test/OpenAPITest.java
@@ -149,7 +149,7 @@ public class OpenAPITest {
             .setResponseCode(201));
 
     Map<String, Object> result =
-        app.workflowDefinition(workflow).instance(Map.of()).start().get().asMap().orElseThrow();
+        app.workflowDefinition(workflow).instance().start().get().asMap().orElseThrow();
 
     RecordedRequest restRequest = restServer.takeRequest();
     assertEquals("POST", restRequest.getMethod());
@@ -196,7 +196,7 @@ public class OpenAPITest {
             Exception.class,
             () ->
                 app.workflowDefinition(workflow)
-                    .instance(Map.of())
+                    .instance()
                     .start()
                     .get()
                     .asMap()
@@ -244,11 +244,11 @@ public class OpenAPITest {
             .setResponseCode(200));
 
     WorkflowDefinition definition = app.workflowDefinition(workflow);
-    assertData(definition.instance(Map.of()).start().get().asMap().orElseThrow());
+    assertData(definition.instance().start().get().asMap().orElseThrow());
     RecordedRequest openAPIRequest = openApiServer.takeRequest();
     assertEquals("GET", openAPIRequest.getMethod());
 
-    assertData(definition.instance(Map.of()).start().get().asMap().orElseThrow());
+    assertData(definition.instance().start().get().asMap().orElseThrow());
     openAPIRequest = openApiServer.takeRequest();
     assertEquals("HEAD", openAPIRequest.getMethod());
   }

--- a/impl/test/src/test/java/io/serverlessworkflow/impl/test/OpenAPITest.java
+++ b/impl/test/src/test/java/io/serverlessworkflow/impl/test/OpenAPITest.java
@@ -194,13 +194,7 @@ public class OpenAPITest {
     Exception exception =
         assertThrows(
             Exception.class,
-            () ->
-                app.workflowDefinition(workflow)
-                    .instance()
-                    .start()
-                    .get()
-                    .asMap()
-                    .orElseThrow());
+            () -> app.workflowDefinition(workflow).instance().start().get().asMap().orElseThrow());
     assertInstanceOf(WorkflowException.class, exception.getCause());
     assertTrue(exception.getMessage().contains("status=409"));
 

--- a/impl/test/src/test/java/io/serverlessworkflow/impl/test/SubWorkflowTest.java
+++ b/impl/test/src/test/java/io/serverlessworkflow/impl/test/SubWorkflowTest.java
@@ -42,7 +42,7 @@ public class SubWorkflowTest {
       app.workflowDefinition(workflowChild);
       Map<String, Object> result =
           app.workflowDefinition(workflowParent)
-              .instance(Map.of())
+              .instance()
               .start()
               .join()
               .asMap()
@@ -63,7 +63,7 @@ public class SubWorkflowTest {
       app.workflowDefinition(workflowChild);
       Map<String, Object> result =
           app.workflowDefinition(workflowParent)
-              .instance(Map.of())
+              .instance()
               .start()
               .join()
               .asMap()
@@ -153,7 +153,7 @@ public class SubWorkflowTest {
     try (WorkflowApplication app = WorkflowApplication.builder().build()) {
       app.workflowDefinition(child);
       Map<String, Object> result =
-          app.workflowDefinition(parent).instance(Map.of()).start().join().asMap().orElseThrow();
+          app.workflowDefinition(parent).instance().start().join().asMap().orElseThrow();
       assertThat(result.get("counter"), is(equalTo(1)));
       assertThat(result.get("greeting"), is(equalTo("helloWorld")));
     }
@@ -181,7 +181,7 @@ public class SubWorkflowTest {
       app.workflowDefinition(child);
       app.workflowDefinition(update);
       Map<String, Object> result =
-          app.workflowDefinition(parent).instance(Map.of()).start().join().asMap().orElseThrow();
+          app.workflowDefinition(parent).instance().start().join().asMap().orElseThrow();
       assertThat(result.get("counter"), is(equalTo(2)));
       assertThat(result.get("greeting"), is(equalTo("helloWorld")));
     }

--- a/impl/test/src/test/java/io/serverlessworkflow/impl/test/SubWorkflowTest.java
+++ b/impl/test/src/test/java/io/serverlessworkflow/impl/test/SubWorkflowTest.java
@@ -41,12 +41,7 @@ public class SubWorkflowTest {
     try (WorkflowApplication app = WorkflowApplication.builder().build()) {
       app.workflowDefinition(workflowChild);
       Map<String, Object> result =
-          app.workflowDefinition(workflowParent)
-              .instance()
-              .start()
-              .join()
-              .asMap()
-              .orElseThrow();
+          app.workflowDefinition(workflowParent).instance().start().join().asMap().orElseThrow();
       assertThat(result.get("counter"), is(equalTo(1)));
       assertThat(result.get("greeting"), is(equalTo("helloWorld")));
     }
@@ -62,12 +57,7 @@ public class SubWorkflowTest {
     try (WorkflowApplication app = WorkflowApplication.builder().build()) {
       app.workflowDefinition(workflowChild);
       Map<String, Object> result =
-          app.workflowDefinition(workflowParent)
-              .instance()
-              .start()
-              .join()
-              .asMap()
-              .orElseThrow();
+          app.workflowDefinition(workflowParent).instance().start().join().asMap().orElseThrow();
       assertThat(result.get("counter"), is(equalTo(1)));
       assertThat(result.get("greeting"), is(equalTo("helloWorld")));
     }


### PR DESCRIPTION
# Changes
                                                                                                                                       
* Add convenience method instance() that creates a workflow instance with empty input parameters by delegating to instance(null). This simplifies the API when no input data is needed.                                                                                                                                                        