### PR TITLE
Initialize OAuth2 default endpoints and expose WorkflowDefinitionId separator

### DIFF
--- a/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/OAuth2AuthenticationPolicyBuilder.java
+++ b/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/OAuth2AuthenticationPolicyBuilder.java
@@ -25,6 +25,7 @@ public final class OAuth2AuthenticationPolicyBuilder
 
   OAuth2AuthenticationPolicyBuilder() {
     super();
+    this.authenticationData.setEndpoints(new OAuth2AuthenticationPropertiesEndpoints());
   }
 
   public OAuth2AuthenticationPolicyBuilder endpoints(

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/WorkflowDefinitionId.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/WorkflowDefinitionId.java
@@ -21,6 +21,8 @@ import io.serverlessworkflow.types.Defaults;
 
 public record WorkflowDefinitionId(String namespace, String name, String version) {
 
+  public static final String DEFAULT_SEPARATOR = ":";
+
   public static WorkflowDefinitionId of(Workflow workflow) {
     Document document = workflow.getDocument();
     return new WorkflowDefinitionId(
@@ -36,7 +38,7 @@ public record WorkflowDefinitionId(String namespace, String name, String version
 
   @Override
   public String toString() {
-    return toString(":");
+    return toString(DEFAULT_SEPARATOR);
   }
 
   public String toString(String separator) {


### PR DESCRIPTION
## Summary

- Initialize `OAuth2AuthenticationPropertiesEndpoints` in `OIDCBuilder` constructor so OAuth2 objects created via the fluent API have spec-compliant default endpoints (`/oauth2/token`, `/oauth2/revoke`, `/oauth2/introspect`) instead of `null`
- Add `DEFAULT_SEPARATOR` constant (`:`) to `WorkflowDefinitionId` and use it in `toString()`, so downstream projects (e.g. quarkus-flow) can reference the canonical separator without duplicating it

## Test plan

- [x] All 162 tests in `fluent/spec` and `impl/core` pass
- [ ] Verify OAuth2 endpoints are non-null when building via fluent API
- [ ] Verify `WorkflowDefinitionId.DEFAULT_SEPARATOR` is accessible from downstream