### PR TITLE
[Fix #1569] OneOf builder null value in serialization

### DIFF
--- a/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/BaseTryTaskBuilder.java
+++ b/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/BaseTryTaskBuilder.java
@@ -351,6 +351,7 @@ public abstract class BaseTryTaskBuilder<
     }
 
     public BackoffBuilder constant(String key, String value) {
+      ensureExclusive(this.constantBackoff, this.exponentialBackOff, this.linearBackoff);
       if (this.constantBackoff == null) {
         this.constantBackoff = new ConstantBackoff();
         this.constantBackoff.setConstant(new Constant());
@@ -360,6 +361,7 @@ public abstract class BaseTryTaskBuilder<
     }
 
     public BackoffBuilder exponential(String key, String value) {
+      ensureExclusive(this.exponentialBackOff, this.constantBackoff, this.linearBackoff);
       if (this.exponentialBackOff == null) {
         this.exponentialBackOff = new ExponentialBackOff();
         this.exponentialBackOff.setExponential(new Exponential());
@@ -369,12 +371,22 @@ public abstract class BaseTryTaskBuilder<
     }
 
     public BackoffBuilder linear(String key, String value) {
+      ensureExclusive(this.linearBackoff, this.constantBackoff, this.exponentialBackOff);
       if (this.linearBackoff == null) {
         this.linearBackoff = new LinearBackoff();
         this.linearBackoff.setLinear(new Linear());
       }
       this.linearBackoff.getLinear().withAdditionalProperty(key, value);
       return this;
+    }
+
+    private void ensureExclusive(Object current, Object... others) {
+      for (Object other : others) {
+        if (other != null) {
+          throw new IllegalStateException(
+              "Only one backoff variant (constant, exponential, or linear) can be configured");
+        }
+      }
     }
 
     public RetryBackoff build() {

--- a/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/BaseTryTaskBuilder.java
+++ b/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/BaseTryTaskBuilder.java
@@ -342,40 +342,49 @@ public abstract class BaseTryTaskBuilder<
 
   public static final class BackoffBuilder {
     private final RetryBackoff retryBackoff;
-    private final ConstantBackoff constantBackoff;
-    private final ExponentialBackOff exponentialBackOff;
-    private final LinearBackoff linearBackoff;
+    private ConstantBackoff constantBackoff;
+    private ExponentialBackOff exponentialBackOff;
+    private LinearBackoff linearBackoff;
 
     BackoffBuilder() {
       this.retryBackoff = new RetryBackoff();
-
-      this.constantBackoff = new ConstantBackoff();
-      this.constantBackoff.setConstant(new Constant());
-      this.exponentialBackOff = new ExponentialBackOff();
-      this.exponentialBackOff.setExponential(new Exponential());
-      this.linearBackoff = new LinearBackoff();
-      this.linearBackoff.setLinear(new Linear());
     }
 
     public BackoffBuilder constant(String key, String value) {
+      if (this.constantBackoff == null) {
+        this.constantBackoff = new ConstantBackoff();
+        this.constantBackoff.setConstant(new Constant());
+      }
       this.constantBackoff.getConstant().withAdditionalProperty(key, value);
       return this;
     }
 
     public BackoffBuilder exponential(String key, String value) {
+      if (this.exponentialBackOff == null) {
+        this.exponentialBackOff = new ExponentialBackOff();
+        this.exponentialBackOff.setExponential(new Exponential());
+      }
       this.exponentialBackOff.getExponential().withAdditionalProperty(key, value);
       return this;
     }
 
     public BackoffBuilder linear(String key, String value) {
+      if (this.linearBackoff == null) {
+        this.linearBackoff = new LinearBackoff();
+        this.linearBackoff.setLinear(new Linear());
+      }
       this.linearBackoff.getLinear().withAdditionalProperty(key, value);
       return this;
     }
 
     public RetryBackoff build() {
-      this.retryBackoff.setConstantBackoff(constantBackoff);
-      this.retryBackoff.setExponentialBackOff(exponentialBackOff);
-      this.retryBackoff.setLinearBackoff(linearBackoff);
+      if (this.constantBackoff != null) {
+        this.retryBackoff.setConstantBackoff(constantBackoff);
+      } else if (this.exponentialBackOff != null) {
+        this.retryBackoff.setExponentialBackOff(exponentialBackOff);
+      } else if (this.linearBackoff != null) {
+        this.retryBackoff.setLinearBackoff(linearBackoff);
+      }
       return this.retryBackoff;
     }
   }

--- a/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/ReferenceableAuthenticationPolicyBuilder.java
+++ b/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/ReferenceableAuthenticationPolicyBuilder.java
@@ -79,8 +79,11 @@ public class ReferenceableAuthenticationPolicyBuilder {
 
   public ReferenceableAuthenticationPolicy build() {
     final ReferenceableAuthenticationPolicy policy = new ReferenceableAuthenticationPolicy();
-    policy.setAuthenticationPolicy(this.authenticationPolicy);
-    policy.setAuthenticationPolicyReference(this.authenticationPolicyReference);
+    if (this.authenticationPolicyReference != null) {
+      policy.setAuthenticationPolicyReference(this.authenticationPolicyReference);
+    } else if (this.authenticationPolicy != null) {
+      policy.setAuthenticationPolicy(this.authenticationPolicy);
+    }
     return policy;
   }
 }

--- a/fluent/spec/src/test/java/io/serverlessworkflow/fluent/spec/dsl/CallHttpAuthDslTest.java
+++ b/fluent/spec/src/test/java/io/serverlessworkflow/fluent/spec/dsl/CallHttpAuthDslTest.java
@@ -234,6 +234,32 @@ public class CallHttpAuthDslTest {
   }
 
   @Test
+  void when_call_http_with_basic_auth_then_oneof_value_is_set() {
+    Workflow wf =
+        WorkflowBuilder.workflow("f", "ns", "1")
+            .tasks(call(http().get().endpoint(EXPR_ENDPOINT, basic("alice", "secret"))))
+            .build();
+
+    var authentication =
+        wf.getDo()
+            .get(0)
+            .getTask()
+            .getCallTask()
+            .getCallHTTP()
+            .getWith()
+            .getEndpoint()
+            .getEndpointConfiguration()
+            .getAuthentication();
+
+    assertThat(authentication.get())
+        .as("ReferenceableAuthenticationPolicy.get() must not be null for serialization")
+        .isNotNull();
+
+    assertThat(authentication.getAuthenticationPolicy()).isNotNull();
+    assertThat(authentication.getAuthenticationPolicyReference()).isNull();
+  }
+
+  @Test
   void when_call_http_with_basic_auth_on_uri_string() {
     Workflow wf =
         WorkflowBuilder.workflow("f", "ns", "1")

--- a/fluent/spec/src/test/java/io/serverlessworkflow/fluent/spec/dsl/TryCatchDslTest.java
+++ b/fluent/spec/src/test/java/io/serverlessworkflow/fluent/spec/dsl/TryCatchDslTest.java
@@ -622,4 +622,76 @@ public class TryCatchDslTest {
     assertThat(constant).isNotNull();
     assertThat(constant.getAdditionalProperties()).containsEntry("c", "10");
   }
+
+  @Test
+  void when_try_catch_backoff_exponential_then_oneof_value_is_set() {
+    Workflow wf =
+        WorkflowBuilder.workflow("try-catch-backoff-oneof", "test", "0.1.0")
+            .tasks(
+                tryCatch(
+                    "tryTask",
+                    tryCatch()
+                        .tasks(call(http().get().endpoint("http://localhost:9797")))
+                        .catches()
+                        .errors(Errors.COMMUNICATION, 404)
+                        .retry()
+                        .backoffExponential()
+                        .done()
+                        .done()))
+            .build();
+
+    var backoff =
+        wf.getDo()
+            .get(0)
+            .getTask()
+            .getTryTask()
+            .getCatch()
+            .getRetry()
+            .getRetryPolicyDefinition()
+            .getBackoff();
+
+    assertThat(backoff.get())
+        .as("RetryBackoff.get() must not be null for serialization")
+        .isNotNull();
+
+    assertThat(backoff.getExponentialBackOff()).isNotNull();
+    assertThat(backoff.getConstantBackoff()).isNull();
+    assertThat(backoff.getLinearBackoff()).isNull();
+  }
+
+  @Test
+  void when_try_catch_backoff_constant_then_oneof_value_is_set() {
+    Workflow wf =
+        WorkflowBuilder.workflow("try-catch-backoff-oneof-const", "test", "0.1.0")
+            .tasks(
+                tryCatch(
+                    "tryTask",
+                    tryCatch()
+                        .tasks(call(http().get().endpoint("http://localhost:9797")))
+                        .catches()
+                        .errors(Errors.COMMUNICATION, 404)
+                        .retry()
+                        .backoffConstant()
+                        .done()
+                        .done()))
+            .build();
+
+    var backoff =
+        wf.getDo()
+            .get(0)
+            .getTask()
+            .getTryTask()
+            .getCatch()
+            .getRetry()
+            .getRetryPolicyDefinition()
+            .getBackoff();
+
+    assertThat(backoff.get())
+        .as("RetryBackoff.get() must not be null for serialization")
+        .isNotNull();
+
+    assertThat(backoff.getConstantBackoff()).isNotNull();
+    assertThat(backoff.getExponentialBackOff()).isNull();
+    assertThat(backoff.getLinearBackoff()).isNull();
+  }
 }

--- a/fluent/spec/src/test/java/io/serverlessworkflow/fluent/spec/dsl/TryCatchDslTest.java
+++ b/fluent/spec/src/test/java/io/serverlessworkflow/fluent/spec/dsl/TryCatchDslTest.java
@@ -24,6 +24,7 @@ import static io.serverlessworkflow.fluent.spec.dsl.DSL.set;
 import static io.serverlessworkflow.fluent.spec.dsl.DSL.tryCatch;
 import static io.serverlessworkflow.fluent.spec.dsl.DSL.use;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.serverlessworkflow.api.types.Workflow;
 import io.serverlessworkflow.fluent.spec.WorkflowBuilder;
@@ -693,5 +694,30 @@ public class TryCatchDslTest {
     assertThat(backoff.getConstantBackoff()).isNotNull();
     assertThat(backoff.getExponentialBackOff()).isNull();
     assertThat(backoff.getLinearBackoff()).isNull();
+  }
+
+  @Test
+  void when_backoff_builder_mixes_variants_then_throws() {
+    assertThatThrownBy(
+            () ->
+                WorkflowBuilder.workflow("mixed-backoff", "test", "0.1.0")
+                    .tasks(
+                        tryCatch(
+                            "tryTask",
+                            tryCatch()
+                                .tasks(call(http().get().endpoint("http://localhost:9797")))
+                                .catches()
+                                .errors(Errors.COMMUNICATION, 404)
+                                .retry()
+                                .backoff(
+                                    b -> {
+                                      b.constant("c", "10");
+                                      b.exponential("e", "1.5");
+                                    })
+                                .done()
+                                .done()))
+                    .build())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Only one backoff variant");
   }
 }


### PR DESCRIPTION
## Summary

- `ReferenceableAuthenticationPolicyBuilder.build()` and `BackoffBuilder.build()` call all OneOf setters unconditionally, causing the last setter (with null/empty) to overwrite `OneOfValueProvider.value` — leading to `null` or wrong values during serialization.
- Fix: add null guards in `build()` so only the configured setter is called. Lazy-init backoff objects in `BackoffBuilder` to avoid empty defaults.
- Add tests verifying `OneOfValueProvider.get()` returns the correct value.

Fixes #1569