### PR TITLE
Deprecate GET()/POST() in favor of get()/post()

### DIFF
--- a/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/dsl/BaseCallHttpSpec.java
+++ b/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/dsl/BaseCallHttpSpec.java
@@ -38,7 +38,10 @@ public interface BaseCallHttpSpec<SELF extends BaseCallHttpSpec<SELF>> {
     return self();
   }
 
-  @Deprecated
+  /**
+   * @deprecated Use {@link #get()} instead.
+   */
+  @Deprecated(since = "7.25.0", forRemoval = true)
   default SELF GET() {
     return get();
   }
@@ -48,7 +51,10 @@ public interface BaseCallHttpSpec<SELF extends BaseCallHttpSpec<SELF>> {
     return self();
   }
 
-  @Deprecated
+  /**
+   * @deprecated Use {@link #post()} instead.
+   */
+  @Deprecated(since = "7.25.0", forRemoval = true)
   default SELF POST() {
     return post();
   }

--- a/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/dsl/DSL.java
+++ b/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/dsl/DSL.java
@@ -77,7 +77,7 @@ public final class DSL {
    * tasks(
    *   call(
    *     http()
-   *       .GET()
+   *       .get()
    *       .endpoint("http://service/api")
    *   )
    * );

--- a/fluent/spec/src/test/java/io/serverlessworkflow/fluent/spec/TaskItemDefaultNamingTest.java
+++ b/fluent/spec/src/test/java/io/serverlessworkflow/fluent/spec/TaskItemDefaultNamingTest.java
@@ -42,7 +42,7 @@ public class TaskItemDefaultNamingTest {
             .tasks(
                 d ->
                     d.set(null, s -> s.expr("$.foo = 'bar'"))
-                        .http(null, http().GET().endpoint("http://example.com"))
+                        .http(null, http().get().endpoint("http://example.com"))
                         .emit("", e -> e.event(ev -> ev.type("test.event")))
                         .set("explicitName", s -> s.expr("$.x = 1")) // Explicit name should be kept
                         .fork(null, fb -> {}) // No-op fork to check index 4
@@ -77,7 +77,7 @@ public class TaskItemDefaultNamingTest {
                             t.tryHandler(
                                 tb ->
                                     tb.set(null, s -> s.expr("$.start = true"))
-                                        .http(null, http().GET().endpoint("http://test"))
+                                        .http(null, http().get().endpoint("http://test"))
                                         .set(null, s -> s.expr("$.end = true")))))
             .build();
 
@@ -112,7 +112,7 @@ public class TaskItemDefaultNamingTest {
                                 // Define tasks to be executed for each item in the forEach loop
                                 .tasks(
                                     tb ->
-                                        tb.http(null, http().POST().endpoint("http://test"))
+                                        tb.http(null, http().post().endpoint("http://test"))
                                             .set(null, s -> s.expr("$.processed = true")))))
             .build();
 
@@ -159,7 +159,7 @@ public class TaskItemDefaultNamingTest {
                                 b ->
                                     b.set(null, s -> s.expr("$.a = 1"))
                                         .set(null, s -> s.expr("$.a = 2"))
-                                        .http(null, http().GET().endpoint("http://b")))))
+                                        .http(null, http().get().endpoint("http://b")))))
             .build();
 
     List<TaskItem> topItems = wf.getDo();
@@ -189,7 +189,7 @@ public class TaskItemDefaultNamingTest {
             .tasks(
                 d ->
                     d.set(null, s -> s.expr("$.a = 1"))
-                        .http(null, http().GET().endpoint("http://example.com"))
+                        .http(null, http().get().endpoint("http://example.com"))
                         .emit("customEmit", e -> e.event(ev -> ev.type("test")))
                         .tryCatch(
                             null, t -> t.tryHandler(tb -> tb.set(null, s -> s.expr("$.b = 2")))))
@@ -201,7 +201,7 @@ public class TaskItemDefaultNamingTest {
             .tasks(
                 d ->
                     d.set(null, s -> s.expr("$.a = 1"))
-                        .http(null, http().GET().endpoint("http://example.com"))
+                        .http(null, http().get().endpoint("http://example.com"))
                         .emit("customEmit", e -> e.event(ev -> ev.type("test")))
                         .tryCatch(
                             null, t -> t.tryHandler(tb -> tb.set(null, s -> s.expr("$.b = 2")))))
@@ -238,7 +238,7 @@ public class TaskItemDefaultNamingTest {
             .tasks(
                 d ->
                     d.set(null, s -> s.expr("$.a = 1"))
-                        .http(null, http().GET().endpoint("http://a")))
+                        .http(null, http().get().endpoint("http://a")))
             // Second invocation: list has 2 items, offset passed to builder should be 2
             .tasks(
                 d ->
@@ -273,7 +273,7 @@ public class TaskItemDefaultNamingTest {
                                 // 2. Second call: list has 1 item, offset should be 1
                                 .branches(b -> b.set(null, s -> s.expr("$.b = 2")))
                                 // 3. Third call: list has 2 items, offset should be 2
-                                .branches(b -> b.http(null, http().GET().endpoint("http://test")))))
+                                .branches(b -> b.http(null, http().get().endpoint("http://test")))))
             .build();
 
     List<TaskItem> topItems = wf.getDo();
