### PR TITLE
[Fix #1553] Initialize call field in generated Callxxx classes

### DIFF
--- a/api/src/test/java/io/serverlessworkflow/api/FeaturesTest.java
+++ b/api/src/test/java/io/serverlessworkflow/api/FeaturesTest.java
@@ -15,7 +15,6 @@
  */
 package io.serverlessworkflow.api;
 
-import static io.serverlessworkflow.api.WorkflowReader.readWorkflow;
 import static io.serverlessworkflow.api.WorkflowReader.readWorkflowFromClasspath;
 import static io.serverlessworkflow.api.WorkflowReader.validation;
 import static io.serverlessworkflow.api.WorkflowWriter.workflowAsBytes;
@@ -30,8 +29,12 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class FeaturesTest {
+
+  private static final Logger logger = LoggerFactory.getLogger(FeaturesTest.class);
 
   @ParameterizedTest
   @ValueSource(
@@ -71,8 +74,11 @@ public class FeaturesTest {
       writeWorkflow(out, workflow, WorkflowFormat.JSON);
       bytes = out.toByteArray();
     }
+    if (logger.isDebugEnabled()) {
+      logger.debug("Workflow string representation is {}", new String(bytes));
+    }
     try (ByteArrayInputStream in = new ByteArrayInputStream(bytes)) {
-      return readWorkflow(in, WorkflowFormat.JSON);
+      return validation().read(in, WorkflowFormat.JSON);
     }
   }
 

--- a/generators/types/src/main/java/io/serverlessworkflow/generator/CustomAnnotator.java
+++ b/generators/types/src/main/java/io/serverlessworkflow/generator/CustomAnnotator.java
@@ -17,6 +17,7 @@ package io.serverlessworkflow.generator;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JExpr;
 import com.sun.codemodel.JFieldVar;
 import io.serverlessworkflow.annotations.AdditionalProperties;
 import jakarta.validation.constraints.Pattern;
@@ -40,7 +41,9 @@ public class CustomAnnotator extends AbstractAnnotator {
   public void propertyField(
       JFieldVar field, JDefinedClass clazz, String propertyName, JsonNode propertyNode) {
     if (propertyNode.has(CONST)) {
-      field.annotate(Pattern.class).param("regexp", propertyNode.get(CONST).asText());
+      String callValue = propertyNode.get(CONST).asText();
+      field.annotate(Pattern.class).param("regexp", callValue);
+      field.init(JExpr.lit(callValue));
     }
   }
 }


### PR DESCRIPTION
Fix https://github.com/open-workflow-specification/sdk-java/issues/1553

When using DSL, the call field is not set unless the DSL method implementation invokes either setCall or withCall, which current implementation is not actually doing, leading to the reported issue.

Rather than changing a lot of fluent dsl classses both in sdk and experimental (recently moved to qflow) it is better to fix in just one place, the generator of the problematic types.
