### PR TITLE
Clearing additional objects map

### DIFF
--- a/impl/core/src/main/java/io/serverlessworkflow/impl/WorkflowMutableInstance.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/WorkflowMutableInstance.java
@@ -109,20 +109,25 @@ public class WorkflowMutableInstance implements WorkflowInstance {
                                         l ->
                                             l.onWorkflowCompleted(
                                                 new WorkflowCompletedEvent(workflowContext, model)))
-                                    .thenApply(__ -> model)));
+                                    .thenApply(__ -> model)))
+            .whenComplete(this::cleanUp);
     futureRef.set(future);
     return future;
   }
 
   private void whenCompleted(WorkflowModel result, Throwable ex) {
     completedAt = Instant.now();
+    if (ex != null) {
+      handleException(ex instanceof CompletionException ? ex = ex.getCause() : ex);
+    }
+  }
+
+  private void cleanUp(WorkflowModel result, Throwable ex) {
     additionalObjects.values().stream()
         .filter(AutoCloseable.class::isInstance)
         .map(AutoCloseable.class::cast)
         .forEach(WorkflowUtils::safeClose);
-    if (ex != null) {
-      handleException(ex instanceof CompletionException ? ex = ex.getCause() : ex);
-    }
+    additionalObjects.clear();
     workflowContext.definition().removeInstance(this);
   }
 


### PR DESCRIPTION
Besides calling Closeable for every additional object, the holding map should be clear in case the WorkflowInstance is not removed from memory (which currrently might happen only for scheduled instances)

