### PR TITLE
Guard against null parameter fields in OpenAPI operation parsing

### DIFF
--- a/impl/openapi/src/main/java/io/serverlessworkflow/impl/executors/openapi/OperationDefinition.java
+++ b/impl/openapi/src/main/java/io/serverlessworkflow/impl/executors/openapi/OperationDefinition.java
@@ -70,7 +70,7 @@ class OperationDefinition {
       }
     }
 
-    if (openAPI.swaggerVersion().equals(UnifiedOpenAPI.SwaggerVersion.SWAGGER_V2)
+    if (openAPI.swaggerVersion() == UnifiedOpenAPI.SwaggerVersion.SWAGGER_V2
         && operation.parameters() != null) {
       operation.parameters().stream()
           .filter(p -> p.in() != null && "body".equals(p.in()))

--- a/impl/openapi/src/main/java/io/serverlessworkflow/impl/executors/openapi/OperationDefinition.java
+++ b/impl/openapi/src/main/java/io/serverlessworkflow/impl/executors/openapi/OperationDefinition.java
@@ -60,7 +60,7 @@ class OperationDefinition {
     List<ParameterDefinition> paramDefinitions = new ArrayList<>();
     if (operation.hasParameters()) {
       for (UnifiedOpenAPI.Parameter parameter : operation.parameters()) {
-        if (parameter.in() != null && "body".equals(parameter.in())) {
+        if ("body".equals(parameter.in())) {
           continue; // body parameters are handled separately
         }
 
@@ -73,7 +73,7 @@ class OperationDefinition {
     if (openAPI.swaggerVersion() == UnifiedOpenAPI.SwaggerVersion.SWAGGER_V2
         && operation.parameters() != null) {
       operation.parameters().stream()
-          .filter(p -> p.in() != null && "body".equals(p.in()))
+          .filter(p -> "body".equals(p.in()))
           .forEach(
               p -> {
                 UnifiedOpenAPI.Schema schema = p.schema();

--- a/impl/openapi/src/main/java/io/serverlessworkflow/impl/executors/openapi/OperationDefinition.java
+++ b/impl/openapi/src/main/java/io/serverlessworkflow/impl/executors/openapi/OperationDefinition.java
@@ -60,7 +60,7 @@ class OperationDefinition {
     List<ParameterDefinition> paramDefinitions = new ArrayList<>();
     if (operation.hasParameters()) {
       for (UnifiedOpenAPI.Parameter parameter : operation.parameters()) {
-        if (parameter.in().equals("body")) {
+        if (parameter.in() != null && parameter.in().equals("body")) {
           continue; // body parameters are handled separately
         }
 
@@ -72,11 +72,11 @@ class OperationDefinition {
 
     if (openAPI.swaggerVersion().equals(UnifiedOpenAPI.SwaggerVersion.SWAGGER_V2)) {
       operation.parameters().stream()
-          .filter(p -> p.in().equals("body"))
+          .filter(p -> p.in() != null && p.in().equals("body"))
           .forEach(
               p -> {
                 UnifiedOpenAPI.Schema schema = p.schema();
-                if (schema.hasRef()) {
+                if (schema != null && schema.hasRef()) {
                   String ref = schema.ref();
                   schema = openAPI.resolveSchema(ref);
                 }

--- a/impl/openapi/src/main/java/io/serverlessworkflow/impl/executors/openapi/OperationDefinition.java
+++ b/impl/openapi/src/main/java/io/serverlessworkflow/impl/executors/openapi/OperationDefinition.java
@@ -60,7 +60,7 @@ class OperationDefinition {
     List<ParameterDefinition> paramDefinitions = new ArrayList<>();
     if (operation.hasParameters()) {
       for (UnifiedOpenAPI.Parameter parameter : operation.parameters()) {
-        if (parameter.in() != null && parameter.in().equals("body")) {
+        if (parameter.in() != null && "body".equals(parameter.in())) {
           continue; // body parameters are handled separately
         }
 
@@ -73,7 +73,7 @@ class OperationDefinition {
     if (openAPI.swaggerVersion().equals(UnifiedOpenAPI.SwaggerVersion.SWAGGER_V2)
         && operation.parameters() != null) {
       operation.parameters().stream()
-          .filter(p -> p.in() != null && p.in().equals("body"))
+          .filter(p -> p.in() != null && "body".equals(p.in()))
           .forEach(
               p -> {
                 UnifiedOpenAPI.Schema schema = p.schema();

--- a/impl/openapi/src/main/java/io/serverlessworkflow/impl/executors/openapi/OperationDefinition.java
+++ b/impl/openapi/src/main/java/io/serverlessworkflow/impl/executors/openapi/OperationDefinition.java
@@ -71,7 +71,7 @@ class OperationDefinition {
     }
 
     if (openAPI.swaggerVersion() == UnifiedOpenAPI.SwaggerVersion.SWAGGER_V2
-        && operation.parameters() != null) {
+        && operation.hasParameters()) {
       operation.parameters().stream()
           .filter(p -> "body".equals(p.in()))
           .forEach(

--- a/impl/openapi/src/main/java/io/serverlessworkflow/impl/executors/openapi/OperationDefinition.java
+++ b/impl/openapi/src/main/java/io/serverlessworkflow/impl/executors/openapi/OperationDefinition.java
@@ -70,7 +70,8 @@ class OperationDefinition {
       }
     }
 
-    if (openAPI.swaggerVersion().equals(UnifiedOpenAPI.SwaggerVersion.SWAGGER_V2)) {
+    if (openAPI.swaggerVersion().equals(UnifiedOpenAPI.SwaggerVersion.SWAGGER_V2)
+        && operation.parameters() != null) {
       operation.parameters().stream()
           .filter(p -> p.in() != null && p.in().equals("body"))
           .forEach(

--- a/impl/openapi/src/main/java/io/serverlessworkflow/impl/executors/openapi/UnifiedOpenAPI.java
+++ b/impl/openapi/src/main/java/io/serverlessworkflow/impl/executors/openapi/UnifiedOpenAPI.java
@@ -165,11 +165,7 @@ public record UnifiedOpenAPI(
     }
   }
 
-  public record Parameter(String name, String in, Boolean required, Schema schema) {
-    public Parameter {
-      required = required != null ? required : Boolean.FALSE;
-    }
-  }
+  public record Parameter(String name, String in, boolean required, Schema schema) {}
 
   public record RequestBody(Content content) {}
 

--- a/impl/openapi/src/main/java/io/serverlessworkflow/impl/executors/openapi/UnifiedOpenAPI.java
+++ b/impl/openapi/src/main/java/io/serverlessworkflow/impl/executors/openapi/UnifiedOpenAPI.java
@@ -165,7 +165,11 @@ public record UnifiedOpenAPI(
     }
   }
 
-  public record Parameter(String name, String in, Boolean required, Schema schema) {}
+  public record Parameter(String name, String in, Boolean required, Schema schema) {
+    public Parameter {
+      required = required != null ? required : Boolean.FALSE;
+    }
+  }
 
   public record RequestBody(Content content) {}
 


### PR DESCRIPTION
 Guard against null parameter fields in OpenAPI operation parsing                                                                                                                                                         
                                                                                                                                                                                                                           
  Add null checks before dereferencing Parameter.in() and Schema in                                                                                                                                                        
  OperationDefinition, so parameters without an explicit "in" value or                                                                                                                                                     
  schema no longer trigger NullPointerExceptions during parsing.  