@@ -310,7 +310,7 @@ public class TaskItemDefaultNamingTest {
                                 // 2. Second call: list has 1 item, offset should be 1
                                 .tasks(tb -> tb.set(null, s -> s.expr("$.b = 2")))
                                 // 3. Third call: list has 2 items, offset should be 2
-                                .tasks(tb -> tb.http(null, http().GET().endpoint("http://test")))))
+                                .tasks(tb -> tb.http(null, http().get().endpoint("http://test")))))
             .build();
 
     List<TaskItem> topItems = wf.getDo();
@@ -344,7 +344,7 @@ public class TaskItemDefaultNamingTest {
     subBuilder.tasks(tb -> tb.set(null, s -> s.expr("$.b = 2")));
 
     // 3. Third call: list has 2 items, offset should be 2
-    subBuilder.tasks(tb -> tb.http(null, http().GET().endpoint("http://test")));
+    subBuilder.tasks(tb -> tb.http(null, http().get().endpoint("http://test")));
 
     // Build and verify
     List<TaskItem> nestedTasks = subBuilder.build().getDo();
@@ -380,7 +380,7 @@ public class TaskItemDefaultNamingTest {
                                                 cb ->
                                                     cb.http(
                                                         null,
-                                                        http().GET().endpoint("http://test"))))))
+                                                        http().get().endpoint("http://test"))))))
             .build();
 
     List<TaskItem> topItems = wf.getDo();
@@ -427,7 +427,7 @@ public class TaskItemDefaultNamingTest {
                                         .tasks(
                                             tb ->
                                                 tb.http(
-                                                    null, http().GET().endpoint("http://test"))))))
+                                                    null, http().get().endpoint("http://test"))))))
             .build();
 
     List<TaskItem> topItems = wf.getDo();

