### PR TITLE
fix: populate instanceData().output() before onWorkflowCompleted fires

### DIFF
--- a/impl/core/src/main/java/io/serverlessworkflow/impl/WorkflowMutableInstance.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/WorkflowMutableInstance.java
@@ -56,6 +56,8 @@ public class WorkflowMutableInstance implements WorkflowInstance {
   private Lock statusLock = new ReentrantLock();
   private Map<CompletableFuture<TaskContext>, TaskContext> suspended;
 
+  private volatile WorkflowModel completedOutput;
+
   private Collection<CompletableFuture<?>> cancelables = new ArrayList<>();
 
   protected WorkflowMutableInstance(WorkflowDefinition definition, String id, WorkflowModel input) {
@@ -140,6 +142,10 @@ public class WorkflowMutableInstance implements WorkflowInstance {
             .map(f -> f.apply(workflowContext, null, node))
             .orElse(node);
     workflowContext.definition().outputSchemaValidator().ifPresent(v -> v.validate(output));
+    // Store before onWorkflowCompleted fires so instanceData().output() is available in the hook.
+    // futureRef is set after startExecution() returns, which is too late for synchronous
+    // workflows where the CompletableFuture chain completes inline on the calling thread.
+    this.completedOutput = output;
     status(WorkflowStatus.COMPLETED);
     return output;
   }
@@ -176,6 +182,9 @@ public class WorkflowMutableInstance implements WorkflowInstance {
 
   @Override
   public WorkflowModel output() {
+    if (completedOutput != null) {
+      return completedOutput;
+    }
     CompletableFuture<WorkflowModel> future = futureRef.get();
     return future != null ? future.join() : null;
   }

--- a/impl/test/src/test/java/io/serverlessworkflow/impl/test/WorkflowExecutionListenerOutputTest.java
+++ b/impl/test/src/test/java/io/serverlessworkflow/impl/test/WorkflowExecutionListenerOutputTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.impl.test;
+
+import static io.serverlessworkflow.api.WorkflowReader.readWorkflowFromClasspath;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.serverlessworkflow.impl.WorkflowApplication;
+import io.serverlessworkflow.impl.WorkflowModel;
+import io.serverlessworkflow.impl.lifecycle.WorkflowCompletedEvent;
+import io.serverlessworkflow.impl.lifecycle.WorkflowExecutionListener;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that {@code instanceData().output()} is populated inside {@code onWorkflowCompleted}.
+ *
+ * <p>For synchronous workflows the {@code CompletableFuture} chain in {@code
+ * WorkflowMutableInstance.startExecution()} completes inline on the calling thread. {@code
+ * futureRef} is set only after the chain returns, so {@code instanceData().output()} — which routes
+ * through {@code futureRef.get().join()} — was returning {@code null} when called from inside the
+ * hook. The fix stores the output in {@code whenSuccess()} before the completion event fires.
+ */
+class WorkflowExecutionListenerOutputTest {
+
+  @Test
+  void instanceDataOutputIsAvailableInsideOnWorkflowCompleted() throws IOException {
+    AtomicReference<WorkflowModel> capturedOutput = new AtomicReference<>();
+
+    WorkflowExecutionListener listener =
+        new WorkflowExecutionListener() {
+          @Override
+          public void onWorkflowCompleted(WorkflowCompletedEvent event) {
+            capturedOutput.set(event.workflowContext().instanceData().output());
+          }
+        };
+
+    try (WorkflowApplication app = WorkflowApplication.builder().withListener(listener).build()) {
+      WorkflowModel result =
+          app.workflowDefinition(
+                  readWorkflowFromClasspath("workflows-samples/simple-expression.yaml"))
+              .instance(Map.of())
+              .start()
+              .join();
+
+      assertThat(result).isNotNull();
+      assertThat(capturedOutput.get())
+          .as(
+              "instanceData().output() must be non-null inside onWorkflowCompleted — "
+                  + "it was null because futureRef is set after startExecution() returns, "
+                  + "which is after the synchronous CompletableFuture chain completes")
+          .isNotNull();
+      assertThat(capturedOutput.get().asMap())
+          .as("instanceData().output() inside the hook must equal the workflow's final output")
+          .isEqualTo(result.asMap());
+    }
+  }
+
+  @Test
+  void eventOutputMatchesInstanceDataOutput() throws IOException {
+    AtomicReference<WorkflowModel> eventOutput = new AtomicReference<>();
+    AtomicReference<WorkflowModel> instanceOutput = new AtomicReference<>();
+
+    WorkflowExecutionListener listener =
+        new WorkflowExecutionListener() {
+          @Override
+          public void onWorkflowCompleted(WorkflowCompletedEvent event) {
+            eventOutput.set(event.output());
+            instanceOutput.set(event.workflowContext().instanceData().output());
+          }
+        };
+
+    try (WorkflowApplication app = WorkflowApplication.builder().withListener(listener).build()) {
+      app.workflowDefinition(readWorkflowFromClasspath("workflows-samples/simple-expression.yaml"))
+          .instance(Map.of())
+          .start()
+          .join();
+
+      assertThat(eventOutput.get())
+          .as("event.output() must be non-null — it is passed directly to WorkflowCompletedEvent")
+          .isNotNull();
+      assertThat(instanceOutput.get())
+          .as(
+              "instanceData().output() must equal event.output() — both should carry the same value")
+          .isEqualTo(eventOutput.get());
+    }
+  }
+}


### PR DESCRIPTION
## Problem

`instanceData().output()` returns `null` when called inside `onWorkflowCompleted` for synchronous workflows.

**Root cause:** In `WorkflowMutableInstance.startExecution()`, the completed `future` is assigned to `futureRef` at line 111 **after** the `CompletableFuture` chain is composed. For synchronous workflows (e.g. simple set-task or Java function tasks), the chain completes inline on the calling thread before `futureRef.set(future)` is reached. `output()` routes through `futureRef.get().join()`, so it returns `null` inside the hook.

Note: `event.output()` on `WorkflowCompletedEvent` already carries the output correctly — that's a separate field passed directly to the constructor. The bug only affects `instanceData().output()`.

## Fix

Store the computed output in a `volatile` field inside `whenSuccess()`, which runs in the chain **before** the completion event is published. `output()` reads that field first, falling back to `futureRef` for callers who retrieve output after `start()` returns.

The change is three lines:

```java
// new field
private volatile WorkflowModel completedOutput;

// in whenSuccess() — store before onWorkflowCompleted fires
this.completedOutput = output;

// in output() — read it first
if (completedOutput != null) return completedOutput;
```

## Test

Adds `WorkflowExecutionListenerOutputTest` with two regression tests:

1. `instanceDataOutputIsAvailableInsideOnWorkflowCompleted` — fails without the fix, passes with it
2. `eventOutputMatchesInstanceDataOutput` — asserts `event.output()` and `instanceData().output()` carry the same value

## Test plan

- [ ] `WorkflowExecutionListenerOutputTest` — both tests pass
- [ ] Full `impl/test` suite — 149 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)