### PR TITLE
Improve CloudEvent defaults for emitted events (#1554)

### DIFF
--- a/impl/core/src/main/java/io/serverlessworkflow/impl/WorkflowApplication.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/WorkflowApplication.java
@@ -110,6 +110,7 @@ public class WorkflowApplication implements AutoCloseable {
   private final AllStrategyCorrelationInfoFactory allStrategyCorrelationInfoFactory;
   private final WorkflowLifeCycleCloudEventFactory lifeCycleCloudEventFactory;
   private final ScheduledExecutorService schedulerExecutorService;
+  private final Optional<URI> defaultEventSource;
 
   private WorkflowApplication(Builder builder) {
     this.taskFactory = builder.taskFactory;
@@ -144,6 +145,18 @@ public class WorkflowApplication implements AutoCloseable {
     this.allStrategyCorrelationInfoFactory = builder.allStrategyCorrelationInfoFactory;
     this.lifeCycleCloudEventFactory = builder.lifeCycleCloudEventFactory;
     this.schedulerExecutorService = builder.schedulerExecutorService;
+    this.defaultEventSource = builder.defaultEventSource;
+  }
+
+  /**
+   * Optional application-wide default CloudEvent {@code source} for emitted events. When set, it
+   * takes precedence over the workflow-identity-derived source but is still overridden by an
+   * explicit per-emit {@code source}.
+   *
+   * @return the configured default source, or empty if none was set
+   */
+  public Optional<URI> defaultEventSource() {
+    return defaultEventSource;
   }
 
   public TaskExecutorFactory taskFactory() {
@@ -248,6 +261,7 @@ public class WorkflowApplication implements AutoCloseable {
     private ExecutorServiceFactory executorFactory = new DefaultExecutorServiceFactory();
     private EventConsumer<?, ?> eventConsumer;
     private Collection<EventPublisher> eventPublishers = new ArrayList<>();
+    private Optional<URI> defaultEventSource = Optional.empty();
     private RuntimeDescriptorFactory descriptorFactory =
         () -> new RuntimeDescriptor("reference impl", "1.0.0_alpha", Collections.emptyMap());
     private boolean lifeCycleCEPublishingEnabled = true;
@@ -357,6 +371,22 @@ public class WorkflowApplication implements AutoCloseable {
     public Builder withEventPublisher(EventPublisher eventPublisher) {
       this.eventPublishers.add(eventPublisher);
       return this;
+    }
+
+    /**
+     * Sets an application-wide default CloudEvent {@code source} applied to every emitted event
+     * that does not specify its own source. Overrides the workflow-identity-derived default; still
+     * overridden by an explicit per-emit {@code source}.
+     */
+    public Builder withDefaultEventSource(URI defaultEventSource) {
+      this.defaultEventSource = Optional.ofNullable(defaultEventSource);
+      return this;
+    }
+
+    /** String overload of {@link #withDefaultEventSource(URI)}. */
+    public Builder withDefaultEventSource(String defaultEventSource) {
+      return withDefaultEventSource(
+          defaultEventSource == null ? null : URI.create(defaultEventSource));
     }
 
     public Builder withSecretManager(SecretManager secretManager) {

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/events/CloudEventUtils.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/events/CloudEventUtils.java
@@ -16,6 +16,7 @@
 package io.serverlessworkflow.impl.events;
 
 import io.cloudevents.CloudEvent;
+import io.serverlessworkflow.impl.WorkflowDefinitionId;
 import java.net.URI;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -44,7 +45,24 @@ public class CloudEventUtils {
     return result;
   }
 
+  /**
+   * Derives a traceable CloudEvent {@code source} from the emitting workflow's identity, rendered
+   * as {@code namespace:name:version}.
+   *
+   * @param id the identity of the workflow definition emitting the event
+   * @return a source URI identifying the emitting workflow
+   */
+  public static URI source(WorkflowDefinitionId id) {
+    return URI.create(id.toString(":"));
+  }
+
+  /**
+   * Last-resort {@code source} default when no per-emit, application-level, or identity-derived
+   * source is available. Identifies the SDK itself rather than an opaque placeholder.
+   *
+   * @return a URN identifying this SDK runtime
+   */
   public static URI source() {
-    return URI.create("reference-impl");
+    return URI.create("urn:serverlessworkflow:sdk-java");
   }
 }

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/executors/EmitExecutor.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/executors/EmitExecutor.java
@@ -100,7 +100,7 @@ public class EmitExecutor extends RegularTaskExecutor<EmitTask> {
             .sourceFilter()
             .map(filter -> filter.apply(workflow, taskContext, taskContext.input()))
             .map(URI::create)
-            .orElse(CloudEventUtils.source()));
+            .orElseGet(() -> defaultSource(workflow)));
     ceBuilder.withType(
         props
             .typeFilter()
@@ -110,7 +110,8 @@ public class EmitExecutor extends RegularTaskExecutor<EmitTask> {
     props
         .timeFilter()
         .map(filter -> filter.apply(workflow, taskContext, taskContext.input()))
-        .ifPresent(value -> ceBuilder.withTime(value));
+        .ifPresentOrElse(
+            value -> ceBuilder.withTime(value), () -> ceBuilder.withTime(OffsetDateTime.now()));
     props
         .subjectFilter()
         .map(filter -> filter.apply(workflow, taskContext, taskContext.input()))
@@ -133,6 +134,14 @@ public class EmitExecutor extends RegularTaskExecutor<EmitTask> {
         .ifPresent(value -> value.forEach((k, v) -> addExtension(ceBuilder, k, v)));
     emittedDecorators.forEach(d -> d.decorate(ceBuilder, workflow, taskContext));
     return ceBuilder.build();
+  }
+
+  private static URI defaultSource(WorkflowContext workflow) {
+    WorkflowDefinition definition = workflow.definition();
+    return definition
+        .application()
+        .defaultEventSource()
+        .orElseGet(() -> CloudEventUtils.source(definition.id()));
   }
 
   private static void addExtension(CloudEventBuilder builder, String name, Object value) {

--- a/impl/test/src/test/java/io/serverlessworkflow/impl/test/EmitCloudEventDefaultsTest.java
+++ b/impl/test/src/test/java/io/serverlessworkflow/impl/test/EmitCloudEventDefaultsTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.impl.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.cloudevents.CloudEvent;
+import io.serverlessworkflow.api.WorkflowReader;
+import io.serverlessworkflow.impl.WorkflowApplication;
+import io.serverlessworkflow.impl.WorkflowDefinition;
+import io.serverlessworkflow.impl.events.EventPublisher;
+import java.io.IOException;
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.junit.jupiter.api.Test;
+
+class EmitCloudEventDefaultsTest {
+
+  private static final class CapturingPublisher implements EventPublisher {
+    private final List<CloudEvent> events = new CopyOnWriteArrayList<>();
+
+    @Override
+    public CompletableFuture<Void> publish(CloudEvent event) {
+      events.add(event);
+      return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public void publishLifeCycle(CloudEvent event) {
+      // ignore lifecycle events for this test
+    }
+
+    @Override
+    public void close() {}
+  }
+
+  private static CloudEvent emitAndCapture(WorkflowApplication.Builder builder, String workflow)
+      throws IOException {
+    CapturingPublisher publisher = new CapturingPublisher();
+    try (WorkflowApplication appl =
+        builder.disableLifeCycleCEPublishing().withEventPublisher(publisher).build()) {
+      WorkflowDefinition definition =
+          appl.workflowDefinition(WorkflowReader.readWorkflowFromClasspath(workflow));
+      definition.instance(Map.of("user", Map.of("firstName", "Cruella"))).start().join();
+      assertThat(publisher.events).hasSize(1);
+      return publisher.events.get(0);
+    }
+  }
+
+  @Test
+  void emit_without_source_derives_source_from_workflow_identity() throws IOException {
+    OffsetDateTime before = OffsetDateTime.now();
+    CloudEvent event =
+        emitAndCapture(WorkflowApplication.builder(), "workflows-samples/emit-defaults.yaml");
+    OffsetDateTime after = OffsetDateTime.now();
+
+    // id is always auto-generated
+    assertThat(event.getId()).isNotBlank();
+    // type is user-provided
+    assertThat(event.getType()).isEqualTo("com.acme.order.placed.v1");
+    // source is derived from namespace:name:version of the emitting workflow
+    assertThat(event.getSource()).isEqualTo(URI.create("acme:emit-defaults:2.1.0"));
+    // time now defaults to "now" instead of being omitted
+    assertThat(event.getTime()).isNotNull();
+    assertThat(event.getTime()).isBetween(before, after);
+  }
+
+  @Test
+  void application_default_source_overrides_identity_derived_source() throws IOException {
+    CloudEvent event =
+        emitAndCapture(
+            WorkflowApplication.builder().withDefaultEventSource("urn:acme:orders"),
+            "workflows-samples/emit-defaults.yaml");
+
+    assertThat(event.getSource()).isEqualTo(URI.create("urn:acme:orders"));
+    assertThat(event.getTime()).isNotNull();
+  }
+
+  @Test
+  void explicit_per_emit_source_overrides_application_default() throws IOException {
+    // emit.yaml sets an explicit source: https://petstore.com
+    CloudEvent event =
+        emitAndCapture(
+            WorkflowApplication.builder().withDefaultEventSource("urn:acme:orders"),
+            "workflows-samples/emit.yaml");
+
+    assertThat(event.getSource()).isEqualTo(URI.create("https://petstore.com"));
+  }
+}

--- a/impl/test/src/test/resources/workflows-samples/emit-defaults.yaml
+++ b/impl/test/src/test/resources/workflows-samples/emit-defaults.yaml
@@ -1,0 +1,13 @@
+document:
+  dsl: 1.0.0-alpha1
+  namespace: acme
+  name: emit-defaults
+  version: 2.1.0
+do:
+  - emitEvent:
+      emit:
+        event:
+          with:
+            type: com.acme.order.placed.v1
+            data:
+              greetings: ${ "Hello \(.user.firstName)!" }


### PR DESCRIPTION
## What & why

Fixes #1554.

Emitted CloudEvents (`emit.event.with`) were under-specified relative to the spec, which requires `id`, `source`, and `type`:

| Field | Before | After |
|-------|--------|-------|
| `id` | auto UUID — good | unchanged |
| `type` | throws if missing — correct | unchanged |
| `source` | falls back to `reference-impl` — no traceability | derived from workflow identity / configurable |
| `time` | omitted entirely | defaults to `OffsetDateTime.now()` |

## How

- **`source`** — when an emit declares no source, derive it from the emitting workflow's identity, `namespace:name:version`, via a new `CloudEventUtils.source(WorkflowDefinitionId)`. `EmitExecutor.buildCloudEvent` already has the `WorkflowContext`, so no new plumbing is needed. The no-arg static fallback changes from `reference-impl` to `urn:serverlessworkflow:sdk-java`.
- **`time`** — in `EmitExecutor`, when the `timeFilter` is empty, set `withTime(OffsetDateTime.now())` instead of omitting the attribute. Explicit literal/expression `time` is untouched.
- **Application-level default source** — new `WorkflowApplication.Builder#withDefaultEventSource(URI|String)` lets an application set one source for all emitted events.
- **Resolution order** (highest wins): explicit per-emit `source` → application-level default → workflow-identity-derived → static fallback.

### Validation

`EventProperties` is deliberately left without `@NotNull`/`@NotBlank` annotations: it is shared between the *emit* and *filter* contexts, where required-ness differs, so annotating it would break filter use. With `id`, `source`, and `time` now all defaulted, `type` remains the only required emit attribute and `EmitExecutor` already throws when it is missing — runtime enforcement remains the correct approach.

## Compatibility note

Changing the default `source` from `reference-impl` is a behavioral change; downstream consumers that filtered or asserted on `source == "reference-impl"` will need to update. This seems acceptable pre-1.0 but is called out here for release notes.

## Testing

`EmitCloudEventDefaultsTest` (new) registers a capturing `EventPublisher` and asserts:
- an emit with no source gets `source == namespace:name:version` and a `time` close to now;
- an application-level default source overrides the identity-derived one;
- an explicit per-emit source overrides the application default.

Full `impl/test` + `impl/lifecycleevent` suites pass (239 tests), confirming no regression in lifecycle-event or correlation behavior.

## Downstream

Quarkus Flow tracks the DSL-ergonomics side in quarkiverse/quarkus-flow#776.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