--- a/fluent/spec/src/test/java/io/serverlessworkflow/fluent/spec/WorkflowBuilderTest.java
+++ b/fluent/spec/src/test/java/io/serverlessworkflow/fluent/spec/WorkflowBuilderTest.java
@@ -199,7 +199,7 @@ public class WorkflowBuilderTest {
             .tasks(
                 doTasks(
                     set("set", "$.initialized = true"),
-                    call("call", http().GET().endpoint("http://example.com")),
+                    call("call", http().get().endpoint("http://example.com")),
                     emit("emit", e -> e.event(p -> p.type("test.event"))),
                     listen(
                         "listen",
@@ -539,7 +539,7 @@ public class WorkflowBuilderTest {
                     d.http(
                         "basicCall",
                         http()
-                            .POST()
+                            .post()
                             .uri(URI.create("http://example.com/api"))
                             .andThen(b -> b.body(Map.of("foo", "bar")))))
             .build();
@@ -564,7 +564,7 @@ public class WorkflowBuilderTest {
                 d ->
                     d.http(
                         "hdrCall",
-                        http().GET().endpoint("${uriExpr}").headers(Map.of("A", "1", "B", "2"))))
+                        http().get().endpoint("${uriExpr}").headers(Map.of("A", "1", "B", "2"))))
             .build();
     CallHTTP call = wf.getDo().get(0).getTask().getCallTask().getCallHTTP();
     HTTPHeaders hh = call.getWith().getHeaders().getHTTPHeaders();
@@ -576,7 +576,7 @@ public class WorkflowBuilderTest {
             .tasks(
                 d ->
                     d.http(
-                        http().GET().endpoint("${ expr }").headers(Map.of("X", "10", "Y", "20"))))
+                        http().get().endpoint("${ expr }").headers(Map.of("X", "10", "Y", "20"))))
             .build();
     CallHTTP call2 = wf2.getDo().get(0).getTask().getCallTask().getCallHTTP();
     HTTPHeaders hh2 = call2.getWith().getHeaders().getHTTPHeaders();
@@ -593,7 +593,7 @@ public class WorkflowBuilderTest {
                     d.http(
                         "qryCall",
                         http()
-                            .GET()
+                            .get()
                             .endpoint("${ exprUri }")
                             .andThen(q -> q.query(Map.of("k1", "v1", "k2", "v2")))))
             .build();
@@ -629,7 +629,7 @@ public class WorkflowBuilderTest {
   void testDoTaskCallHTTPQuerySingleKeyValue() {
     Workflow wf =
         WorkflowBuilder.workflow("flowCallQuerySingle")
-            .tasks(d -> d.http("qryOne", http().GET().endpoint("http://uri").query("id", "42")))
+            .tasks(d -> d.http("qryOne", http().get().endpoint("http://uri").query("id", "42")))
             .build();
     HTTPQuery hq =
         wf.getDo().get(0).getTask().getCallTask().getCallHTTP().getWith().getQuery().getHTTPQuery();

--- a/fluent/spec/src/test/java/io/serverlessworkflow/fluent/spec/dsl/CallHttpAuthDslTest.java
+++ b/fluent/spec/src/test/java/io/serverlessworkflow/fluent/spec/dsl/CallHttpAuthDslTest.java
@@ -38,7 +38,7 @@ public class CallHttpAuthDslTest {
   void when_call_http_with_basic_auth_on_endpoint_expr() {
     Workflow wf =
         WorkflowBuilder.workflow("f", "ns", "1")
-            .tasks(call(http().GET().endpoint(EXPR_ENDPOINT, basic("alice", "secret"))))
+            .tasks(call(http().get().endpoint(EXPR_ENDPOINT, basic("alice", "secret"))))
             .build();
 
     var args = wf.getDo().get(0).getTask().getCallTask().getCallHTTP().getWith();
@@ -79,7 +79,7 @@ public class CallHttpAuthDslTest {
   void when_call_http_with_bearer_auth_on_endpoint_expr() {
     Workflow wf =
         WorkflowBuilder.workflow("f", "ns", "1")
-            .tasks(call(http().GET().endpoint(EXPR_ENDPOINT, bearer("token-123"))))
+            .tasks(call(http().get().endpoint(EXPR_ENDPOINT, bearer("token-123"))))
             .build();
 
     var args = wf.getDo().get(0).getTask().getCallTask().getCallHTTP().getWith();
@@ -109,7 +109,7 @@ public class CallHttpAuthDslTest {
   void when_call_http_with_digest_auth_on_endpoint_expr() {
     Workflow wf =
         WorkflowBuilder.workflow("f", "ns", "1")
-            .tasks(call(http().GET().endpoint(EXPR_ENDPOINT, digest("bob", "p@ssw0rd"))))
+            .tasks(call(http().get().endpoint(EXPR_ENDPOINT, digest("bob", "p@ssw0rd"))))
             .build();
 
     var args = wf.getDo().get(0).getTask().getCallTask().getCallHTTP().getWith();
@@ -148,7 +148,7 @@ public class CallHttpAuthDslTest {
             .tasks(
                 call(
                     http()
-                        .POST()
+                        .post()
                         .endpoint(
                             EXPR_ENDPOINT,
                             oidc(
@@ -196,7 +196,7 @@ public class CallHttpAuthDslTest {
             .tasks(
                 call(
                     http()
-                        .POST()
+                        .post()
                         .endpoint(
                             EXPR_ENDPOINT,
                             oauth2(
@@ -237,7 +237,7 @@ public class CallHttpAuthDslTest {
   void when_call_http_with_basic_auth_on_uri_string() {
     Workflow wf =
         WorkflowBuilder.workflow("f", "ns", "1")
-            .tasks(call(http().GET().uri("https://api.example.com/v1/resource", basic("u", "p"))))
+            .tasks(call(http().get().uri("https://api.example.com/v1/resource", basic("u", "p"))))
             .build();
 
     var args = wf.getDo().get(0).getTask().getCallTask().getCallHTTP().getWith();

--- a/fluent/spec/src/test/java/io/serverlessworkflow/fluent/spec/dsl/DSLTest.java
+++ b/fluent/spec/src/test/java/io/serverlessworkflow/fluent/spec/dsl/DSLTest.java
@@ -52,7 +52,7 @@ public class DSLTest {
                     http()
                         .acceptJSON()
                         .header("CustomKey", "CustomValue")
-                        .POST()
+                        .post()
                         .endpoint("${ \"https://petstore.swagger.io/v2/pet/\\(.petId)\" }")))
             .build();
 

--- a/fluent/spec/src/test/java/io/serverlessworkflow/fluent/spec/dsl/TryCatchDslTest.java
+++ b/fluent/spec/src/test/java/io/serverlessworkflow/fluent/spec/dsl/TryCatchDslTest.java
@@ -44,7 +44,7 @@ public class TryCatchDslTest {
                     t.tryCatch(
                         tryCatch()
                             // try block (one HTTP call)
-                            .tasks(call(http().GET().endpoint(EXPR_ENDPOINT)))
+                            .tasks(call(http().get().endpoint(EXPR_ENDPOINT)))
                             // catch block
                             .catches()
                             .when("$.error == true")
@@ -118,7 +118,7 @@ public class TryCatchDslTest {
                         tryCatch()
                             // try with two tasks
                             .tasks(
-                                call(http().GET().endpoint(EXPR_ENDPOINT)),
+                                call(http().get().endpoint(EXPR_ENDPOINT)),
                                 set("$.status = \"IN_FLIGHT\""))
                             // catch with exceptWhen + explicit URI error filter + status
                             .catches()
@@ -170,7 +170,7 @@ public class TryCatchDslTest {
                 t ->
                     t.tryCatch(
                         tryCatch()
-                            .tasks(call(http().GET().endpoint(EXPR_ENDPOINT)))
+                            .tasks(call(http().get().endpoint(EXPR_ENDPOINT)))
                             .catches()
                             .when("$.fail == true")
                             .errors(Errors.COMMUNICATION, 503)
@@ -407,7 +407,7 @@ public class TryCatchDslTest {
                         .tasks(
                             call(
                                 "getPet",
-                                http().GET().endpoint("http://localhost:9797").redirect(true)))
+                                http().get().endpoint("http://localhost:9797").redirect(true)))
                         .catches()
                         .errors(Errors.COMMUNICATION, 404)
                         .retry()
@@ -450,7 +450,7 @@ public class TryCatchDslTest {
                         .tasks(
                             call(
                                 "getPet",
-                                http().GET().endpoint("http://localhost:9797").redirect(true)))
+                                http().get().endpoint("http://localhost:9797").redirect(true)))
                         .catches()
                         .errors(Errors.COMMUNICATION, 404)
                         .retry("default")
@@ -494,7 +494,7 @@ public class TryCatchDslTest {
                                         call(
                                             "getPet",
                                             http()
-                                                .GET()
+                                                .get()
                                                 .endpoint("http://localhost:9797")
                                                 .redirect(true)))
                                     .catches()
@@ -539,7 +539,7 @@ public class TryCatchDslTest {
                         .tasks(
                             call(
                                 "getPet",
-                                http().GET().endpoint("http://localhost:9797").redirect(true)))
+                                http().get().endpoint("http://localhost:9797").redirect(true)))
                         .catches()
                         .errors(Errors.COMMUNICATION, 404)
                         .retry()
@@ -567,7 +567,7 @@ public class TryCatchDslTest {
                 tryCatch(
                     "tryTask",
                     tryCatch()
-                        .tasks(call(http().GET().endpoint("http://localhost:9797")))
+                        .tasks(call(http().get().endpoint("http://localhost:9797")))
                         .catches()
                         .errors(Errors.COMMUNICATION, 404)
                         .retry()
@@ -599,7 +599,7 @@ public class TryCatchDslTest {
                 tryCatch(
                     "tryTask",
                     tryCatch()
-                        .tasks(call(http().GET().endpoint("http://localhost:9797")))
+                        .tasks(call(http().get().endpoint("http://localhost:9797")))
                         .catches()
                         .errors(Errors.COMMUNICATION, 404)
                         .retry()


### PR DESCRIPTION
## Summary

- Add `@Deprecated(since = "7.25.0", forRemoval = true)` to `GET()` and `POST()` in `BaseCallHttpSpec`, with Javadoc directing users to `get()`/`post()`
- Replace all `GET()`/`POST()` usages in `fluent/spec` tests with `get()`/`post()`
- Update Javadoc example in `DSL.java`

## Test plan

- [ ] Build passes with no deprecation warnings in tests
- [ ] Existing callers of `GET()`/`POST()` still compile (deprecated, not removed)