### PR TITLE
Fix #1354 - Isolate variables in ForExecutor to avoid racing condition to overwrite loop variables

### DIFF
--- a/experimental/test/src/test/java/io/serverlessworkflow/fluent/test/ForEachFuncTest.java
+++ b/experimental/test/src/test/java/io/serverlessworkflow/fluent/test/ForEachFuncTest.java
@@ -25,7 +25,7 @@ import io.serverlessworkflow.api.types.Workflow;
 import io.serverlessworkflow.fluent.func.FuncWorkflowBuilder;
 import io.serverlessworkflow.impl.WorkflowApplication;
 import io.serverlessworkflow.impl.WorkflowModel;
-import io.serverlessworkflow.impl.events.InMemoryEvents;
+import io.serverlessworkflow.impl.lifecycle.TraceExecutionListener;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
@@ -35,13 +35,13 @@ import org.junit.jupiter.api.Test;
 
 public class ForEachFuncTest {
 
-  private static record Order(String id) {}
+  private record Order(String id) {}
 
-  private static record EnhancedOrder(String id, int salary) {}
+  private record EnhancedOrder(String id, int salary) {}
 
-  private static record OrdersPayload(List<Order> orders) {}
+  private record OrdersPayload(List<Order> orders) {}
 
-  private static record OrderName(String id, String name) {}
+  private record OrderName(String id, String name) {}
 
   @Test
   void testForEachIteration() {
@@ -75,13 +75,14 @@ public class ForEachFuncTest {
             .build();
 
     List<CloudEvent> publishedEvents = new CopyOnWriteArrayList<>();
-    InMemoryEvents eventBroker = new InMemoryEvents();
+    LaggedInMemoryEvents eventBroker = new LaggedInMemoryEvents();
     eventBroker.register(eventType, ce -> publishedEvents.add(ce));
 
     try (WorkflowApplication app =
         WorkflowApplication.builder()
             .withEventConsumer(eventBroker)
             .withEventPublisher(eventBroker)
+            .withListener(new TraceExecutionListener())
             .build()) {
       app.workflowDefinition(workflow)
           .instance(

--- a/experimental/test/src/test/java/io/serverlessworkflow/fluent/test/LaggedInMemoryEvents.java
+++ b/experimental/test/src/test/java/io/serverlessworkflow/fluent/test/LaggedInMemoryEvents.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.fluent.test;
+
+import io.cloudevents.CloudEvent;
+import io.serverlessworkflow.impl.events.InMemoryEvents;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LaggedInMemoryEvents extends InMemoryEvents {
+
+  private static final Logger logger = LoggerFactory.getLogger(InMemoryEvents.class);
+
+  @Override
+  public CompletableFuture<Void> publish(CloudEvent ce) {
+    return CompletableFuture.runAsync(
+        () -> {
+          Consumer<CloudEvent> allConsumer = allConsumerRef.get();
+          if (allConsumer != null) {
+            allConsumer.accept(ce);
+          }
+          Consumer<CloudEvent> consumer = topicMap.get(ce.getType());
+          if (consumer != null) {
+            consumer.accept(ce);
+          }
+          try {
+            Thread.sleep(10);
+          } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+          }
+          logger.info("Accepted event {} for topic {}", ce.getId(), ce.getType());
+        },
+        serviceFactory.get());
+  }
+}

--- a/experimental/test/src/test/java/io/serverlessworkflow/fluent/test/LaggedInMemoryEvents.java
+++ b/experimental/test/src/test/java/io/serverlessworkflow/fluent/test/LaggedInMemoryEvents.java
@@ -18,33 +18,20 @@ package io.serverlessworkflow.fluent.test;
 import io.cloudevents.CloudEvent;
 import io.serverlessworkflow.impl.events.InMemoryEvents;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class LaggedInMemoryEvents extends InMemoryEvents {
 
-  private static final Logger logger = LoggerFactory.getLogger(InMemoryEvents.class);
-
   @Override
   public CompletableFuture<Void> publish(CloudEvent ce) {
-    return CompletableFuture.runAsync(
-        () -> {
-          Consumer<CloudEvent> allConsumer = allConsumerRef.get();
-          if (allConsumer != null) {
-            allConsumer.accept(ce);
-          }
-          Consumer<CloudEvent> consumer = topicMap.get(ce.getType());
-          if (consumer != null) {
-            consumer.accept(ce);
-          }
-          try {
-            Thread.sleep(10);
-          } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-          }
-          logger.info("Accepted event {} for topic {}", ce.getId(), ce.getType());
-        },
-        serviceFactory.get());
+
+    return super.publish(ce)
+        .thenRun(
+            () -> {
+              try {
+                Thread.sleep(50);
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+            });
   }
 }

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/events/InMemoryEvents.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/events/InMemoryEvents.java
@@ -30,6 +30,10 @@ import java.util.function.Consumer;
  */
 public class InMemoryEvents extends AbstractTypeConsumer implements EventPublisher {
 
+  protected final ExecutorServiceFactory serviceFactory;
+  protected final Map<String, Consumer<CloudEvent>> topicMap = new ConcurrentHashMap<>();
+  protected final AtomicReference<Consumer<CloudEvent>> allConsumerRef = new AtomicReference<>();
+
   public InMemoryEvents() {
     this(new DefaultExecutorServiceFactory());
   }
@@ -37,12 +41,6 @@ public class InMemoryEvents extends AbstractTypeConsumer implements EventPublish
   public InMemoryEvents(ExecutorServiceFactory serviceFactory) {
     this.serviceFactory = serviceFactory;
   }
-
-  private ExecutorServiceFactory serviceFactory;
-
-  private Map<String, Consumer<CloudEvent>> topicMap = new ConcurrentHashMap<>();
-
-  private AtomicReference<Consumer<CloudEvent>> allConsumerRef = new AtomicReference<>();
 
   @Override
   public void register(String topicName, Consumer<CloudEvent> consumer) {

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/events/InMemoryEvents.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/events/InMemoryEvents.java
@@ -30,9 +30,9 @@ import java.util.function.Consumer;
  */
 public class InMemoryEvents extends AbstractTypeConsumer implements EventPublisher {
 
-  protected final ExecutorServiceFactory serviceFactory;
-  protected final Map<String, Consumer<CloudEvent>> topicMap = new ConcurrentHashMap<>();
-  protected final AtomicReference<Consumer<CloudEvent>> allConsumerRef = new AtomicReference<>();
+  private final ExecutorServiceFactory serviceFactory;
+  private final Map<String, Consumer<CloudEvent>> topicMap = new ConcurrentHashMap<>();
+  private final AtomicReference<Consumer<CloudEvent>> allConsumerRef = new AtomicReference<>();
 
   public InMemoryEvents() {
     this(new DefaultExecutorServiceFactory());

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/executors/ForExecutor.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/executors/ForExecutor.java
@@ -80,11 +80,8 @@ public class ForExecutor extends RegularTaskExecutor<ForTask> {
     CompletableFuture<WorkflowModel> future =
         CompletableFuture.completedFuture(taskContext.input());
     while (iter.hasNext()) {
-      // Capture iteration variables as final locals to avoid race condition with async tasks
       final Object currentItem = iter.next();
       final int currentIndex = i++;
-
-      // Set variables for condition evaluation
       taskContext.variables().put(task.getFor().getEach(), currentItem);
       taskContext.variables().put(task.getFor().getAt(), currentIndex);
 
@@ -92,8 +89,6 @@ public class ForExecutor extends RegularTaskExecutor<ForTask> {
         future =
             future.thenCompose(
                 input -> {
-                  // Set variables from captured finals before executing subtasks
-                  // This ensures each async task gets its own iteration values
                   taskContext.variables().put(task.getFor().getEach(), currentItem);
                   taskContext.variables().put(task.getFor().getAt(), currentIndex);
                   return TaskExecutorHelper.processTaskList(

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/executors/ForExecutor.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/executors/ForExecutor.java
@@ -80,14 +80,25 @@ public class ForExecutor extends RegularTaskExecutor<ForTask> {
     CompletableFuture<WorkflowModel> future =
         CompletableFuture.completedFuture(taskContext.input());
     while (iter.hasNext()) {
-      taskContext.variables().put(task.getFor().getEach(), iter.next());
-      taskContext.variables().put(task.getFor().getAt(), i++);
+      // Capture iteration variables as final locals to avoid race condition with async tasks
+      final Object currentItem = iter.next();
+      final int currentIndex = i++;
+
+      // Set variables for condition evaluation
+      taskContext.variables().put(task.getFor().getEach(), currentItem);
+      taskContext.variables().put(task.getFor().getAt(), currentIndex);
+
       if (whileExpr.map(w -> w.test(workflow, taskContext, taskContext.input())).orElse(true)) {
         future =
             future.thenCompose(
-                input ->
-                    TaskExecutorHelper.processTaskList(
-                        taskExecutor, workflow, Optional.of(taskContext), input));
+                input -> {
+                  // Set variables from captured finals before executing subtasks
+                  // This ensures each async task gets its own iteration values
+                  taskContext.variables().put(task.getFor().getEach(), currentItem);
+                  taskContext.variables().put(task.getFor().getAt(), currentIndex);
+                  return TaskExecutorHelper.processTaskList(
+                      taskExecutor, workflow, Optional.of(taskContext), input);
+                });
       } else {
         break;
       }

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/executors/ForExecutor.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/executors/ForExecutor.java
@@ -75,29 +75,30 @@ public class ForExecutor extends RegularTaskExecutor<ForTask> {
   @Override
   protected CompletableFuture<WorkflowModel> internalExecute(
       WorkflowContext workflow, TaskContext taskContext) {
-    Iterator<?> iter = collectionExpr.apply(workflow, taskContext, taskContext.input()).iterator();
-    int i = 0;
-    CompletableFuture<WorkflowModel> future =
-        CompletableFuture.completedFuture(taskContext.input());
-    while (iter.hasNext()) {
-      final Object currentItem = iter.next();
-      final int currentIndex = i++;
-      taskContext.variables().put(task.getFor().getEach(), currentItem);
-      taskContext.variables().put(task.getFor().getAt(), currentIndex);
+    return buildLoopFuture(
+        workflow,
+        taskContext,
+        taskContext.input(),
+        collectionExpr.apply(workflow, taskContext, taskContext.input()).iterator(),
+        -1);
+  }
 
-      if (whileExpr.map(w -> w.test(workflow, taskContext, taskContext.input())).orElse(true)) {
-        future =
-            future.thenCompose(
-                input -> {
-                  taskContext.variables().put(task.getFor().getEach(), currentItem);
-                  taskContext.variables().put(task.getFor().getAt(), currentIndex);
-                  return TaskExecutorHelper.processTaskList(
-                      taskExecutor, workflow, Optional.of(taskContext), input);
-                });
-      } else {
-        break;
+  private CompletableFuture<WorkflowModel> buildLoopFuture(
+      WorkflowContext workflow,
+      TaskContext taskContext,
+      WorkflowModel input,
+      Iterator<?> iter,
+      int index) {
+    final int newIndex = index + 1;
+    if (iter.hasNext()) {
+      taskContext.variables().put(task.getFor().getEach(), iter.next());
+      taskContext.variables().put(task.getFor().getAt(), newIndex);
+      if (whileExpr.map(w -> w.test(workflow, taskContext, input)).orElse(true)) {
+        return TaskExecutorHelper.processTaskList(
+                taskExecutor, workflow, Optional.of(taskContext), input)
+            .thenCompose(output -> buildLoopFuture(workflow, taskContext, output, iter, newIndex));
       }
     }
-    return future;
+    return CompletableFuture.completedFuture(input);
   }
 }

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/lifecycle/TraceExecutionListener.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/lifecycle/TraceExecutionListener.java
@@ -13,19 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.serverlessworkflow.impl.test;
+package io.serverlessworkflow.impl.lifecycle;
 
-import io.serverlessworkflow.impl.lifecycle.TaskCompletedEvent;
-import io.serverlessworkflow.impl.lifecycle.TaskFailedEvent;
-import io.serverlessworkflow.impl.lifecycle.TaskRetriedEvent;
-import io.serverlessworkflow.impl.lifecycle.TaskStartedEvent;
-import io.serverlessworkflow.impl.lifecycle.WorkflowCompletedEvent;
-import io.serverlessworkflow.impl.lifecycle.WorkflowExecutionListener;
-import io.serverlessworkflow.impl.lifecycle.WorkflowFailedEvent;
-import io.serverlessworkflow.impl.lifecycle.WorkflowResumedEvent;
-import io.serverlessworkflow.impl.lifecycle.WorkflowStartedEvent;
-import io.serverlessworkflow.impl.lifecycle.WorkflowStatusEvent;
-import io.serverlessworkflow.impl.lifecycle.WorkflowSuspendedEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/impl/test/src/test/java/io/serverlessworkflow/impl/test/DBGenerator.java
+++ b/impl/test/src/test/java/io/serverlessworkflow/impl/test/DBGenerator.java
@@ -47,7 +47,9 @@ public class DBGenerator {
             DefaultPersistenceInstanceHandlers.from(new MVStorePersistenceStore(dbName));
         WorkflowApplication application =
             PersistenceApplicationBuilder.builder(
-                    WorkflowApplication.builder().withListener(new TraceExecutionListener()),
+                    WorkflowApplication.builder()
+                        .withListener(
+                            new io.serverlessworkflow.impl.lifecycle.TraceExecutionListener()),
                     factories.writer())
                 .build()) {
       WorkflowDefinition definition =

--- a/impl/test/src/test/java/io/serverlessworkflow/impl/test/DBGenerator.java
+++ b/impl/test/src/test/java/io/serverlessworkflow/impl/test/DBGenerator.java
@@ -20,6 +20,7 @@ import static io.serverlessworkflow.api.WorkflowReader.readWorkflowFromClasspath
 import io.serverlessworkflow.impl.WorkflowApplication;
 import io.serverlessworkflow.impl.WorkflowDefinition;
 import io.serverlessworkflow.impl.WorkflowInstance;
+import io.serverlessworkflow.impl.lifecycle.TraceExecutionListener;
 import io.serverlessworkflow.impl.persistence.DefaultPersistenceInstanceHandlers;
 import io.serverlessworkflow.impl.persistence.PersistenceApplicationBuilder;
 import io.serverlessworkflow.impl.persistence.PersistenceInstanceHandlers;
@@ -47,9 +48,7 @@ public class DBGenerator {
             DefaultPersistenceInstanceHandlers.from(new MVStorePersistenceStore(dbName));
         WorkflowApplication application =
             PersistenceApplicationBuilder.builder(
-                    WorkflowApplication.builder()
-                        .withListener(
-                            new io.serverlessworkflow.impl.lifecycle.TraceExecutionListener()),
+                    WorkflowApplication.builder().withListener(new TraceExecutionListener()),
                     factories.writer())
                 .build()) {
       WorkflowDefinition definition =

--- a/impl/test/src/test/java/io/serverlessworkflow/impl/test/MvStorePersistenceTest.java
+++ b/impl/test/src/test/java/io/serverlessworkflow/impl/test/MvStorePersistenceTest.java
@@ -22,6 +22,7 @@ import io.serverlessworkflow.impl.WorkflowApplication;
 import io.serverlessworkflow.impl.WorkflowDefinition;
 import io.serverlessworkflow.impl.WorkflowInstance;
 import io.serverlessworkflow.impl.WorkflowStatus;
+import io.serverlessworkflow.impl.lifecycle.TraceExecutionListener;
 import io.serverlessworkflow.impl.persistence.DefaultPersistenceInstanceHandlers;
 import io.serverlessworkflow.impl.persistence.PersistenceApplicationBuilder;
 import io.serverlessworkflow.impl.persistence.PersistenceInstanceHandlers;
@@ -114,8 +115,7 @@ public class MvStorePersistenceTest {
             PersistenceApplicationBuilder.builder(
                     WorkflowApplication.builder()
                         .withListener(taskCounter)
-                        .withListener(
-                            new io.serverlessworkflow.impl.lifecycle.TraceExecutionListener()),
+                        .withListener(new TraceExecutionListener()),
                     handlers.writer())
                 .build(); ) {
       WorkflowDefinition definition =

--- a/impl/test/src/test/java/io/serverlessworkflow/impl/test/MvStorePersistenceTest.java
+++ b/impl/test/src/test/java/io/serverlessworkflow/impl/test/MvStorePersistenceTest.java
@@ -114,7 +114,8 @@ public class MvStorePersistenceTest {
             PersistenceApplicationBuilder.builder(
                     WorkflowApplication.builder()
                         .withListener(taskCounter)
-                        .withListener(new TraceExecutionListener()),
+                        .withListener(
+                            new io.serverlessworkflow.impl.lifecycle.TraceExecutionListener()),
                     handlers.writer())
                 .build(); ) {
       WorkflowDefinition definition =


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
Fixes #1354 

**Special notes for reviewers**:
- I changed the `InMemoryEvents` class slightly to be inherit-friendly
- Moved `TranceExecutionListener` to `impl` so it can easily be reused in other tests and in client code - it's quite useful for debugging/tracing, even in prod code.

**Additional information (if needed):**