### PR TITLE
Fix NPE in TryExecutor when retry policy omits optional fields

### DIFF
--- a/experimental/test/src/test/java/io/serverlessworkflow/fluent/test/FuncTryCatchTest.java
+++ b/experimental/test/src/test/java/io/serverlessworkflow/fluent/test/FuncTryCatchTest.java
@@ -521,7 +521,6 @@ public class FuncTryCatchTest {
 
   @Test
   void testRetryWithoutLimit() {
-    AtomicInteger attempts = new AtomicInteger();
 
     Workflow workflow =
         FuncWorkflowBuilder.workflow()
@@ -534,11 +533,8 @@ public class FuncTryCatchTest {
                                     function(
                                         "riskyTask",
                                         (String input) -> {
-                                          if (attempts.incrementAndGet() <= 2) {
-                                            throw new WorkflowException(
-                                                WorkflowError.error(TRANSIENT_ERROR, 503).build());
-                                          }
-                                          return "success";
+                                          throw new WorkflowException(
+                                              WorkflowError.error(TRANSIENT_ERROR, 503).build());
                                         },
                                         String.class)))
                             .catchHandler(
@@ -554,9 +550,8 @@ public class FuncTryCatchTest {
 
     try (WorkflowApplication application = WorkflowApplication.builder().build()) {
       WorkflowDefinition definition = application.workflowDefinition(workflow);
-      WorkflowModel result = definition.instance("input").start().join();
-      Assertions.assertThat(result.asText()).hasValue("success");
-      Assertions.assertThat(attempts.get()).isEqualTo(3);
+      Assertions.assertThatThrownBy(() -> definition.instance("input").start().join())
+          .hasCauseInstanceOf(WorkflowException.class);
     }
   }
 

--- a/experimental/test/src/test/java/io/serverlessworkflow/fluent/test/FuncTryCatchTest.java
+++ b/experimental/test/src/test/java/io/serverlessworkflow/fluent/test/FuncTryCatchTest.java
@@ -32,6 +32,7 @@ package io.serverlessworkflow.fluent.test;
  */
 
 import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.function;
+import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.tasks;
 import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.tryCatch;
 import static io.serverlessworkflow.fluent.test.TestSerializationUtils.writeAndReadInMemory;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
@@ -45,6 +46,8 @@ import io.serverlessworkflow.impl.WorkflowException;
 import io.serverlessworkflow.impl.WorkflowModel;
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,6 +63,8 @@ public class FuncTryCatchTest {
   private static final String ORDER_001 = "ORDER#001";
   private static final String ORDER_002 = "ORDER#002";
   private static final String ORDER_003 = "ORDER#003";
+
+  private static final String TRANSIENT_ERROR = "ERR_TRANSIENT";
 
   @Test
   void booking_compensation_dsl() throws IOException {
@@ -469,6 +474,131 @@ public class FuncTryCatchTest {
       assertThat(workflowModel.asCollection())
           .map(w -> w.asText().orElseThrow())
           .contains(ORDER_001, "endFlow");
+    }
+  }
+
+  @Test
+  void testRetryWithoutBackoff() {
+    AtomicInteger attempts = new AtomicInteger();
+
+    Workflow workflow =
+        FuncWorkflowBuilder.workflow()
+            .tasks(
+                tryCatch(
+                    "tryTask",
+                    t ->
+                        t.tryCatch(
+                                tasks(
+                                    function(
+                                        "riskyTask",
+                                        (String input) -> {
+                                          if (attempts.incrementAndGet() <= 2) {
+                                            throw new WorkflowException(
+                                                WorkflowError.error(TRANSIENT_ERROR, 503).build());
+                                          }
+                                          return "success";
+                                        },
+                                        String.class)))
+                            .catchHandler(
+                                handler ->
+                                    handler
+                                        .errorsWith(err -> err.type(TRANSIENT_ERROR))
+                                        .retry(
+                                            retry ->
+                                                retry
+                                                    .delay(d -> d.milliseconds(10))
+                                                    .limit(
+                                                        limit -> limit.attempt(a -> a.count(3)))))))
+            .build();
+
+    try (WorkflowApplication application = WorkflowApplication.builder().build()) {
+      WorkflowDefinition definition = application.workflowDefinition(workflow);
+      WorkflowModel result = definition.instance("input").start().join();
+      Assertions.assertThat(result.asText()).hasValue("success");
+      Assertions.assertThat(attempts.get()).isEqualTo(3);
+    }
+  }
+
+  @Test
+  void testRetryWithoutLimit() {
+    AtomicInteger attempts = new AtomicInteger();
+
+    Workflow workflow =
+        FuncWorkflowBuilder.workflow()
+            .tasks(
+                tryCatch(
+                    "tryTask",
+                    t ->
+                        t.tryCatch(
+                                tasks(
+                                    function(
+                                        "riskyTask",
+                                        (String input) -> {
+                                          if (attempts.incrementAndGet() <= 2) {
+                                            throw new WorkflowException(
+                                                WorkflowError.error(TRANSIENT_ERROR, 503).build());
+                                          }
+                                          return "success";
+                                        },
+                                        String.class)))
+                            .catchHandler(
+                                handler ->
+                                    handler
+                                        .errorsWith(err -> err.type(TRANSIENT_ERROR))
+                                        .retry(
+                                            retry ->
+                                                retry
+                                                    .delay(d -> d.milliseconds(10))
+                                                    .backoff(b -> b.constant("c", "10"))))))
+            .build();
+
+    try (WorkflowApplication application = WorkflowApplication.builder().build()) {
+      WorkflowDefinition definition = application.workflowDefinition(workflow);
+      WorkflowModel result = definition.instance("input").start().join();
+      Assertions.assertThat(result.asText()).hasValue("success");
+      Assertions.assertThat(attempts.get()).isEqualTo(3);
+    }
+  }
+
+  @Test
+  void testRetryWithoutDelay() {
+    AtomicInteger attempts = new AtomicInteger();
+
+    Workflow workflow =
+        FuncWorkflowBuilder.workflow()
+            .tasks(
+                tryCatch(
+                    "tryTask",
+                    t ->
+                        t.tryCatch(
+                                tasks(
+                                    function(
+                                        "riskyTask",
+                                        (String input) -> {
+                                          if (attempts.incrementAndGet() <= 2) {
+                                            throw new WorkflowException(
+                                                WorkflowError.error(TRANSIENT_ERROR, 503).build());
+                                          }
+                                          return "success";
+                                        },
+                                        String.class)))
+                            .catchHandler(
+                                handler ->
+                                    handler
+                                        .errorsWith(err -> err.type(TRANSIENT_ERROR))
+                                        .retry(
+                                            retry ->
+                                                retry
+                                                    .backoff(b -> b.constant("c", "10"))
+                                                    .limit(
+                                                        limit -> limit.attempt(a -> a.count(3)))))))
+            .build();
+
+    try (WorkflowApplication application = WorkflowApplication.builder().build()) {
+      WorkflowDefinition definition = application.workflowDefinition(workflow);
+      WorkflowModel result = definition.instance("input").start().join();
+      Assertions.assertThat(result.asText()).hasValue("success");
+      Assertions.assertThat(attempts.get()).isEqualTo(3);
     }
   }
 

--- a/experimental/test/src/test/java/io/serverlessworkflow/fluent/test/FuncTryCatchTest.java
+++ b/experimental/test/src/test/java/io/serverlessworkflow/fluent/test/FuncTryCatchTest.java
@@ -480,7 +480,6 @@ public class FuncTryCatchTest {
   @Test
   void testRetryWithoutBackoff() {
     AtomicInteger attempts = new AtomicInteger();
-
     Workflow workflow =
         FuncWorkflowBuilder.workflow()
             .tasks(
@@ -521,7 +520,7 @@ public class FuncTryCatchTest {
 
   @Test
   void testRetryWithoutLimit() {
-
+    AtomicInteger attempts = new AtomicInteger();
     Workflow workflow =
         FuncWorkflowBuilder.workflow()
             .tasks(
@@ -533,8 +532,11 @@ public class FuncTryCatchTest {
                                     function(
                                         "riskyTask",
                                         (String input) -> {
-                                          throw new WorkflowException(
-                                              WorkflowError.error(TRANSIENT_ERROR, 503).build());
+                                          if (attempts.incrementAndGet() <= 2) {
+                                            throw new WorkflowException(
+                                                WorkflowError.error(TRANSIENT_ERROR, 503).build());
+                                          }
+                                          return "success";
                                         },
                                         String.class)))
                             .catchHandler(
@@ -550,8 +552,9 @@ public class FuncTryCatchTest {
 
     try (WorkflowApplication application = WorkflowApplication.builder().build()) {
       WorkflowDefinition definition = application.workflowDefinition(workflow);
-      Assertions.assertThatThrownBy(() -> definition.instance("input").start().join())
-          .hasCauseInstanceOf(WorkflowException.class);
+      WorkflowModel result = definition.instance("input").start().join();
+      Assertions.assertThat(result.asText()).hasValue("success");
+      Assertions.assertThat(attempts.get()).isEqualTo(3);
     }
   }
 

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/TaskContext.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/TaskContext.java
@@ -37,10 +37,10 @@ public class TaskContext implements TaskContextData {
   private WorkflowModel rawOutput;
   private Instant completedAt;
   private TransitionInfo transition;
-  private short retryAttempt;
+  private int retryAttempt;
   private int iteration;
   private AuthorizationDescriptor authorization;
-  private Optional<Short> tryRetryCount = Optional.empty();
+  private Optional<Integer> tryRetryCount = Optional.empty();
 
   public TaskContext(
       WorkflowModel input,
@@ -71,7 +71,7 @@ public class TaskContext implements TaskContextData {
     this.output = output;
     this.rawOutput = rawOutput;
     this.retryAttempt =
-        parentContext.map(ctx -> ctx.tryRetryCount.orElse(ctx.retryAttempt())).orElse((short) 0);
+        parentContext.map(ctx -> ctx.tryRetryCount.orElse(ctx.retryAttempt())).orElse(0);
     this.contextVariables =
         parentContext.map(p -> new HashMap<>(p.contextVariables)).orElseGet(HashMap::new);
   }
@@ -173,19 +173,19 @@ public class TaskContext implements TaskContextData {
   }
 
   @Override
-  public short retryAttempt() {
+  public int retryAttempt() {
     return retryAttempt;
   }
 
-  public void retryAttempt(short retryAttempt) {
+  public void retryAttempt(int retryAttempt) {
     this.retryAttempt = retryAttempt;
   }
 
-  public void tryRetryCount(short tryRetryCount) {
+  public void tryRetryCount(int tryRetryCount) {
     this.tryRetryCount = Optional.of(tryRetryCount);
   }
 
-  public Optional<Short> tryRetryCount() {
+  public Optional<Integer> tryRetryCount() {
     return tryRetryCount;
   }
 

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/TaskContextData.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/TaskContextData.java
@@ -40,5 +40,5 @@ public interface TaskContextData {
 
   int iteration();
 
-  short retryAttempt();
+  int retryAttempt();
 }

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/WorkflowUtils.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/WorkflowUtils.java
@@ -187,30 +187,36 @@ public class WorkflowUtils {
         && exceptFilter.map(w -> !w.test(workflow, taskContext, model)).orElse(true);
   }
 
+  private static final class ZeroDelayResolverHolder {
+    private static final WorkflowValueResolver<Duration> ZERO_DELAY_RESOLVER =
+        (w, t, f) -> Duration.ZERO;
+  }
+
   public static WorkflowValueResolver<Duration> fromTimeoutAfter(
       WorkflowApplication application, TimeoutAfter timeout) {
-    if (timeout.getDurationExpression() != null) {
-      return (w, f, t) ->
-          Duration.parse(
-              application
-                  .expressionFactory()
-                  .resolveString(ExpressionDescriptor.from(timeout.getDurationExpression()))
-                  .apply(w, f, t));
-    } else if (timeout.getDurationLiteral() != null) {
-      Duration duration = Duration.parse(timeout.getDurationLiteral());
-      return (w, f, t) -> duration;
-    } else if (timeout.getDurationInline() != null) {
-      DurationInline inlineDuration = timeout.getDurationInline();
-      return (w, t, f) ->
-          Duration.ofDays(inlineDuration.getDays())
-              .plus(
-                  Duration.ofHours(inlineDuration.getHours())
-                      .plus(Duration.ofMinutes(inlineDuration.getMinutes()))
-                      .plus(Duration.ofSeconds(inlineDuration.getSeconds()))
-                      .plus(Duration.ofMillis(inlineDuration.getMilliseconds())));
-    } else {
-      return (w, t, f) -> Duration.ZERO;
+    if (timeout != null) {
+      if (timeout.getDurationExpression() != null) {
+        return (w, f, t) ->
+            Duration.parse(
+                application
+                    .expressionFactory()
+                    .resolveString(ExpressionDescriptor.from(timeout.getDurationExpression()))
+                    .apply(w, f, t));
+      } else if (timeout.getDurationLiteral() != null) {
+        Duration duration = Duration.parse(timeout.getDurationLiteral());
+        return (w, f, t) -> duration;
+      } else if (timeout.getDurationInline() != null) {
+        DurationInline inlineDuration = timeout.getDurationInline();
+        return (w, t, f) ->
+            Duration.ofDays(inlineDuration.getDays())
+                .plus(
+                    Duration.ofHours(inlineDuration.getHours())
+                        .plus(Duration.ofMinutes(inlineDuration.getMinutes()))
+                        .plus(Duration.ofSeconds(inlineDuration.getSeconds()))
+                        .plus(Duration.ofMillis(inlineDuration.getMilliseconds())));
+      }
     }
+    return ZeroDelayResolverHolder.ZERO_DELAY_RESOLVER;
   }
 
   public static Optional<WorkflowValueResolver<Duration>> getTaskTimeout(

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/executors/TryExecutor.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/executors/TryExecutor.java
@@ -19,6 +19,8 @@ import io.serverlessworkflow.api.types.CatchErrors;
 import io.serverlessworkflow.api.types.ErrorFilter;
 import io.serverlessworkflow.api.types.Retry;
 import io.serverlessworkflow.api.types.RetryBackoff;
+import io.serverlessworkflow.api.types.RetryLimit;
+import io.serverlessworkflow.api.types.RetryLimitAttempt;
 import io.serverlessworkflow.api.types.RetryPolicy;
 import io.serverlessworkflow.api.types.TaskItem;
 import io.serverlessworkflow.api.types.TryTask;
@@ -107,15 +109,26 @@ public class TryExecutor extends RegularTaskExecutor<TryTask> {
 
     protected RetryExecutor buildRetryExecutor(RetryPolicy retryPolicy) {
       return new DefaultRetryExecutor(
-          retryPolicy.getLimit().getAttempt().getCount(),
+          resolveMaxAttempts(retryPolicy.getLimit()),
           buildIntervalFunction(retryPolicy),
           WorkflowUtils.optionalPredicate(application, retryPolicy.getWhen()),
           WorkflowUtils.optionalPredicate(application, retryPolicy.getExceptWhen()));
     }
 
+    private static int resolveMaxAttempts(RetryLimit limit) {
+      if (limit == null) {
+        return Integer.MAX_VALUE;
+      }
+      RetryLimitAttempt attempt = limit.getAttempt();
+      if (attempt == null) {
+        return Integer.MAX_VALUE;
+      }
+      return attempt.getCount();
+    }
+
     private RetryIntervalFunction buildIntervalFunction(RetryPolicy retryPolicy) {
       RetryBackoff backoff = retryPolicy.getBackoff();
-      if (backoff.getConstantBackoff() != null) {
+      if (backoff == null || backoff.getConstantBackoff() != null) {
         return new ConstantRetryIntervalFunction(
             application, retryPolicy.getDelay(), retryPolicy.getJitter());
       } else if (backoff.getLinearBackoff() != null) {

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/executors/TryExecutor.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/executors/TryExecutor.java
@@ -20,7 +20,6 @@ import io.serverlessworkflow.api.types.ErrorFilter;
 import io.serverlessworkflow.api.types.Retry;
 import io.serverlessworkflow.api.types.RetryBackoff;
 import io.serverlessworkflow.api.types.RetryLimit;
-import io.serverlessworkflow.api.types.RetryLimitAttempt;
 import io.serverlessworkflow.api.types.RetryPolicy;
 import io.serverlessworkflow.api.types.TaskItem;
 import io.serverlessworkflow.api.types.TryTask;
@@ -116,14 +115,10 @@ public class TryExecutor extends RegularTaskExecutor<TryTask> {
     }
 
     private static int resolveMaxAttempts(RetryLimit limit) {
-      if (limit == null) {
-        return Integer.MAX_VALUE;
+      if (limit == null || limit.getAttempt() == null) {
+        return 0;
       }
-      RetryLimitAttempt attempt = limit.getAttempt();
-      if (attempt == null) {
-        return Integer.MAX_VALUE;
-      }
-      return attempt.getCount();
+      return limit.getAttempt().getCount();
     }
 
     private RetryIntervalFunction buildIntervalFunction(RetryPolicy retryPolicy) {

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/executors/TryExecutor.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/executors/TryExecutor.java
@@ -115,25 +115,27 @@ public class TryExecutor extends RegularTaskExecutor<TryTask> {
     }
 
     private static int resolveMaxAttempts(RetryLimit limit) {
-      if (limit == null || limit.getAttempt() == null) {
-        return 0;
-      }
-      return limit.getAttempt().getCount();
+      return limit != null && limit.getAttempt() != null
+          ? limit.getAttempt().getCount()
+          : Integer.MAX_VALUE - 1;
     }
 
     private RetryIntervalFunction buildIntervalFunction(RetryPolicy retryPolicy) {
       RetryBackoff backoff = retryPolicy.getBackoff();
-      if (backoff == null || backoff.getConstantBackoff() != null) {
-        return new ConstantRetryIntervalFunction(
-            application, retryPolicy.getDelay(), retryPolicy.getJitter());
-      } else if (backoff.getLinearBackoff() != null) {
-        return new LinearRetryIntervalFunction(
-            application, retryPolicy.getDelay(), retryPolicy.getJitter());
-      } else if (backoff.getExponentialBackOff() != null) {
-        return new ExponentialRetryIntervalFunction(
-            application, retryPolicy.getDelay(), retryPolicy.getJitter());
+      if (backoff != null) {
+        if (backoff.getConstantBackoff() != null) {
+          return new ConstantRetryIntervalFunction(
+              application, retryPolicy.getDelay(), retryPolicy.getJitter());
+        } else if (backoff.getLinearBackoff() != null) {
+          return new LinearRetryIntervalFunction(
+              application, retryPolicy.getDelay(), retryPolicy.getJitter());
+        } else if (backoff.getExponentialBackOff() != null) {
+          return new ExponentialRetryIntervalFunction(
+              application, retryPolicy.getDelay(), retryPolicy.getJitter());
+        }
       }
-      throw new IllegalStateException("A backoff strategy should be set");
+      return new ConstantRetryIntervalFunction(
+          application, retryPolicy.getDelay(), retryPolicy.getJitter());
     }
 
     @Override

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/executors/retry/AbstractRetryIntervalFunction.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/executors/retry/AbstractRetryIntervalFunction.java
@@ -32,9 +32,6 @@ public abstract class AbstractRetryIntervalFunction implements RetryIntervalFunc
   private final Optional<WorkflowValueResolver<Duration>> maxJitteringResolver;
   private final WorkflowValueResolver<Duration> delayResolver;
 
-  private static final WorkflowValueResolver<Duration> ZERO_DURATION_RESOLVER =
-      (w, t, m) -> Duration.ZERO;
-
   public AbstractRetryIntervalFunction(
       WorkflowApplication appl, TimeoutAfter delay, RetryPolicyJitter jitter) {
     if (jitter != null) {
@@ -44,8 +41,7 @@ public abstract class AbstractRetryIntervalFunction implements RetryIntervalFunc
       minJitteringResolver = Optional.empty();
       maxJitteringResolver = Optional.empty();
     }
-    delayResolver =
-        delay != null ? WorkflowUtils.fromTimeoutAfter(appl, delay) : ZERO_DURATION_RESOLVER;
+    delayResolver = WorkflowUtils.fromTimeoutAfter(appl, delay);
   }
 
   @Override
@@ -53,21 +49,24 @@ public abstract class AbstractRetryIntervalFunction implements RetryIntervalFunc
       WorkflowContext workflowContext,
       TaskContext taskContext,
       WorkflowModel model,
-      short numAttempts) {
+      int numAttempts) {
     Duration delay = delayResolver.apply(workflowContext, taskContext, model);
     Duration minJittering =
         minJitteringResolver
             .map(min -> min.apply(workflowContext, taskContext, model))
             .orElse(Duration.ZERO);
-    Duration maxJittering =
+    Duration result = calcDelay(delay, numAttempts).plus(minJittering);
+    long maxJittering =
         maxJitteringResolver
             .map(max -> max.apply(workflowContext, taskContext, model))
-            .orElse(Duration.ZERO);
-    return calcDelay(delay, numAttempts)
-        .plus(
-            Duration.ofMillis(
-                (long) (minJittering.toMillis() + Math.random() * maxJittering.toMillis())));
+            .orElse(Duration.ZERO)
+            .toMillis();
+    long diff = maxJittering - minJittering.toMillis();
+    if (diff > 0) {
+      result = result.plus(Duration.ofMillis(Math.round(Math.random() * diff)));
+    }
+    return result;
   }
 
-  protected abstract Duration calcDelay(Duration delay, short numAttempts);
+  protected abstract Duration calcDelay(Duration delay, int numAttempts);
 }

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/executors/retry/AbstractRetryIntervalFunction.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/executors/retry/AbstractRetryIntervalFunction.java
@@ -32,6 +32,9 @@ public abstract class AbstractRetryIntervalFunction implements RetryIntervalFunc
   private final Optional<WorkflowValueResolver<Duration>> maxJitteringResolver;
   private final WorkflowValueResolver<Duration> delayResolver;
 
+  private static final WorkflowValueResolver<Duration> ZERO_DURATION_RESOLVER =
+      (w, t, m) -> Duration.ZERO;
+
   public AbstractRetryIntervalFunction(
       WorkflowApplication appl, TimeoutAfter delay, RetryPolicyJitter jitter) {
     if (jitter != null) {
@@ -41,7 +44,8 @@ public abstract class AbstractRetryIntervalFunction implements RetryIntervalFunc
       minJitteringResolver = Optional.empty();
       maxJitteringResolver = Optional.empty();
     }
-    delayResolver = WorkflowUtils.fromTimeoutAfter(appl, delay);
+    delayResolver =
+        delay != null ? WorkflowUtils.fromTimeoutAfter(appl, delay) : ZERO_DURATION_RESOLVER;
   }
 
   @Override

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/executors/retry/ConstantRetryIntervalFunction.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/executors/retry/ConstantRetryIntervalFunction.java
@@ -28,7 +28,7 @@ public class ConstantRetryIntervalFunction extends AbstractRetryIntervalFunction
   }
 
   @Override
-  protected Duration calcDelay(Duration delay, short numAttempts) {
+  protected Duration calcDelay(Duration delay, int numAttempts) {
     return delay;
   }
 }

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/executors/retry/DefaultRetryExecutor.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/executors/retry/DefaultRetryExecutor.java
@@ -46,7 +46,7 @@ public class DefaultRetryExecutor implements RetryExecutor {
   @Override
   public Optional<CompletableFuture<WorkflowModel>> retry(
       WorkflowContext workflowContext, TaskContext taskContext, WorkflowModel model) {
-    short numAttempts = taskContext.tryRetryCount().orElseThrow();
+    int numAttempts = taskContext.tryRetryCount().orElseThrow();
     if (numAttempts++ < maxAttempts
         && WorkflowUtils.whenExceptTest(
             whenFilter, exceptFilter, workflowContext, taskContext, model)) {
@@ -62,7 +62,7 @@ public class DefaultRetryExecutor implements RetryExecutor {
   @Override
   public void init(WorkflowContext workflowContext, TaskContext taskContext, WorkflowModel model) {
     if (taskContext.tryRetryCount().isEmpty()) {
-      taskContext.tryRetryCount((short) 0);
+      taskContext.tryRetryCount(0);
     }
   }
 }

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/executors/retry/ExponentialRetryIntervalFunction.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/executors/retry/ExponentialRetryIntervalFunction.java
@@ -22,13 +22,16 @@ import java.time.Duration;
 
 public class ExponentialRetryIntervalFunction extends AbstractRetryIntervalFunction {
 
+  // 2^33 will be several years, which I think is too high as delay
+  private static final int MAX_EXPONENTIAL_RETRY = 32;
+
   public ExponentialRetryIntervalFunction(
       WorkflowApplication appl, TimeoutAfter delay, RetryPolicyJitter jitter) {
     super(appl, delay, jitter);
   }
 
   @Override
-  protected Duration calcDelay(Duration delay, short numAttempts) {
-    return delay.multipliedBy(1 << numAttempts);
+  protected Duration calcDelay(Duration delay, int numAttempts) {
+    return delay.multipliedBy(1L << Math.min(numAttempts, MAX_EXPONENTIAL_RETRY));
   }
 }

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/executors/retry/LinearRetryIntervalFunction.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/executors/retry/LinearRetryIntervalFunction.java
@@ -28,7 +28,7 @@ public class LinearRetryIntervalFunction extends AbstractRetryIntervalFunction {
   }
 
   @Override
-  protected Duration calcDelay(Duration delay, short numAttempts) {
+  protected Duration calcDelay(Duration delay, int numAttempts) {
     return delay.multipliedBy(numAttempts);
   }
 }

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/executors/retry/RetryIntervalFunction.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/executors/retry/RetryIntervalFunction.java
@@ -25,5 +25,5 @@ public interface RetryIntervalFunction {
       WorkflowContext workflowContext,
       TaskContext taskContext,
       WorkflowModel model,
-      short numAttempts);
+      int numAttempts);
 }

--- a/impl/core/src/test/java/io/serverlessworkflow/impl/WorkflowAdditionalObjectTest.java
+++ b/impl/core/src/test/java/io/serverlessworkflow/impl/WorkflowAdditionalObjectTest.java
@@ -59,7 +59,7 @@ public class WorkflowAdditionalObjectTest {
   void testAdditionalObjectBiFunction() {
     WorkflowContext workflowContext = mock(WorkflowContext.class);
     TaskContext taskContext = mock(TaskContext.class);
-    when(taskContext.retryAttempt()).thenReturn((short) 2);
+    when(taskContext.retryAttempt()).thenReturn(2);
     final String key = "Dummy_Bifactory";
     try (WorkflowApplication appl =
         WorkflowApplication.builder()

--- a/impl/persistence/api/src/main/java/io/serverlessworkflow/impl/persistence/RetriedTaskInfo.java
+++ b/impl/persistence/api/src/main/java/io/serverlessworkflow/impl/persistence/RetriedTaskInfo.java
@@ -15,4 +15,4 @@
  */
 package io.serverlessworkflow.impl.persistence;
 
-public record RetriedTaskInfo(short retryAttempt) implements PersistenceTaskInfo {}
+public record RetriedTaskInfo(int retryAttempt) implements PersistenceTaskInfo {}

--- a/impl/persistence/bigmap/src/main/java/io/serverlessworkflow/impl/persistence/bigmap/BytesMapInstanceTransaction.java
+++ b/impl/persistence/bigmap/src/main/java/io/serverlessworkflow/impl/persistence/bigmap/BytesMapInstanceTransaction.java
@@ -124,9 +124,9 @@ public abstract class BytesMapInstanceTransaction
       WorkflowContextData workflowContext, TaskContext taskContext) {
     ByteArrayOutputStream bytes = new ByteArrayOutputStream();
     try (WorkflowOutputBuffer writer = factory.output(bytes)) {
-      writer.writeByte(VERSION_1);
+      writer.writeByte(VERSION_2);
       writer.writeEnum(TaskStatus.RETRIED);
-      writer.writeShort(taskContext.retryAttempt());
+      writer.writeInt(taskContext.retryAttempt());
     }
     return bytes.toByteArray();
   }
@@ -159,7 +159,7 @@ public abstract class BytesMapInstanceTransaction
             buffer.readBoolean() ? buffer.readString() : null,
             buffer.readInt());
       case RETRIED:
-        return new RetriedTaskInfo(buffer.readShort());
+        return new RetriedTaskInfo(buffer.readInt());
     }
     throw new UnsupportedOperationException("Unknown status " + taskStatus);
   }

--- a/impl/persistence/tests/src/main/java/io/serverlessworkflow/impl/persistence/test/AbstractHandlerPersistenceTest.java
+++ b/impl/persistence/tests/src/main/java/io/serverlessworkflow/impl/persistence/test/AbstractHandlerPersistenceTest.java
@@ -95,7 +95,7 @@ public abstract class AbstractHandlerPersistenceTest {
     return taskContext;
   }
 
-  protected TaskContextData retriedTaskContext(WorkflowPosition position, short retryAttempt) {
+  protected TaskContextData retriedTaskContext(WorkflowPosition position, int retryAttempt) {
     TaskContext taskContext = mock(TaskContext.class);
     when(taskContext.position()).thenReturn(position);
     when(taskContext.retryAttempt()).thenReturn(retryAttempt);
@@ -120,7 +120,7 @@ public abstract class AbstractHandlerPersistenceTest {
         app.positionFactory().get().addProperty("do").addIndex(0).addProperty("useExpression");
     final WorkflowMutablePosition position2 =
         app.positionFactory().get().addProperty("do").addIndex(1).addProperty("useExpression");
-    final short numRetries = 1;
+    final int numRetries = 1;
 
     final Map<String, Object> completedMap = Map.of("name", "fulanito");
 
@@ -147,7 +147,7 @@ public abstract class AbstractHandlerPersistenceTest {
     when(parentContext.task()).thenReturn(taskBase);
     when(updateTContext.parent()).thenReturn(Optional.of(parentContext));
     instance.restoreContext(updateWContext, updateTContext);
-    ArgumentCaptor<Short> retryAttempt = ArgumentCaptor.forClass(Short.class);
+    ArgumentCaptor<Integer> retryAttempt = ArgumentCaptor.forClass(Integer.class);
     verify(updateTContext).retryAttempt(retryAttempt.capture());
     assertThat(retryAttempt.getValue()).isEqualTo(numRetries);
     verify(parentContext).tryRetryCount(retryAttempt.capture());

--- a/impl/test/src/test/java/io/serverlessworkflow/impl/test/RetryTimeoutTest.java
+++ b/impl/test/src/test/java/io/serverlessworkflow/impl/test/RetryTimeoutTest.java
@@ -65,8 +65,8 @@ public class RetryTimeoutTest {
 
   private class RetryListener implements WorkflowExecutionListener {
 
-    private Map<String, Short> taskRetried = new ConcurrentHashMap<>();
-    private Map<String, Short> taskCompleted = new ConcurrentHashMap<>();
+    private Map<String, Integer> taskRetried = new ConcurrentHashMap<>();
+    private Map<String, Integer> taskCompleted = new ConcurrentHashMap<>();
 
     @Override
     public void onTaskRetried(TaskRetriedEvent ev) {
@@ -78,7 +78,7 @@ public class RetryTimeoutTest {
       add2Map(taskCompleted, ev);
     }
 
-    private static void add2Map(Map<String, Short> map, TaskEvent ev) {
+    private static void add2Map(Map<String, Integer> map, TaskEvent ev) {
       TaskContextData taskContext = ev.taskContext();
       map.put(taskContext.position().jsonPointer(), taskContext.retryAttempt());
     }


### PR DESCRIPTION
The spec defines backoff, limit, and delay as optional in a retry policy, but the runtime assumed all three were always present, causing NullPointerException when any was omitted.

- Default to constant backoff when backoff is not specified
- Default to unlimited retries when limit is not specified
- Default to zero delay when delay is not specified

Closes #1517 