### PR TITLE
[Fix #1395] Refining All strategy correlation persistence approach

### DIFF
--- a/impl/core/src/main/java/io/serverlessworkflow/impl/marshaller/AbstractInputBuffer.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/marshaller/AbstractInputBuffer.java
@@ -17,8 +17,6 @@ package io.serverlessworkflow.impl.marshaller;
 
 import java.net.URI;
 import java.time.Instant;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -116,10 +114,10 @@ public abstract class AbstractInputBuffer implements WorkflowInputBuffer {
         return readCustomObject();
 
       case URI:
-        return URI.create(readString());
+        return readURI();
 
       case OFFSET_DATE_TIME:
-        return OffsetDateTime.ofInstant(readInstant(), ZoneOffset.of(readString()));
+        return readOffsetDateTime();
 
       default:
         throw new IllegalStateException("Unsupported type " + type);

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/marshaller/AbstractOutputBuffer.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/marshaller/AbstractOutputBuffer.java
@@ -104,8 +104,7 @@ public abstract class AbstractOutputBuffer implements WorkflowOutputBuffer {
       writeInstant(value);
     } else if (object instanceof OffsetDateTime value) {
       writeType(Type.OFFSET_DATE_TIME);
-      writeInstant(value.toInstant());
-      writeString(value.getOffset().toString());
+      writeOffsetDateTime(value);
     } else if (object instanceof URI value) {
       writeType(Type.URI);
       writeString(value.toString());

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/marshaller/MarshallingUtils.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/marshaller/MarshallingUtils.java
@@ -78,6 +78,14 @@ public class MarshallingUtils {
     return writeValue(factory, value, (b, v) -> b.writeString(v));
   }
 
+  public static byte[] writeOffsetDateTime(WorkflowBufferFactory factory, OffsetDateTime value) {
+    return writeValue(factory, value, (b, v) -> b.writeOffsetDateTime(v));
+  }
+
+  public static byte[] writeURI(WorkflowBufferFactory factory, URI value) {
+    return writeValue(factory, value, (b, v) -> b.writeURI(v));
+  }
+
   public static byte[] writeCloudEventExtensions(WorkflowBufferFactory factory, CloudEvent event) {
     try (ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
         WorkflowOutputBuffer out = factory.output(bytesOut)) {
@@ -99,6 +107,9 @@ public class MarshallingUtils {
 
   public static CloudEventBuilder readCloudEventExtensions(
       WorkflowBufferFactory factory, byte[] value, CloudEventBuilder builder) {
+    if (value == null) {
+      return builder;
+    }
     try (ByteArrayInputStream bytesInt = new ByteArrayInputStream(value);
         WorkflowInputBuffer in = factory.input(bytesInt)) {
       return readCloudEventExtenstions(in, value, builder);
@@ -160,6 +171,14 @@ public class MarshallingUtils {
 
   public static Instant readInstant(WorkflowBufferFactory factory, byte[] value) {
     return readValue(factory, value, WorkflowInputBuffer::readInstant);
+  }
+
+  public static OffsetDateTime readOffsetDateTime(WorkflowBufferFactory factory, byte[] value) {
+    return readValue(factory, value, WorkflowInputBuffer::readOffsetDateTime);
+  }
+
+  public static URI readURI(WorkflowBufferFactory factory, byte[] value) {
+    return readValue(factory, value, WorkflowInputBuffer::readURI);
   }
 
   public static <T extends Enum<T>> T readEnum(

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/marshaller/WorkflowInputBuffer.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/marshaller/WorkflowInputBuffer.java
@@ -16,7 +16,10 @@
 package io.serverlessworkflow.impl.marshaller;
 
 import java.io.Closeable;
+import java.net.URI;
 import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Collection;
 import java.util.Map;
 
@@ -39,6 +42,14 @@ public interface WorkflowInputBuffer extends Closeable {
   byte readByte();
 
   byte[] readBytes();
+
+  default OffsetDateTime readOffsetDateTime() {
+    return OffsetDateTime.ofInstant(readInstant(), ZoneOffset.of(readString()));
+  }
+
+  default URI readURI() {
+    return URI.create(readString());
+  }
 
   <T extends Enum<T>> T readEnum(Class<T> enumClass);
 

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/marshaller/WorkflowOutputBuffer.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/marshaller/WorkflowOutputBuffer.java
@@ -15,7 +15,9 @@
  */
 package io.serverlessworkflow.impl.marshaller;
 
+import java.net.URI;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.Map;
 
@@ -40,6 +42,17 @@ public interface WorkflowOutputBuffer extends AutoCloseable {
   WorkflowOutputBuffer writeBytes(byte[] bytes);
 
   WorkflowOutputBuffer writeInstant(Instant instant);
+
+  default WorkflowOutputBuffer writeOffsetDateTime(OffsetDateTime time) {
+    writeInstant(time.toInstant());
+    writeString(time.getOffset().toString());
+    return this;
+  }
+
+  default WorkflowOutputBuffer writeURI(URI uri) {
+    writeString(uri.toString());
+    return this;
+  }
 
   WorkflowOutputBuffer writeMap(Map<String, Object> map);
 

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/scheduler/InMemoryAllStrategyCorrelationInfo.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/scheduler/InMemoryAllStrategyCorrelationInfo.java
@@ -17,10 +17,10 @@ package io.serverlessworkflow.impl.scheduler;
 
 import io.cloudevents.CloudEvent;
 import io.serverlessworkflow.impl.events.EventRegistrationBuilder;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -37,7 +37,7 @@ public class InMemoryAllStrategyCorrelationInfo implements AllStrategyCorrelatio
 
   private InMemoryAllStrategyCorrelationInfo() {}
 
-  private Map<EventRegistrationBuilder, List<CloudEvent>> correlatedEvents;
+  private Map<EventRegistrationBuilder, Collection<CloudEvent>> correlatedEvents;
   private Consumer<Map<EventRegistrationBuilder, CloudEvent>> starter;
 
   @Override
@@ -48,9 +48,11 @@ public class InMemoryAllStrategyCorrelationInfo implements AllStrategyCorrelatio
     synchronized (correlatedEvents) {
       correlatedEvents.get(reg).add(event);
       if (satisfyCondition(correlatedEvents)) {
-        for (java.util.Map.Entry<EventRegistrationBuilder, List<CloudEvent>> values :
+        for (java.util.Map.Entry<EventRegistrationBuilder, Collection<CloudEvent>> values :
             correlatedEvents.entrySet()) {
-          result.put(values.getKey(), values.getValue().remove(0));
+          Iterator<CloudEvent> iter = values.getValue().iterator();
+          result.put(values.getKey(), iter.next());
+          iter.remove();
         }
       }
     }
@@ -65,11 +67,11 @@ public class InMemoryAllStrategyCorrelationInfo implements AllStrategyCorrelatio
       Consumer<Map<EventRegistrationBuilder, CloudEvent>> starter) {
     correlatedEvents = new HashMap<>();
     this.starter = starter;
-    regs.forEach(reg -> correlatedEvents.put(reg, new ArrayList<CloudEvent>()));
+    regs.forEach(reg -> correlatedEvents.put(reg, new LinkedHashSet<CloudEvent>()));
   }
 
-  private boolean satisfyCondition(Map<EventRegistrationBuilder, List<CloudEvent>> events) {
-    for (List<CloudEvent> values : events.values()) {
+  private boolean satisfyCondition(Map<EventRegistrationBuilder, Collection<CloudEvent>> events) {
+    for (Collection<CloudEvent> values : events.values()) {
       if (values.isEmpty()) {
         return false;
       }

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/scheduler/ScheduledEventConsumer.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/scheduler/ScheduledEventConsumer.java
@@ -60,11 +60,10 @@ public class ScheduledEventConsumer implements AutoCloseable {
           builderInfo.registrations().registrations();
       allStrategyCorrelationInfo.init(registrationBuilders, this::start);
       registrationBuilders.forEach(
-          reg -> {
-            registrations.add(
-                eventConsumer.register(
-                    reg, ce -> allStrategyCorrelationInfo.correlate(reg, (CloudEvent) ce)));
-          });
+          reg ->
+              registrations.add(
+                  eventConsumer.register(
+                      reg, ce -> allStrategyCorrelationInfo.correlate(reg, (CloudEvent) ce))));
     } else {
       builderInfo
           .registrations()

--- a/impl/persistence/api/src/main/java/io/serverlessworkflow/impl/persistence/AbstractAllStrategyCorrelationInfo.java
+++ b/impl/persistence/api/src/main/java/io/serverlessworkflow/impl/persistence/AbstractAllStrategyCorrelationInfo.java
@@ -90,19 +90,33 @@ public abstract class AbstractAllStrategyCorrelationInfo implements AllStrategyC
       CorrelationOperations operations, String reg, CloudEvent event) {
     logger.debug(
         "Received event {} for definition {} and registration {}", event, definition.id(), reg);
+    Map<String, List<CloudEvent>> events = initMap();
+    operations.retrieveEvents(events);
+    events.get(reg).add(event);
+    Collection<Map<EventRegistrationBuilder, CloudEvent>> result = checkCorrelation(events);
     operations.storeEvent(reg, event);
-    return checkCorrelation(operations);
+    markProcessed(operations, result);
+    return result;
+  }
+
+  private Map<String, List<CloudEvent>> initMap() {
+    return id2RegMapping.keySet().stream()
+        .collect(Collectors.toMap(k -> k, k -> new ArrayList<>()));
   }
 
   private Collection<Map<EventRegistrationBuilder, CloudEvent>> startupCheck(
       CorrelationOperations operations) {
+    logger.debug("Checking cloud events for definition {}", definition.id());
     operations.clearProcessed();
-    return checkCorrelation(operations);
+    Map<String, List<CloudEvent>> events = initMap();
+    operations.retrieveEvents(events);
+    Collection<Map<EventRegistrationBuilder, CloudEvent>> result = checkCorrelation(events);
+    markProcessed(operations, result);
+    return result;
   }
 
   private final Collection<Map<EventRegistrationBuilder, CloudEvent>> checkCorrelation(
-      CorrelationOperations operations) {
-    Map<String, List<CloudEvent>> events = operations.retrieveEvents(id2RegMapping.keySet());
+      Map<String, List<CloudEvent>> events) {
     logger.debug("Stored CloudEvents for definition {} are {}", definition.id(), events);
     if (events.isEmpty()) {
       return List.of();
@@ -117,13 +131,18 @@ public abstract class AbstractAllStrategyCorrelationInfo implements AllStrategyC
           notDone = false;
           break;
         }
-        CloudEvent retrieved = list.remove(0);
-        row.put(id2RegMapping.get(item.getKey()), retrieved);
+        row.put(id2RegMapping.get(item.getKey()), list.remove(0));
       }
       if (notDone) {
         result.add(row);
       }
     }
+    return result;
+  }
+
+  private void markProcessed(
+      CorrelationOperations operations,
+      Collection<Map<EventRegistrationBuilder, CloudEvent>> result) {
     if (!result.isEmpty()) {
       Map<String, Collection<String>> processed = new HashMap<>();
       for (Map<EventRegistrationBuilder, CloudEvent> item : result) {
@@ -135,7 +154,6 @@ public abstract class AbstractAllStrategyCorrelationInfo implements AllStrategyC
       }
       operations.markAsProcessed(processed);
     }
-    return result;
   }
 
   public void addMetadata(

--- a/impl/persistence/api/src/main/java/io/serverlessworkflow/impl/persistence/AbstractAllStrategyCorrelationInfo.java
+++ b/impl/persistence/api/src/main/java/io/serverlessworkflow/impl/persistence/AbstractAllStrategyCorrelationInfo.java
@@ -23,6 +23,8 @@ import io.serverlessworkflow.impl.scheduler.AllStrategyCorrelationInfo;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -80,8 +82,16 @@ public abstract class AbstractAllStrategyCorrelationInfo implements AllStrategyC
       Consumer<Map<EventRegistrationBuilder, CloudEvent>> starter) {
     synchronized (this) {
       this.completableFuture =
-          completableFuture.thenCompose(
-              v -> executor.execute(() -> doTransaction(function), definition));
+          completableFuture
+              .thenCompose(v -> executor.execute(() -> doTransaction(function), definition))
+              .exceptionally(
+                  ex -> {
+                    logger.error(
+                        "Exception processing correlation task for definition {}",
+                        definition.id(),
+                        ex);
+                    return List.of();
+                  });
       completableFuture.thenAccept(events -> events.forEach(starter));
     }
   }
@@ -90,7 +100,7 @@ public abstract class AbstractAllStrategyCorrelationInfo implements AllStrategyC
       CorrelationOperations operations, String reg, CloudEvent event) {
     logger.debug(
         "Received event {} for definition {} and registration {}", event, definition.id(), reg);
-    Map<String, List<CloudEvent>> events = initMap();
+    Map<String, Collection<CloudEvent>> events = initMap();
     operations.retrieveEvents(events);
     events.get(reg).add(event);
     Collection<Map<EventRegistrationBuilder, CloudEvent>> result = checkCorrelation(events);
@@ -99,16 +109,16 @@ public abstract class AbstractAllStrategyCorrelationInfo implements AllStrategyC
     return result;
   }
 
-  private Map<String, List<CloudEvent>> initMap() {
+  private Map<String, Collection<CloudEvent>> initMap() {
     return id2RegMapping.keySet().stream()
-        .collect(Collectors.toMap(k -> k, k -> new ArrayList<>()));
+        .collect(Collectors.toMap(k -> k, k -> new LinkedHashSet<>()));
   }
 
   private Collection<Map<EventRegistrationBuilder, CloudEvent>> startupCheck(
       CorrelationOperations operations) {
     logger.debug("Checking cloud events for definition {}", definition.id());
     operations.clearProcessed();
-    Map<String, List<CloudEvent>> events = initMap();
+    Map<String, Collection<CloudEvent>> events = initMap();
     operations.retrieveEvents(events);
     Collection<Map<EventRegistrationBuilder, CloudEvent>> result = checkCorrelation(events);
     markProcessed(operations, result);
@@ -116,22 +126,23 @@ public abstract class AbstractAllStrategyCorrelationInfo implements AllStrategyC
   }
 
   private final Collection<Map<EventRegistrationBuilder, CloudEvent>> checkCorrelation(
-      Map<String, List<CloudEvent>> events) {
+      Map<String, Collection<CloudEvent>> events) {
     logger.debug("Stored CloudEvents for definition {} are {}", definition.id(), events);
-    if (events.isEmpty()) {
-      return List.of();
-    }
     Collection<Map<EventRegistrationBuilder, CloudEvent>> result = new ArrayList<>();
+    Map<String, Iterator<CloudEvent>> iteratingEvents =
+        events.entrySet().stream()
+            .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().iterator()));
     boolean notDone = true;
     while (notDone) {
       Map<EventRegistrationBuilder, CloudEvent> row = new HashMap<>();
-      for (Entry<String, List<CloudEvent>> item : events.entrySet()) {
-        List<CloudEvent> list = item.getValue();
-        if (list.isEmpty()) {
+      for (Entry<String, Iterator<CloudEvent>> item : iteratingEvents.entrySet()) {
+        Iterator<CloudEvent> iter = item.getValue();
+        if (!iter.hasNext()) {
           notDone = false;
           break;
         }
-        row.put(id2RegMapping.get(item.getKey()), list.remove(0));
+        row.put(id2RegMapping.get(item.getKey()), iter.next());
+        iter.remove();
       }
       if (notDone) {
         result.add(row);

--- a/impl/persistence/api/src/main/java/io/serverlessworkflow/impl/persistence/CorrelationOperations.java
+++ b/impl/persistence/api/src/main/java/io/serverlessworkflow/impl/persistence/CorrelationOperations.java
@@ -17,12 +17,11 @@ package io.serverlessworkflow.impl.persistence;
 
 import io.cloudevents.CloudEvent;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
-interface CorrelationOperations {
+public interface CorrelationOperations {
 
-  default void retrieveEvents(Map<String, List<CloudEvent>> reg2EventsMap) {}
+  default void retrieveEvents(Map<String, Collection<CloudEvent>> reg2EventsMap) {}
 
   default void storeEvent(String regId, CloudEvent event) {}
 

--- a/impl/persistence/api/src/main/java/io/serverlessworkflow/impl/persistence/CorrelationOperations.java
+++ b/impl/persistence/api/src/main/java/io/serverlessworkflow/impl/persistence/CorrelationOperations.java
@@ -22,9 +22,7 @@ import java.util.Map;
 
 interface CorrelationOperations {
 
-  default Map<String, List<CloudEvent>> retrieveEvents(Collection<String> targetRegIds) {
-    return Map.of();
-  }
+  default void retrieveEvents(Map<String, List<CloudEvent>> reg2EventsMap) {}
 
   default void storeEvent(String regId, CloudEvent event) {}
 

--- a/impl/persistence/api/src/main/java/io/serverlessworkflow/impl/persistence/OperationAllStrategyCorrelationInfo.java
+++ b/impl/persistence/api/src/main/java/io/serverlessworkflow/impl/persistence/OperationAllStrategyCorrelationInfo.java
@@ -22,7 +22,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.function.Function;
 
-class OperationAllStrategyCorrelationInfo extends AbstractAllStrategyCorrelationInfo {
+public class OperationAllStrategyCorrelationInfo extends AbstractAllStrategyCorrelationInfo {
 
   private final PersistenceInstanceOperations operations;
 

--- a/impl/persistence/api/src/main/java/io/serverlessworkflow/impl/persistence/StoreAllStrategyCorrelationInfo.java
+++ b/impl/persistence/api/src/main/java/io/serverlessworkflow/impl/persistence/StoreAllStrategyCorrelationInfo.java
@@ -24,7 +24,7 @@ import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class StoreAllStrategyCorrelationInfo extends AbstractAllStrategyCorrelationInfo {
+public class StoreAllStrategyCorrelationInfo extends AbstractAllStrategyCorrelationInfo {
 
   private static final Logger logger =
       LoggerFactory.getLogger(StoreAllStrategyCorrelationInfo.class);

--- a/impl/persistence/bigmap/src/main/java/io/serverlessworkflow/impl/persistence/bigmap/BigMapInstanceTransaction.java
+++ b/impl/persistence/bigmap/src/main/java/io/serverlessworkflow/impl/persistence/bigmap/BigMapInstanceTransaction.java
@@ -27,9 +27,7 @@ import io.serverlessworkflow.impl.persistence.PersistenceInstanceInfo;
 import io.serverlessworkflow.impl.persistence.PersistenceInstanceTransaction;
 import io.serverlessworkflow.impl.persistence.PersistenceTaskInfo;
 import io.serverlessworkflow.impl.persistence.PersistenceWorkflowInfo;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -113,26 +111,28 @@ public abstract class BigMapInstanceTransaction<V, T, S, A, C, P>
     clearStatus(workflowContext.definition(), key(workflowContext));
   }
 
-  public Map<String, List<CloudEvent>> retrieveEvents(Collection<String> targetRegIds) {
-    Map<String, List<CloudEvent>> result = new HashMap<>();
-    targetRegIds.forEach(
-        regId -> {
-          Map<String, P> processedCes = processedCloudEvents(regId);
-          Map<String, C> ces = cloudEvents(regId);
-          result.put(
-              regId,
-              ces.values().stream()
+  @Override
+  public void retrieveEvents(Map<String, List<CloudEvent>> events) {
+    events
+        .entrySet()
+        .forEach(
+            e -> {
+              String regId = e.getKey();
+              List<CloudEvent> cloudEvents = e.getValue();
+              Map<String, P> processedCes = processedCloudEvents(regId);
+              cloudEvents(regId).values().stream()
                   .map(this::unmarshallCloudEvent)
                   .filter(ce -> !processedCes.containsKey(ce.getId()))
-                  .collect(Collectors.toCollection(ArrayList::new)));
-        });
-    return result;
+                  .forEach(cloudEvents::add);
+            });
   }
 
+  @Override
   public void storeEvent(String regId, CloudEvent event) {
     cloudEvents(regId).put(event.getId(), marshallCloudEvent(event));
   }
 
+  @Override
   public void markAsProcessed(Map<String, Collection<String>> regCeIds) {
     regCeIds.forEach(
         (k, v) -> {
@@ -141,6 +141,7 @@ public abstract class BigMapInstanceTransaction<V, T, S, A, C, P>
         });
   }
 
+  @Override
   public void clearProcessed() {
     deleteAllProcessedMaps();
   }

--- a/impl/persistence/bigmap/src/main/java/io/serverlessworkflow/impl/persistence/bigmap/BigMapInstanceTransaction.java
+++ b/impl/persistence/bigmap/src/main/java/io/serverlessworkflow/impl/persistence/bigmap/BigMapInstanceTransaction.java
@@ -28,7 +28,6 @@ import io.serverlessworkflow.impl.persistence.PersistenceInstanceTransaction;
 import io.serverlessworkflow.impl.persistence.PersistenceTaskInfo;
 import io.serverlessworkflow.impl.persistence.PersistenceWorkflowInfo;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -112,18 +111,18 @@ public abstract class BigMapInstanceTransaction<V, T, S, A, C, P>
   }
 
   @Override
-  public void retrieveEvents(Map<String, List<CloudEvent>> events) {
+  public void retrieveEvents(Map<String, Collection<CloudEvent>> events) {
     events
         .entrySet()
         .forEach(
             e -> {
               String regId = e.getKey();
-              List<CloudEvent> cloudEvents = e.getValue();
+              Collection<CloudEvent> ces = e.getValue();
               Map<String, P> processedCes = processedCloudEvents(regId);
               cloudEvents(regId).values().stream()
                   .map(this::unmarshallCloudEvent)
                   .filter(ce -> !processedCes.containsKey(ce.getId()))
-                  .forEach(cloudEvents::add);
+                  .forEach(ces::add);
             });
   }
 

--- a/impl/persistence/bigmap/src/main/java/io/serverlessworkflow/impl/persistence/bigmap/BytesMapInstanceTransaction.java
+++ b/impl/persistence/bigmap/src/main/java/io/serverlessworkflow/impl/persistence/bigmap/BytesMapInstanceTransaction.java
@@ -39,6 +39,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
+import java.time.OffsetDateTime;
 
 public abstract class BytesMapInstanceTransaction
     extends BigMapInstanceTransaction<byte[], byte[], byte[], byte[], byte[], byte[]> {
@@ -205,7 +206,8 @@ public abstract class BytesMapInstanceTransaction
       writer.writeEnum(event.getSpecVersion());
       writer.writeString(event.getId());
       writer.writeString(event.getType());
-      writer.writeString(event.getSource().toString());
+      writer.writeURI(event.getSource());
+      writer.writeObject(event.getTime());
       writer.writeObject(event.getSubject());
       writer.writeObject(event.getDataSchema());
       writer.writeObject(event.getDataContentType());
@@ -224,7 +226,8 @@ public abstract class BytesMapInstanceTransaction
           CloudEventBuilder.fromSpecVersion(reader.readEnum(SpecVersion.class));
       builder.withId(reader.readString());
       builder.withType(reader.readString());
-      builder.withSource(URI.create(reader.readString()));
+      builder.withSource(reader.readURI());
+      builder.withTime((OffsetDateTime) reader.readObject());
       builder.withSubject((String) reader.readObject());
       builder.withDataSchema((URI) reader.readObject());
       builder.withDataContentType((String) reader.readObject());


### PR DESCRIPTION
There were some implicit constraints in the map to be returned by `retrieveEvents` method, which 
makes it better to pass the Map already populated with the expected registrations associated to an empty modifiable list. This will enforce implementors just to  add the cloud events associated to every registration list (they are not responsible to create the map or the list any longer) 

Also, the event should be stored after the correlation check, reducing the likeness of using it for calculations in a different cluster, event when not suitable db locking strategy exist. 