### PR TITLE
[5.x] - Migrate to Jackson 3 and json-schema-validator 3

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -22,15 +22,15 @@
             <artifactId>jcl-over-slf4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <groupId>tools.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
         <dependency>
@@ -92,6 +92,7 @@
                     <targetVersion>${java.version}</targetVersion>
                     <usePrimitives>true</usePrimitives>
                     <useJakartaValidation>true</useJakartaValidation>
+                    <annotationStyle>jackson3</annotationStyle>
                 </configuration>
                 <executions>
                     <execution>
@@ -99,6 +100,40 @@
                             <goal>generate</goal>
                         </goals>
                         <phase>generate-sources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <!--
+                          WORKAROUND: https://github.com/joelittlejohn/jsonschema2pojo/issues/1586
+
+                          jsonschema2pojo 1.3.3 emits an invalid placement when useJakartaValidation=true:
+                              List<@Valid java.lang.String> scopes
+                          javac in Java 22+ rejects this with 'cannot find symbol: class java' because
+                          the @Valid type-use annotation must sit between the package and the simple
+                          name when the type is fully qualified. The correct placement is:
+                              List<java.lang.@Valid String> scopes
+
+                          Upstream fix merged in jsonschema2pojo PR #1778 but not yet released.
+                          Remove this step once a release including #1778 is in use.
+                        -->
+                        <id>fix-generated-valid-annotation-placement</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <replace dir="${project.build.directory}/generated-sources/src/main/java"
+                                         token="@Valid java.lang.String" value="java.lang.@Valid String">
+                                    <include name="**/*.java" />
+                                </replace>
+                            </target>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/AuthDefinitionDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/AuthDefinitionDeserializer.java
@@ -15,21 +15,17 @@
  */
 package io.serverlessworkflow.api.deserializers;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.serverlessworkflow.api.auth.AuthDefinition;
 import io.serverlessworkflow.api.auth.BasicAuthDefinition;
 import io.serverlessworkflow.api.auth.BearerAuthDefinition;
 import io.serverlessworkflow.api.auth.OauthDefinition;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
-import java.io.IOException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class AuthDefinitionDeserializer extends StdDeserializer<AuthDefinition> {
-
-  private static final long serialVersionUID = 510l;
 
   @SuppressWarnings("unused")
   private WorkflowPropertySource context;
@@ -48,30 +44,29 @@ public class AuthDefinitionDeserializer extends StdDeserializer<AuthDefinition> 
   }
 
   @Override
-  public AuthDefinition deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+  public AuthDefinition deserialize(JsonParser jp, DeserializationContext ctxt) {
 
-    ObjectMapper mapper = (ObjectMapper) jp.getCodec();
-    JsonNode node = jp.getCodec().readTree(jp);
+    JsonNode node = jp.readValueAsTree();
 
     AuthDefinition authDefinition = new AuthDefinition();
 
     if (node.get("name") != null) {
-      authDefinition.setName(node.get("name").asText());
+      authDefinition.setName(node.get("name").asString());
     }
 
     if (node.get("scheme") != null) {
-      authDefinition.setScheme(AuthDefinition.Scheme.fromValue(node.get("scheme").asText()));
+      authDefinition.setScheme(AuthDefinition.Scheme.fromValue(node.get("scheme").asString()));
     }
 
     if (node.get("properties") != null) {
       JsonNode propsNode = node.get("properties");
 
       if (propsNode.get("grantType") != null) {
-        authDefinition.setOauth(mapper.treeToValue(propsNode, OauthDefinition.class));
+        authDefinition.setOauth(ctxt.readTreeAsValue(propsNode, OauthDefinition.class));
       } else if (propsNode.get("token") != null) {
-        authDefinition.setBearerauth(mapper.treeToValue(propsNode, BearerAuthDefinition.class));
+        authDefinition.setBearerauth(ctxt.readTreeAsValue(propsNode, BearerAuthDefinition.class));
       } else {
-        authDefinition.setBasicauth(mapper.treeToValue(propsNode, BasicAuthDefinition.class));
+        authDefinition.setBasicauth(ctxt.readTreeAsValue(propsNode, BasicAuthDefinition.class));
       }
     }
 

--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/AuthDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/AuthDeserializer.java
@@ -15,24 +15,21 @@
  */
 package io.serverlessworkflow.api.deserializers;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.serverlessworkflow.api.auth.AuthDefinition;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
 import io.serverlessworkflow.api.utils.Utils;
 import io.serverlessworkflow.api.workflow.Auth;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class AuthDeserializer extends StdDeserializer<Auth> {
 
-  private static final long serialVersionUID = 520L;
   private static Logger logger = LoggerFactory.getLogger(AuthDeserializer.class);
 
   @SuppressWarnings("unused")
@@ -52,27 +49,26 @@ public class AuthDeserializer extends StdDeserializer<Auth> {
   }
 
   @Override
-  public Auth deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+  public Auth deserialize(JsonParser jp, DeserializationContext ctxt) {
 
-    ObjectMapper mapper = (ObjectMapper) jp.getCodec();
-    JsonNode node = jp.getCodec().readTree(jp);
+    JsonNode node = jp.readValueAsTree();
 
     Auth auth = new Auth();
     List<AuthDefinition> authDefinitions = new ArrayList<>();
 
     if (node.isArray()) {
       for (final JsonNode nodeEle : node) {
-        authDefinitions.add(mapper.treeToValue(nodeEle, AuthDefinition.class));
+        authDefinitions.add(ctxt.readTreeAsValue(nodeEle, AuthDefinition.class));
       }
     } else {
-      String authFileDef = node.asText();
+      String authFileDef = node.asString();
       String authFileSrc = Utils.getResourceFileAsString(authFileDef);
       if (authFileSrc != null && authFileSrc.trim().length() > 0) {
         JsonNode authRefNode = Utils.getNode(authFileSrc);
         JsonNode refAuth = authRefNode.get("auth");
         if (refAuth != null) {
           for (final JsonNode nodeEle : refAuth) {
-            authDefinitions.add(mapper.treeToValue(nodeEle, AuthDefinition.class));
+            authDefinitions.add(ctxt.readTreeAsValue(nodeEle, AuthDefinition.class));
           }
         } else {
           logger.error("Unable to find auth definitions in reference file: {}", authFileSrc);

--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/ConstantsDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/ConstantsDeserializer.java
@@ -15,20 +15,18 @@
  */
 package io.serverlessworkflow.api.deserializers;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
 import io.serverlessworkflow.api.utils.Utils;
 import io.serverlessworkflow.api.workflow.Constants;
-import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class ConstantsDeserializer extends StdDeserializer<Constants> {
 
-  private static final long serialVersionUID = 510l;
   private static Logger logger = LoggerFactory.getLogger(ConstantsDeserializer.class);
 
   @SuppressWarnings("unused")
@@ -48,9 +46,9 @@ public class ConstantsDeserializer extends StdDeserializer<Constants> {
   }
 
   @Override
-  public Constants deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+  public Constants deserialize(JsonParser jp, DeserializationContext ctxt) {
 
-    JsonNode node = jp.getCodec().readTree(jp);
+    JsonNode node = jp.readValueAsTree();
 
     Constants constants = new Constants();
     JsonNode constantsDefinition = null;
@@ -58,7 +56,7 @@ public class ConstantsDeserializer extends StdDeserializer<Constants> {
     if (node.isObject()) {
       constantsDefinition = node;
     } else {
-      String constantsFileDef = node.asText();
+      String constantsFileDef = node.isNull() ? "null" : node.asString();
       constants.setRefValue(constantsFileDef);
       String constantsFileSrc = Utils.getResourceFileAsString(constantsFileDef);
       if (constantsFileSrc != null && constantsFileSrc.trim().length() > 0) {

--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/ContinueAsDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/ContinueAsDeserializer.java
@@ -15,19 +15,15 @@
  */
 package io.serverlessworkflow.api.deserializers;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.serverlessworkflow.api.end.ContinueAs;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
 import io.serverlessworkflow.api.timeouts.WorkflowExecTimeout;
-import java.io.IOException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class ContinueAsDeserializer extends StdDeserializer<ContinueAs> {
-
-  private static final long serialVersionUID = 510l;
 
   @SuppressWarnings("unused")
   private WorkflowPropertySource context;
@@ -46,35 +42,34 @@ public class ContinueAsDeserializer extends StdDeserializer<ContinueAs> {
   }
 
   @Override
-  public ContinueAs deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+  public ContinueAs deserialize(JsonParser jp, DeserializationContext ctxt) {
 
-    ObjectMapper mapper = (ObjectMapper) jp.getCodec();
-    JsonNode node = jp.getCodec().readTree(jp);
+    JsonNode node = jp.readValueAsTree();
 
     ContinueAs continueAs = new ContinueAs();
 
     if (!node.isObject()) {
-      continueAs.setWorkflowId(node.asText());
+      continueAs.setWorkflowId(node.asString());
       continueAs.setVersion(null);
       continueAs.setData(null);
       continueAs.setWorkflowExecTimeout(null);
       return continueAs;
     } else {
       if (node.get("workflowId") != null) {
-        continueAs.setWorkflowId(node.get("workflowId").asText());
+        continueAs.setWorkflowId(node.get("workflowId").asString());
       }
 
       if (node.get("version") != null) {
-        continueAs.setVersion(node.get("version").asText());
+        continueAs.setVersion(node.get("version").asString());
       }
 
       if (node.get("data") != null) {
-        continueAs.setData(node.get("data").asText());
+        continueAs.setData(node.get("data").asString());
       }
 
       if (node.get("workflowExecTimeout") != null) {
         continueAs.setWorkflowExecTimeout(
-            mapper.treeToValue(node.get("workflowExecTimeout"), WorkflowExecTimeout.class));
+            ctxt.readTreeAsValue(node.get("workflowExecTimeout"), WorkflowExecTimeout.class));
       }
 
       return continueAs;

--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/CronDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/CronDeserializer.java
@@ -15,17 +15,14 @@
  */
 package io.serverlessworkflow.api.deserializers;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.serverlessworkflow.api.cron.Cron;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
-import java.io.IOException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class CronDeserializer extends StdDeserializer<Cron> {
-
-  private static final long serialVersionUID = 510l;
 
   @SuppressWarnings("unused")
   private WorkflowPropertySource context;
@@ -44,22 +41,22 @@ public class CronDeserializer extends StdDeserializer<Cron> {
   }
 
   @Override
-  public Cron deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+  public Cron deserialize(JsonParser jp, DeserializationContext ctxt) {
 
-    JsonNode node = jp.getCodec().readTree(jp);
+    JsonNode node = jp.readValueAsTree();
 
     Cron cron = new Cron();
 
     if (!node.isObject()) {
-      cron.setExpression(node.asText());
+      cron.setExpression(node.asString());
       return cron;
     } else {
       if (node.get("expression") != null) {
-        cron.setExpression(node.get("expression").asText());
+        cron.setExpression(node.get("expression").asString());
       }
 
       if (node.get("validUntil") != null) {
-        cron.setValidUntil(node.get("validUntil").asText());
+        cron.setValidUntil(node.get("validUntil").asString());
       }
 
       return cron;

--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/DataInputSchemaDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/DataInputSchemaDeserializer.java
@@ -15,19 +15,17 @@
  */
 package io.serverlessworkflow.api.deserializers;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
 import io.serverlessworkflow.api.workflow.DataInputSchema;
-import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class DataInputSchemaDeserializer extends StdDeserializer<DataInputSchema> {
 
-  private static final long serialVersionUID = 510l;
   private static Logger logger = LoggerFactory.getLogger(DataInputSchemaDeserializer.class);
 
   public DataInputSchemaDeserializer() {
@@ -43,10 +41,9 @@ public class DataInputSchemaDeserializer extends StdDeserializer<DataInputSchema
   }
 
   @Override
-  public DataInputSchema deserialize(JsonParser jp, DeserializationContext ctxt)
-      throws IOException {
+  public DataInputSchema deserialize(JsonParser jp, DeserializationContext ctxt) {
 
-    JsonNode node = jp.getCodec().readTree(jp);
+    JsonNode node = jp.readValueAsTree();
 
     DataInputSchema dataInputSchema = new DataInputSchema();
     JsonNode schemaDefinition = null;
@@ -56,7 +53,8 @@ public class DataInputSchemaDeserializer extends StdDeserializer<DataInputSchema
       dataInputSchema.setFailOnValidationErrors(node.get("failOnValidationErrors").asBoolean());
       dataInputSchema.setSchemaDef(schemaDefinition);
     } else {
-      String schemaFileDef = node.isObject() ? node.get("schema").asText() : node.asText();
+      JsonNode schemaRefNode = node.isObject() ? node.get("schema") : node;
+      String schemaFileDef = schemaRefNode.isNull() ? "null" : schemaRefNode.asString();
       dataInputSchema.setFailOnValidationErrors(true);
       dataInputSchema.setRefValue(schemaFileDef);
     }

--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/DefaultStateTypeDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/DefaultStateTypeDeserializer.java
@@ -15,18 +15,16 @@
  */
 package io.serverlessworkflow.api.deserializers;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
 import io.serverlessworkflow.api.states.DefaultState;
-import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class DefaultStateTypeDeserializer extends StdDeserializer<DefaultState.Type> {
 
-  private static final long serialVersionUID = 510l;
   private static Logger logger = LoggerFactory.getLogger(DefaultStateTypeDeserializer.class);
 
   private WorkflowPropertySource context;
@@ -45,10 +43,9 @@ public class DefaultStateTypeDeserializer extends StdDeserializer<DefaultState.T
   }
 
   @Override
-  public DefaultState.Type deserialize(JsonParser jp, DeserializationContext ctxt)
-      throws IOException {
+  public DefaultState.Type deserialize(JsonParser jp, DeserializationContext ctxt) {
 
-    String value = jp.getText();
+    String value = jp.getString();
 
     if (context != null) {
       try {
@@ -57,14 +54,14 @@ public class DefaultStateTypeDeserializer extends StdDeserializer<DefaultState.T
         if (result != null) {
           return DefaultState.Type.fromValue(result);
         } else {
-          return DefaultState.Type.fromValue(jp.getText());
+          return DefaultState.Type.fromValue(jp.getString());
         }
       } catch (Exception e) {
         logger.info("Exception trying to evaluate property: {}", e.getMessage());
-        return DefaultState.Type.fromValue(jp.getText());
+        return DefaultState.Type.fromValue(jp.getString());
       }
     } else {
-      return DefaultState.Type.fromValue(jp.getText());
+      return DefaultState.Type.fromValue(jp.getString());
     }
   }
 }

--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/EndDefinitionDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/EndDefinitionDeserializer.java
@@ -15,23 +15,19 @@
  */
 package io.serverlessworkflow.api.deserializers;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.serverlessworkflow.api.end.ContinueAs;
 import io.serverlessworkflow.api.end.End;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
 import io.serverlessworkflow.api.produce.ProduceEvent;
 import io.serverlessworkflow.api.start.Start;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class EndDefinitionDeserializer extends StdDeserializer<End> {
-
-  private static final long serialVersionUID = 510l;
 
   @SuppressWarnings("unused")
   private WorkflowPropertySource context;
@@ -50,10 +46,9 @@ public class EndDefinitionDeserializer extends StdDeserializer<End> {
   }
 
   @Override
-  public End deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+  public End deserialize(JsonParser jp, DeserializationContext ctxt) {
 
-    ObjectMapper mapper = (ObjectMapper) jp.getCodec();
-    JsonNode node = jp.getCodec().readTree(jp);
+    JsonNode node = jp.readValueAsTree();
 
     End end = new End();
 
@@ -67,7 +62,7 @@ public class EndDefinitionDeserializer extends StdDeserializer<End> {
       if (node.get("produceEvents") != null) {
         List<ProduceEvent> produceEvents = new ArrayList<>();
         for (final JsonNode nodeEle : node.get("produceEvents")) {
-          produceEvents.add(mapper.treeToValue(nodeEle, ProduceEvent.class));
+          produceEvents.add(ctxt.readTreeAsValue(nodeEle, ProduceEvent.class));
         }
         end.setProduceEvents(produceEvents);
       }
@@ -85,7 +80,7 @@ public class EndDefinitionDeserializer extends StdDeserializer<End> {
       }
 
       if (node.get("continueAs") != null) {
-        end.setContinueAs(mapper.treeToValue(node.get("continueAs"), ContinueAs.class));
+        end.setContinueAs(ctxt.readTreeAsValue(node.get("continueAs"), ContinueAs.class));
       }
 
       return end;

--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/ErrorsDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/ErrorsDeserializer.java
@@ -15,24 +15,21 @@
  */
 package io.serverlessworkflow.api.deserializers;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.serverlessworkflow.api.error.ErrorDefinition;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
 import io.serverlessworkflow.api.utils.Utils;
 import io.serverlessworkflow.api.workflow.Errors;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class ErrorsDeserializer extends StdDeserializer<Errors> {
 
-  private static final long serialVersionUID = 510l;
   private static Logger logger = LoggerFactory.getLogger(ErrorsDeserializer.class);
 
   @SuppressWarnings("unused")
@@ -52,27 +49,26 @@ public class ErrorsDeserializer extends StdDeserializer<Errors> {
   }
 
   @Override
-  public Errors deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+  public Errors deserialize(JsonParser jp, DeserializationContext ctxt) {
 
-    ObjectMapper mapper = (ObjectMapper) jp.getCodec();
-    JsonNode node = jp.getCodec().readTree(jp);
+    JsonNode node = jp.readValueAsTree();
 
     Errors errors = new Errors();
     List<ErrorDefinition> errorDefinitions = new ArrayList<>();
 
     if (node.isArray()) {
       for (final JsonNode nodeEle : node) {
-        errorDefinitions.add(mapper.treeToValue(nodeEle, ErrorDefinition.class));
+        errorDefinitions.add(ctxt.readTreeAsValue(nodeEle, ErrorDefinition.class));
       }
     } else {
-      String errorsFileDef = node.asText();
+      String errorsFileDef = node.asString();
       String errorsFileSrc = Utils.getResourceFileAsString(errorsFileDef);
       if (errorsFileSrc != null && errorsFileSrc.trim().length() > 0) {
         JsonNode errorsRefNode = Utils.getNode(errorsFileSrc);
         JsonNode refErrors = errorsRefNode.get("errors");
         if (refErrors != null) {
           for (final JsonNode nodeEle : refErrors) {
-            errorDefinitions.add(mapper.treeToValue(nodeEle, ErrorDefinition.class));
+            errorDefinitions.add(ctxt.readTreeAsValue(nodeEle, ErrorDefinition.class));
           }
         } else {
           logger.error("Unable to find error definitions in reference file: {}", errorsFileSrc);

--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/EventDefinitionKindDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/EventDefinitionKindDeserializer.java
@@ -15,17 +15,15 @@
  */
 package io.serverlessworkflow.api.deserializers;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.serverlessworkflow.api.events.EventDefinition;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
-import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class EventDefinitionKindDeserializer extends StdDeserializer<EventDefinition.Kind> {
-  private static final long serialVersionUID = 510l;
   private static Logger logger = LoggerFactory.getLogger(EventDefinitionKindDeserializer.class);
 
   private WorkflowPropertySource context;
@@ -44,10 +42,9 @@ public class EventDefinitionKindDeserializer extends StdDeserializer<EventDefini
   }
 
   @Override
-  public EventDefinition.Kind deserialize(JsonParser jp, DeserializationContext ctxt)
-      throws IOException {
+  public EventDefinition.Kind deserialize(JsonParser jp, DeserializationContext ctxt) {
 
-    String value = jp.getText();
+    String value = jp.getString();
     if (context != null) {
       try {
         String result = context.getPropertySource().getProperty(value);
@@ -55,14 +52,14 @@ public class EventDefinitionKindDeserializer extends StdDeserializer<EventDefini
         if (result != null) {
           return EventDefinition.Kind.fromValue(result);
         } else {
-          return EventDefinition.Kind.fromValue(jp.getText());
+          return EventDefinition.Kind.fromValue(jp.getString());
         }
       } catch (Exception e) {
         logger.info("Exception trying to evaluate property: {}", e.getMessage());
-        return EventDefinition.Kind.fromValue(jp.getText());
+        return EventDefinition.Kind.fromValue(jp.getString());
       }
     } else {
-      return EventDefinition.Kind.fromValue(jp.getText());
+      return EventDefinition.Kind.fromValue(jp.getString());
     }
   }
 }

--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/EventsDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/EventsDeserializer.java
@@ -15,24 +15,21 @@
  */
 package io.serverlessworkflow.api.deserializers;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.serverlessworkflow.api.events.EventDefinition;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
 import io.serverlessworkflow.api.utils.Utils;
 import io.serverlessworkflow.api.workflow.Events;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class EventsDeserializer extends StdDeserializer<Events> {
 
-  private static final long serialVersionUID = 510l;
   private static Logger logger = LoggerFactory.getLogger(EventsDeserializer.class);
 
   @SuppressWarnings("unused")
@@ -52,20 +49,19 @@ public class EventsDeserializer extends StdDeserializer<Events> {
   }
 
   @Override
-  public Events deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+  public Events deserialize(JsonParser jp, DeserializationContext ctxt) {
 
-    ObjectMapper mapper = (ObjectMapper) jp.getCodec();
-    JsonNode node = jp.getCodec().readTree(jp);
+    JsonNode node = jp.readValueAsTree();
 
     Events events = new Events();
     List<EventDefinition> eventDefs = new ArrayList<>();
 
     if (node.isArray()) {
       for (final JsonNode nodeEle : node) {
-        eventDefs.add(mapper.treeToValue(nodeEle, EventDefinition.class));
+        eventDefs.add(ctxt.readTreeAsValue(nodeEle, EventDefinition.class));
       }
     } else {
-      String eventsFileDef = node.asText();
+      String eventsFileDef = node.asString();
       String eventsFileSrc = Utils.getResourceFileAsString(eventsFileDef);
       if (eventsFileSrc != null && eventsFileSrc.trim().length() > 0) {
         // if its a yaml def convert to json first
@@ -73,7 +69,7 @@ public class EventsDeserializer extends StdDeserializer<Events> {
         JsonNode refEvents = eventsRefNode.get("events");
         if (refEvents != null) {
           for (final JsonNode nodeEle : refEvents) {
-            eventDefs.add(mapper.treeToValue(nodeEle, EventDefinition.class));
+            eventDefs.add(ctxt.readTreeAsValue(nodeEle, EventDefinition.class));
           }
         } else {
           logger.error("Unable to find event definitions in reference file: {}", eventsFileSrc);

--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/ExtensionDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/ExtensionDeserializer.java
@@ -15,18 +15,16 @@
  */
 package io.serverlessworkflow.api.deserializers;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.serverlessworkflow.api.interfaces.Extension;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class ExtensionDeserializer extends StdDeserializer<Extension> {
 
@@ -52,12 +50,11 @@ public class ExtensionDeserializer extends StdDeserializer<Extension> {
   }
 
   @Override
-  public Extension deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+  public Extension deserialize(JsonParser jp, DeserializationContext ctxt) {
 
-    ObjectMapper mapper = (ObjectMapper) jp.getCodec();
-    JsonNode node = jp.getCodec().readTree(jp);
+    JsonNode node = jp.readValueAsTree();
 
-    String extensionId = node.get("extensionId").asText();
+    String extensionId = node.get("extensionId").asString();
 
     if (context != null) {
       try {
@@ -73,7 +70,7 @@ public class ExtensionDeserializer extends StdDeserializer<Extension> {
 
     // based on the name return the specific extension impl
     if (extensionsMap != null && extensionsMap.containsKey(extensionId)) {
-      return mapper.treeToValue(node, extensionsMap.get(extensionId));
+      return ctxt.readTreeAsValue(node, extensionsMap.get(extensionId));
     } else {
       throw new IllegalArgumentException("Extension handler not registered for: " + extensionId);
     }

--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/FunctionDefinitionTypeDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/FunctionDefinitionTypeDeserializer.java
@@ -15,18 +15,16 @@
  */
 package io.serverlessworkflow.api.deserializers;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.serverlessworkflow.api.functions.FunctionDefinition;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
-import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class FunctionDefinitionTypeDeserializer extends StdDeserializer<FunctionDefinition.Type> {
 
-  private static final long serialVersionUID = 510l;
   private static Logger logger = LoggerFactory.getLogger(FunctionDefinitionTypeDeserializer.class);
 
   private WorkflowPropertySource context;
@@ -45,10 +43,9 @@ public class FunctionDefinitionTypeDeserializer extends StdDeserializer<Function
   }
 
   @Override
-  public FunctionDefinition.Type deserialize(JsonParser jp, DeserializationContext ctxt)
-      throws IOException {
+  public FunctionDefinition.Type deserialize(JsonParser jp, DeserializationContext ctxt) {
 
-    String value = jp.getText();
+    String value = jp.getString();
     if (context != null) {
       try {
         String result = context.getPropertySource().getProperty(value);
@@ -56,14 +53,14 @@ public class FunctionDefinitionTypeDeserializer extends StdDeserializer<Function
         if (result != null) {
           return FunctionDefinition.Type.fromValue(result);
         } else {
-          return FunctionDefinition.Type.fromValue(jp.getText());
+          return FunctionDefinition.Type.fromValue(jp.getString());
         }
       } catch (Exception e) {
         logger.info("Exception trying to evaluate property: {}", e.getMessage());
-        return FunctionDefinition.Type.fromValue(jp.getText());
+        return FunctionDefinition.Type.fromValue(jp.getString());
       }
     } else {
-      return FunctionDefinition.Type.fromValue(jp.getText());
+      return FunctionDefinition.Type.fromValue(jp.getString());
     }
   }
 }

--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/FunctionRefDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/FunctionRefDeserializer.java
@@ -15,18 +15,14 @@
  */
 package io.serverlessworkflow.api.deserializers;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.serverlessworkflow.api.functions.FunctionRef;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
-import java.io.IOException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class FunctionRefDeserializer extends StdDeserializer<FunctionRef> {
-
-  private static final long serialVersionUID = 510l;
 
   @SuppressWarnings("unused")
   private WorkflowPropertySource context;
@@ -45,33 +41,32 @@ public class FunctionRefDeserializer extends StdDeserializer<FunctionRef> {
   }
 
   @Override
-  public FunctionRef deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+  public FunctionRef deserialize(JsonParser jp, DeserializationContext ctxt) {
 
-    ObjectMapper mapper = (ObjectMapper) jp.getCodec();
-    JsonNode node = jp.getCodec().readTree(jp);
+    JsonNode node = jp.readValueAsTree();
 
     FunctionRef functionRef = new FunctionRef();
 
     if (!node.isObject()) {
-      functionRef.setRefName(node.asText());
+      functionRef.setRefName(node.asString());
       functionRef.setArguments(null);
       functionRef.setInvoke(FunctionRef.Invoke.SYNC);
       return functionRef;
     } else {
       if (node.get("arguments") != null) {
-        functionRef.setArguments(mapper.treeToValue(node.get("arguments"), JsonNode.class));
+        functionRef.setArguments(ctxt.readTreeAsValue(node.get("arguments"), JsonNode.class));
       }
 
       if (node.get("refName") != null) {
-        functionRef.setRefName(node.get("refName").asText());
+        functionRef.setRefName(node.get("refName").asString());
       }
 
       if (node.get("selectionSet") != null) {
-        functionRef.setSelectionSet(node.get("selectionSet").asText());
+        functionRef.setSelectionSet(node.get("selectionSet").asString());
       }
 
       if (node.get("invoke") != null) {
-        functionRef.setInvoke(FunctionRef.Invoke.fromValue(node.get("invoke").asText()));
+        functionRef.setInvoke(FunctionRef.Invoke.fromValue(node.get("invoke").asString()));
       }
 
       return functionRef;

--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/FunctionsDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/FunctionsDeserializer.java
@@ -15,24 +15,21 @@
  */
 package io.serverlessworkflow.api.deserializers;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.serverlessworkflow.api.functions.FunctionDefinition;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
 import io.serverlessworkflow.api.utils.Utils;
 import io.serverlessworkflow.api.workflow.Functions;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class FunctionsDeserializer extends StdDeserializer<Functions> {
 
-  private static final long serialVersionUID = 510l;
   private static Logger logger = LoggerFactory.getLogger(FunctionsDeserializer.class);
 
   @SuppressWarnings("unused")
@@ -52,19 +49,18 @@ public class FunctionsDeserializer extends StdDeserializer<Functions> {
   }
 
   @Override
-  public Functions deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+  public Functions deserialize(JsonParser jp, DeserializationContext ctxt) {
 
-    ObjectMapper mapper = (ObjectMapper) jp.getCodec();
-    JsonNode node = jp.getCodec().readTree(jp);
+    JsonNode node = jp.readValueAsTree();
 
     Functions functions = new Functions();
     List<FunctionDefinition> functionDefs = new ArrayList<>();
     if (node.isArray()) {
       for (final JsonNode nodeEle : node) {
-        functionDefs.add(mapper.treeToValue(nodeEle, FunctionDefinition.class));
+        functionDefs.add(ctxt.readTreeAsValue(nodeEle, FunctionDefinition.class));
       }
     } else {
-      String functionsFileDef = node.asText();
+      String functionsFileDef = node.asString();
       String functionsFileSrc = Utils.getResourceFileAsString(functionsFileDef);
       JsonNode functionsRefNode;
       if (functionsFileSrc != null && functionsFileSrc.trim().length() > 0) {
@@ -73,7 +69,7 @@ public class FunctionsDeserializer extends StdDeserializer<Functions> {
         JsonNode refFunctions = functionsRefNode.get("functions");
         if (refFunctions != null) {
           for (final JsonNode nodeEle : refFunctions) {
-            functionDefs.add(mapper.treeToValue(nodeEle, FunctionDefinition.class));
+            functionDefs.add(ctxt.readTreeAsValue(nodeEle, FunctionDefinition.class));
           }
         } else {
           logger.error(

--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/OnEventsActionModeDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/OnEventsActionModeDeserializer.java
@@ -15,18 +15,16 @@
  */
 package io.serverlessworkflow.api.deserializers;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.serverlessworkflow.api.events.OnEvents;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
-import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class OnEventsActionModeDeserializer extends StdDeserializer<OnEvents.ActionMode> {
 
-  private static final long serialVersionUID = 510l;
   private static Logger logger = LoggerFactory.getLogger(OnEventsActionModeDeserializer.class);
 
   private WorkflowPropertySource context;
@@ -45,10 +43,9 @@ public class OnEventsActionModeDeserializer extends StdDeserializer<OnEvents.Act
   }
 
   @Override
-  public OnEvents.ActionMode deserialize(JsonParser jp, DeserializationContext ctxt)
-      throws IOException {
+  public OnEvents.ActionMode deserialize(JsonParser jp, DeserializationContext ctxt) {
 
-    String value = jp.getText();
+    String value = jp.getString();
     if (context != null) {
       try {
         String result = context.getPropertySource().getProperty(value);
@@ -56,14 +53,14 @@ public class OnEventsActionModeDeserializer extends StdDeserializer<OnEvents.Act
         if (result != null) {
           return OnEvents.ActionMode.fromValue(result);
         } else {
-          return OnEvents.ActionMode.fromValue(jp.getText());
+          return OnEvents.ActionMode.fromValue(jp.getString());
         }
       } catch (Exception e) {
         logger.info("Exception trying to evaluate property: {}", e.getMessage());
-        return OnEvents.ActionMode.fromValue(jp.getText());
+        return OnEvents.ActionMode.fromValue(jp.getString());
       }
     } else {
-      return OnEvents.ActionMode.fromValue(jp.getText());
+      return OnEvents.ActionMode.fromValue(jp.getString());
     }
   }
 }

--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/OperationStateActionModeDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/OperationStateActionModeDeserializer.java
@@ -15,19 +15,17 @@
  */
 package io.serverlessworkflow.api.deserializers;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
 import io.serverlessworkflow.api.states.OperationState;
-import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class OperationStateActionModeDeserializer
     extends StdDeserializer<OperationState.ActionMode> {
 
-  private static final long serialVersionUID = 510l;
   private static Logger logger =
       LoggerFactory.getLogger(OperationStateActionModeDeserializer.class);
 
@@ -47,10 +45,9 @@ public class OperationStateActionModeDeserializer
   }
 
   @Override
-  public OperationState.ActionMode deserialize(JsonParser jp, DeserializationContext ctxt)
-      throws IOException {
+  public OperationState.ActionMode deserialize(JsonParser jp, DeserializationContext ctxt) {
 
-    String value = jp.getText();
+    String value = jp.getString();
     if (context != null) {
       try {
         String result = context.getPropertySource().getProperty(value);
@@ -58,14 +55,14 @@ public class OperationStateActionModeDeserializer
         if (result != null) {
           return OperationState.ActionMode.fromValue(result);
         } else {
-          return OperationState.ActionMode.fromValue(jp.getText());
+          return OperationState.ActionMode.fromValue(jp.getString());
         }
       } catch (Exception e) {
         logger.info("Exception trying to evaluate property: {}", e.getMessage());
-        return OperationState.ActionMode.fromValue(jp.getText());
+        return OperationState.ActionMode.fromValue(jp.getString());
       }
     } else {
-      return OperationState.ActionMode.fromValue(jp.getText());
+      return OperationState.ActionMode.fromValue(jp.getString());
     }
   }
 }

--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/ParallelStateCompletionTypeDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/ParallelStateCompletionTypeDeserializer.java
@@ -15,19 +15,17 @@
  */
 package io.serverlessworkflow.api.deserializers;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
 import io.serverlessworkflow.api.states.ParallelState;
-import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class ParallelStateCompletionTypeDeserializer
     extends StdDeserializer<ParallelState.CompletionType> {
 
-  private static final long serialVersionUID = 510l;
   private static Logger logger =
       LoggerFactory.getLogger(ParallelStateCompletionTypeDeserializer.class);
 
@@ -47,10 +45,9 @@ public class ParallelStateCompletionTypeDeserializer
   }
 
   @Override
-  public ParallelState.CompletionType deserialize(JsonParser jp, DeserializationContext ctxt)
-      throws IOException {
+  public ParallelState.CompletionType deserialize(JsonParser jp, DeserializationContext ctxt) {
 
-    String value = jp.getText();
+    String value = jp.getString();
     if (context != null) {
       try {
         String result = context.getPropertySource().getProperty(value);
@@ -58,14 +55,14 @@ public class ParallelStateCompletionTypeDeserializer
         if (result != null) {
           return ParallelState.CompletionType.fromValue(result);
         } else {
-          return ParallelState.CompletionType.fromValue(jp.getText());
+          return ParallelState.CompletionType.fromValue(jp.getString());
         }
       } catch (Exception e) {
         logger.info("Exception trying to evaluate property: {}", e.getMessage());
-        return ParallelState.CompletionType.fromValue(jp.getText());
+        return ParallelState.CompletionType.fromValue(jp.getString());
       }
     } else {
-      return ParallelState.CompletionType.fromValue(jp.getText());
+      return ParallelState.CompletionType.fromValue(jp.getString());
     }
   }
 }

--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/RetriesDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/RetriesDeserializer.java
@@ -15,24 +15,21 @@
  */
 package io.serverlessworkflow.api.deserializers;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
 import io.serverlessworkflow.api.retry.RetryDefinition;
 import io.serverlessworkflow.api.utils.Utils;
 import io.serverlessworkflow.api.workflow.Retries;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class RetriesDeserializer extends StdDeserializer<Retries> {
 
-  private static final long serialVersionUID = 510l;
   private static Logger logger = LoggerFactory.getLogger(RetriesDeserializer.class);
 
   @SuppressWarnings("unused")
@@ -52,27 +49,26 @@ public class RetriesDeserializer extends StdDeserializer<Retries> {
   }
 
   @Override
-  public Retries deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+  public Retries deserialize(JsonParser jp, DeserializationContext ctxt) {
 
-    ObjectMapper mapper = (ObjectMapper) jp.getCodec();
-    JsonNode node = jp.getCodec().readTree(jp);
+    JsonNode node = jp.readValueAsTree();
 
     Retries retries = new Retries();
     List<RetryDefinition> retryDefinitions = new ArrayList<>();
 
     if (node.isArray()) {
       for (final JsonNode nodeEle : node) {
-        retryDefinitions.add(mapper.treeToValue(nodeEle, RetryDefinition.class));
+        retryDefinitions.add(ctxt.readTreeAsValue(nodeEle, RetryDefinition.class));
       }
     } else {
-      String retriesFileDef = node.asText();
+      String retriesFileDef = node.asString();
       String retriesFileSrc = Utils.getResourceFileAsString(retriesFileDef);
       if (retriesFileSrc != null && retriesFileSrc.trim().length() > 0) {
         JsonNode retriesRefNode = Utils.getNode(retriesFileSrc);
         JsonNode refRetries = retriesRefNode.get("retries");
         if (refRetries != null) {
           for (final JsonNode nodeEle : refRetries) {
-            retryDefinitions.add(mapper.treeToValue(nodeEle, RetryDefinition.class));
+            retryDefinitions.add(ctxt.readTreeAsValue(nodeEle, RetryDefinition.class));
           }
         } else {
           logger.error("Unable to find retries definitions in reference file: {}", retriesFileSrc);

--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/ScheduleDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/ScheduleDeserializer.java
@@ -15,19 +15,15 @@
  */
 package io.serverlessworkflow.api.deserializers;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.serverlessworkflow.api.cron.Cron;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
 import io.serverlessworkflow.api.schedule.Schedule;
-import java.io.IOException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class ScheduleDeserializer extends StdDeserializer<Schedule> {
-
-  private static final long serialVersionUID = 510l;
 
   @SuppressWarnings("unused")
   private WorkflowPropertySource context;
@@ -46,27 +42,26 @@ public class ScheduleDeserializer extends StdDeserializer<Schedule> {
   }
 
   @Override
-  public Schedule deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+  public Schedule deserialize(JsonParser jp, DeserializationContext ctxt) {
 
-    ObjectMapper mapper = (ObjectMapper) jp.getCodec();
-    JsonNode node = jp.getCodec().readTree(jp);
+    JsonNode node = jp.readValueAsTree();
 
     Schedule schedule = new Schedule();
 
     if (!node.isObject()) {
-      schedule.setInterval(node.asText());
+      schedule.setInterval(node.asString());
       return schedule;
     } else {
       if (node.get("interval") != null) {
-        schedule.setInterval(node.get("interval").asText());
+        schedule.setInterval(node.get("interval").asString());
       }
 
       if (node.get("cron") != null) {
-        schedule.setCron(mapper.treeToValue(node.get("cron"), Cron.class));
+        schedule.setCron(ctxt.readTreeAsValue(node.get("cron"), Cron.class));
       }
 
       if (node.get("timezone") != null) {
-        schedule.setTimezone(node.get("timezone").asText());
+        schedule.setTimezone(node.get("timezone").asString());
       }
 
       return schedule;

--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/SecretsDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/SecretsDeserializer.java
@@ -15,22 +15,20 @@
  */
 package io.serverlessworkflow.api.deserializers;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
 import io.serverlessworkflow.api.utils.Utils;
 import io.serverlessworkflow.api.workflow.Secrets;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class SecretsDeserializer extends StdDeserializer<Secrets> {
 
-  private static final long serialVersionUID = 510l;
   private static Logger logger = LoggerFactory.getLogger(SecretsDeserializer.class);
 
   @SuppressWarnings("unused")
@@ -50,26 +48,26 @@ public class SecretsDeserializer extends StdDeserializer<Secrets> {
   }
 
   @Override
-  public Secrets deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
-    JsonNode node = jp.getCodec().readTree(jp);
+  public Secrets deserialize(JsonParser jp, DeserializationContext ctxt) {
+    JsonNode node = jp.readValueAsTree();
 
     Secrets secrets = new Secrets();
     List<String> secretsDefinitions = new ArrayList<>();
 
     if (node.isArray()) {
       for (final JsonNode nodeEle : node) {
-        secretsDefinitions.add(nodeEle.asText());
+        secretsDefinitions.add(nodeEle.asString());
       }
     } else {
-      String secretsFileDef = node.asText();
+      String secretsFileDef = node.asString();
       String secretsFileSrc = Utils.getResourceFileAsString(secretsFileDef);
-      if (secretsFileSrc != null && secretsFileSrc.trim().length() > 0) {
+      if (secretsFileSrc != null && !secretsFileSrc.trim().isEmpty()) {
         // if its a yaml def convert to json first
         JsonNode secretsRefNode = Utils.getNode(secretsFileSrc);
         JsonNode refSecrets = secretsRefNode.get("secrets");
         if (refSecrets != null) {
           for (final JsonNode nodeEle : refSecrets) {
-            secretsDefinitions.add(nodeEle.asText());
+            secretsDefinitions.add(nodeEle.asString());
           }
         } else {
           logger.error("Unable to find secrets definitions in reference file: {}", secretsFileSrc);

--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/StartDefinitionDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/StartDefinitionDeserializer.java
@@ -15,19 +15,15 @@
  */
 package io.serverlessworkflow.api.deserializers;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
 import io.serverlessworkflow.api.schedule.Schedule;
 import io.serverlessworkflow.api.start.Start;
-import java.io.IOException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class StartDefinitionDeserializer extends StdDeserializer<Start> {
-
-  private static final long serialVersionUID = 510l;
 
   @SuppressWarnings("unused")
   private WorkflowPropertySource context;
@@ -46,24 +42,23 @@ public class StartDefinitionDeserializer extends StdDeserializer<Start> {
   }
 
   @Override
-  public Start deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+  public Start deserialize(JsonParser jp, DeserializationContext ctxt) {
 
-    ObjectMapper mapper = (ObjectMapper) jp.getCodec();
-    JsonNode node = jp.getCodec().readTree(jp);
+    JsonNode node = jp.readValueAsTree();
 
     Start start = new Start();
 
     if (!node.isObject()) {
-      start.setStateName(node.asText());
+      start.setStateName(node.asString());
       start.setSchedule(null);
       return start;
     } else {
       if (node.get("stateName") != null) {
-        start.setStateName(node.get("stateName").asText());
+        start.setStateName(node.get("stateName").asString());
       }
 
       if (node.get("schedule") != null) {
-        start.setSchedule(mapper.treeToValue(node.get("schedule"), Schedule.class));
+        start.setSchedule(ctxt.readTreeAsValue(node.get("schedule"), Schedule.class));
       }
 
       return start;

--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/StateDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/StateDeserializer.java
@@ -15,21 +15,18 @@
  */
 package io.serverlessworkflow.api.deserializers;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.serverlessworkflow.api.interfaces.State;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
 import io.serverlessworkflow.api.states.*;
-import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class StateDeserializer extends StdDeserializer<State> {
 
-  private static final long serialVersionUID = 510l;
   private static Logger logger = LoggerFactory.getLogger(StateDeserializer.class);
 
   private WorkflowPropertySource context;
@@ -48,11 +45,10 @@ public class StateDeserializer extends StdDeserializer<State> {
   }
 
   @Override
-  public State deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+  public State deserialize(JsonParser jp, DeserializationContext ctxt) {
 
-    ObjectMapper mapper = (ObjectMapper) jp.getCodec();
-    JsonNode node = jp.getCodec().readTree(jp);
-    String typeValue = node.get("type").asText();
+    JsonNode node = jp.readValueAsTree();
+    String typeValue = node.get("type").asString();
 
     if (context != null) {
       try {
@@ -70,26 +66,26 @@ public class StateDeserializer extends StdDeserializer<State> {
     DefaultState.Type type = DefaultState.Type.fromValue(typeValue);
     switch (type) {
       case EVENT:
-        return mapper.treeToValue(node, EventState.class);
+        return ctxt.readTreeAsValue(node, EventState.class);
       case OPERATION:
-        return mapper.treeToValue(node, OperationState.class);
+        return ctxt.readTreeAsValue(node, OperationState.class);
       case SWITCH:
-        return mapper.treeToValue(node, SwitchState.class);
+        return ctxt.readTreeAsValue(node, SwitchState.class);
       case SLEEP:
-        return mapper.treeToValue(node, SleepState.class);
+        return ctxt.readTreeAsValue(node, SleepState.class);
       case PARALLEL:
-        return mapper.treeToValue(node, ParallelState.class);
+        return ctxt.readTreeAsValue(node, ParallelState.class);
 
       case INJECT:
-        return mapper.treeToValue(node, InjectState.class);
+        return ctxt.readTreeAsValue(node, InjectState.class);
 
       case FOREACH:
-        return mapper.treeToValue(node, ForEachState.class);
+        return ctxt.readTreeAsValue(node, ForEachState.class);
 
       case CALLBACK:
-        return mapper.treeToValue(node, CallbackState.class);
+        return ctxt.readTreeAsValue(node, CallbackState.class);
       default:
-        return mapper.treeToValue(node, DefaultState.class);
+        return ctxt.readTreeAsValue(node, DefaultState.class);
     }
   }
 }

--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/StateExecTimeoutDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/StateExecTimeoutDeserializer.java
@@ -15,17 +15,14 @@
  */
 package io.serverlessworkflow.api.deserializers;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
 import io.serverlessworkflow.api.timeouts.StateExecTimeout;
-import java.io.IOException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class StateExecTimeoutDeserializer extends StdDeserializer<StateExecTimeout> {
-
-  private static final long serialVersionUID = 510l;
 
   @SuppressWarnings("unused")
   private WorkflowPropertySource context;
@@ -44,24 +41,23 @@ public class StateExecTimeoutDeserializer extends StdDeserializer<StateExecTimeo
   }
 
   @Override
-  public StateExecTimeout deserialize(JsonParser jp, DeserializationContext ctxt)
-      throws IOException {
+  public StateExecTimeout deserialize(JsonParser jp, DeserializationContext ctxt) {
 
-    JsonNode node = jp.getCodec().readTree(jp);
+    JsonNode node = jp.readValueAsTree();
 
     StateExecTimeout stateExecTimeout = new StateExecTimeout();
 
     if (!node.isObject()) {
-      stateExecTimeout.setTotal(node.asText());
+      stateExecTimeout.setTotal(node.asString());
       stateExecTimeout.setSingle(null);
       return stateExecTimeout;
     } else {
       if (node.get("single") != null) {
-        stateExecTimeout.setSingle(node.get("single").asText());
+        stateExecTimeout.setSingle(node.get("single").asString());
       }
 
       if (node.get("total") != null) {
-        stateExecTimeout.setTotal(node.get("total").asText());
+        stateExecTimeout.setTotal(node.get("total").asString());
       }
 
       return stateExecTimeout;

--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/StringValueDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/StringValueDeserializer.java
@@ -15,17 +15,15 @@
  */
 package io.serverlessworkflow.api.deserializers;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
-import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class StringValueDeserializer extends StdDeserializer<String> {
 
-  private static final long serialVersionUID = 510l;
   private static Logger logger = LoggerFactory.getLogger(StringValueDeserializer.class);
 
   private WorkflowPropertySource context;
@@ -44,9 +42,9 @@ public class StringValueDeserializer extends StdDeserializer<String> {
   }
 
   @Override
-  public String deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+  public String deserialize(JsonParser jp, DeserializationContext ctxt) {
 
-    String value = jp.getText();
+    String value = jp.getString();
     if (context != null) {
       try {
         String result = context.getPropertySource().getProperty(value);
@@ -54,14 +52,14 @@ public class StringValueDeserializer extends StdDeserializer<String> {
         if (result != null) {
           return result;
         } else {
-          return jp.getText();
+          return jp.getString();
         }
       } catch (Exception e) {
         logger.info("Exception trying to evaluate property: {}", e.getMessage());
-        return jp.getText();
+        return jp.getString();
       }
     } else {
-      return jp.getText();
+      return jp.getString();
     }
   }
 }

--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/SubFlowRefDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/SubFlowRefDeserializer.java
@@ -15,17 +15,14 @@
  */
 package io.serverlessworkflow.api.deserializers;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.serverlessworkflow.api.functions.SubFlowRef;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
-import java.io.IOException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class SubFlowRefDeserializer extends StdDeserializer<SubFlowRef> {
-
-  private static final long serialVersionUID = 510l;
 
   @SuppressWarnings("unused")
   private WorkflowPropertySource context;
@@ -44,31 +41,31 @@ public class SubFlowRefDeserializer extends StdDeserializer<SubFlowRef> {
   }
 
   @Override
-  public SubFlowRef deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+  public SubFlowRef deserialize(JsonParser jp, DeserializationContext ctxt) {
 
-    JsonNode node = jp.getCodec().readTree(jp);
+    JsonNode node = jp.readValueAsTree();
 
     SubFlowRef subflowRef = new SubFlowRef();
 
     if (!node.isObject()) {
-      subflowRef.setWorkflowId(node.asText());
+      subflowRef.setWorkflowId(node.asString());
       return subflowRef;
     } else {
       if (node.get("workflowId") != null) {
-        subflowRef.setWorkflowId(node.get("workflowId").asText());
+        subflowRef.setWorkflowId(node.get("workflowId").asString());
       }
 
       if (node.get("version") != null) {
-        subflowRef.setVersion(node.get("version").asText());
+        subflowRef.setVersion(node.get("version").asString());
       }
 
       if (node.get("onParentComplete") != null) {
         subflowRef.setOnParentComplete(
-            SubFlowRef.OnParentComplete.fromValue(node.get("onParentComplete").asText()));
+            SubFlowRef.OnParentComplete.fromValue(node.get("onParentComplete").asString()));
       }
 
       if (node.get("invoke") != null) {
-        subflowRef.setInvoke(SubFlowRef.Invoke.fromValue(node.get("invoke").asText()));
+        subflowRef.setInvoke(SubFlowRef.Invoke.fromValue(node.get("invoke").asString()));
       }
 
       return subflowRef;

--- a/api/src/main/java/io/serverlessworkflow/api/deserializers/TransitionDeserializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/deserializers/TransitionDeserializer.java
@@ -15,21 +15,17 @@
  */
 package io.serverlessworkflow.api.deserializers;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
 import io.serverlessworkflow.api.produce.ProduceEvent;
 import io.serverlessworkflow.api.transitions.Transition;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class TransitionDeserializer extends StdDeserializer<Transition> {
-
-  private static final long serialVersionUID = 510l;
 
   @SuppressWarnings("unused")
   private WorkflowPropertySource context;
@@ -48,26 +44,25 @@ public class TransitionDeserializer extends StdDeserializer<Transition> {
   }
 
   @Override
-  public Transition deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+  public Transition deserialize(JsonParser jp, DeserializationContext ctxt) {
 
-    ObjectMapper mapper = (ObjectMapper) jp.getCodec();
-    JsonNode node = jp.getCodec().readTree(jp);
+    JsonNode node = jp.readValueAsTree();
 
     Transition transition = new Transition();
 
     if (!node.isObject()) {
       transition.setProduceEvents(new ArrayList<>());
       transition.setCompensate(false);
-      transition.setNextState(node.asText());
+      transition.setNextState(node.asString());
       return transition;
     } else {
       if (node.get("produceEvents") != null) {
         transition.setProduceEvents(
-            Arrays.asList(mapper.treeToValue(node.get("produceEvents"), ProduceEvent[].class)));
+            Arrays.asList(ctxt.readTreeAsValue(node.get("produceEvents"), ProduceEvent[].class)));
       }
 
       if (node.get("nextState") != null) {
-        transition.setNextState(node.get("nextState").asText());
+        transition.setNextState(node.get("nextState").asString());
       }
 
       if (node.get("compensate") != null) {

--- a/api/src/main/java/io/serverlessworkflow/api/mapper/BaseObjectMapper.java
+++ b/api/src/main/java/io/serverlessworkflow/api/mapper/BaseObjectMapper.java
@@ -16,31 +16,25 @@
 package io.serverlessworkflow.api.mapper;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
 import java.util.Map;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.cfg.MapperBuilder;
 
-public class BaseObjectMapper extends ObjectMapper {
+final class BaseObjectMapper {
 
-  private final WorkflowModule workflowModule;
+  private BaseObjectMapper() {}
 
-  public BaseObjectMapper(JsonFactory factory, WorkflowPropertySource workflowPropertySource) {
-    super(factory);
-
-    workflowModule = new WorkflowModule(workflowPropertySource);
-
-    configure(SerializationFeature.INDENT_OUTPUT, true);
-    registerModule(workflowModule);
-    setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
-    configOverride(Map.class)
-        .setInclude(
-            JsonInclude.Value.construct(
-                JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL));
-  }
-
-  public WorkflowModule getWorkflowModule() {
-    return workflowModule;
+  static <B extends MapperBuilder<?, B>> B configure(B builder, WorkflowModule workflowModule) {
+    return builder
+        .configure(SerializationFeature.INDENT_OUTPUT, true)
+        .addModule(workflowModule)
+        .changeDefaultPropertyInclusion(
+            incl -> incl.withValueInclusion(JsonInclude.Include.NON_EMPTY))
+        .withConfigOverride(
+            Map.class,
+            override ->
+                override.setInclude(
+                    JsonInclude.Value.construct(
+                        JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL)));
   }
 }

--- a/api/src/main/java/io/serverlessworkflow/api/mapper/JsonObjectMapper.java
+++ b/api/src/main/java/io/serverlessworkflow/api/mapper/JsonObjectMapper.java
@@ -16,14 +16,18 @@
 package io.serverlessworkflow.api.mapper;
 
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
-public class JsonObjectMapper extends BaseObjectMapper {
+public final class JsonObjectMapper {
 
-  public JsonObjectMapper() {
-    this(null);
+  private JsonObjectMapper() {}
+
+  public static ObjectMapper create() {
+    return create(null);
   }
 
-  public JsonObjectMapper(WorkflowPropertySource context) {
-    super(null, context);
+  public static ObjectMapper create(WorkflowPropertySource context) {
+    return BaseObjectMapper.configure(JsonMapper.builder(), new WorkflowModule(context)).build();
   }
 }

--- a/api/src/main/java/io/serverlessworkflow/api/mapper/JsonObjectMapperFactory.java
+++ b/api/src/main/java/io/serverlessworkflow/api/mapper/JsonObjectMapperFactory.java
@@ -15,11 +15,11 @@
  */
 package io.serverlessworkflow.api.mapper;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 public class JsonObjectMapperFactory {
 
-  private static final ObjectMapper instance = new JsonObjectMapper();
+  private static final ObjectMapper instance = JsonObjectMapper.create();
 
   public static final ObjectMapper mapper() {
     return instance;

--- a/api/src/main/java/io/serverlessworkflow/api/mapper/WorkflowModule.java
+++ b/api/src/main/java/io/serverlessworkflow/api/mapper/WorkflowModule.java
@@ -15,7 +15,6 @@
  */
 package io.serverlessworkflow.api.mapper;
 
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.serverlessworkflow.api.auth.AuthDefinition;
 import io.serverlessworkflow.api.cron.Cron;
 import io.serverlessworkflow.api.deserializers.*;
@@ -38,6 +37,7 @@ import io.serverlessworkflow.api.states.ParallelState;
 import io.serverlessworkflow.api.timeouts.StateExecTimeout;
 import io.serverlessworkflow.api.transitions.Transition;
 import io.serverlessworkflow.api.workflow.*;
+import tools.jackson.databind.module.SimpleModule;
 
 public class WorkflowModule extends SimpleModule {
 

--- a/api/src/main/java/io/serverlessworkflow/api/mapper/YamlObjectMapper.java
+++ b/api/src/main/java/io/serverlessworkflow/api/mapper/YamlObjectMapper.java
@@ -15,16 +15,23 @@
  */
 package io.serverlessworkflow.api.mapper;
 
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator.Feature;
 import io.serverlessworkflow.api.interfaces.WorkflowPropertySource;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+import tools.jackson.dataformat.yaml.YAMLWriteFeature;
 
-public class YamlObjectMapper extends BaseObjectMapper {
-  public YamlObjectMapper() {
-    this(null);
+public final class YamlObjectMapper {
+
+  private YamlObjectMapper() {}
+
+  public static ObjectMapper create() {
+    return create(null);
   }
 
-  public YamlObjectMapper(WorkflowPropertySource context) {
-    super(new YAMLFactory().enable(Feature.MINIMIZE_QUOTES), context);
+  public static ObjectMapper create(WorkflowPropertySource context) {
+    return BaseObjectMapper.configure(
+            YAMLMapper.builder().enable(YAMLWriteFeature.MINIMIZE_QUOTES),
+            new WorkflowModule(context))
+        .build();
   }
 }

--- a/api/src/main/java/io/serverlessworkflow/api/mapper/YamlObjectMapperFactory.java
+++ b/api/src/main/java/io/serverlessworkflow/api/mapper/YamlObjectMapperFactory.java
@@ -15,11 +15,11 @@
  */
 package io.serverlessworkflow.api.mapper;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 public class YamlObjectMapperFactory {
 
-  private static final ObjectMapper instance = new YamlObjectMapper();
+  private static final ObjectMapper instance = YamlObjectMapper.create();
 
   public static final ObjectMapper mapper() {
     return instance;

--- a/api/src/main/java/io/serverlessworkflow/api/serializers/AuthDefinitionSerializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/serializers/AuthDefinitionSerializer.java
@@ -15,11 +15,10 @@
  */
 package io.serverlessworkflow.api.serializers;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import io.serverlessworkflow.api.auth.AuthDefinition;
-import java.io.IOException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.std.StdSerializer;
 
 public class AuthDefinitionSerializer extends StdSerializer<AuthDefinition> {
 
@@ -33,17 +32,16 @@ public class AuthDefinitionSerializer extends StdSerializer<AuthDefinition> {
 
   @Override
   public void serialize(
-      AuthDefinition authDefinition, JsonGenerator gen, SerializerProvider provider)
-      throws IOException {
+      AuthDefinition authDefinition, JsonGenerator gen, SerializationContext provider) {
 
     gen.writeStartObject();
     if (authDefinition != null) {
       if (authDefinition.getName() != null && !authDefinition.getName().isEmpty()) {
-        gen.writeStringField("name", authDefinition.getName());
+        gen.writeStringProperty("name", authDefinition.getName());
       }
 
       if (authDefinition.getScheme() != null) {
-        gen.writeStringField("scheme", authDefinition.getScheme().value());
+        gen.writeStringProperty("scheme", authDefinition.getScheme().value());
       }
 
       if (authDefinition.getBasicauth() != null
@@ -51,15 +49,15 @@ public class AuthDefinitionSerializer extends StdSerializer<AuthDefinition> {
           || authDefinition.getOauth() != null) {
 
         if (authDefinition.getBasicauth() != null) {
-          gen.writeObjectField("properties", authDefinition.getBasicauth());
+          gen.writePOJOProperty("properties", authDefinition.getBasicauth());
         }
 
         if (authDefinition.getBearerauth() != null) {
-          gen.writeObjectField("properties", authDefinition.getBearerauth());
+          gen.writePOJOProperty("properties", authDefinition.getBearerauth());
         }
 
         if (authDefinition.getOauth() != null) {
-          gen.writeObjectField("properties", authDefinition.getOauth());
+          gen.writePOJOProperty("properties", authDefinition.getOauth());
         }
       }
     }

--- a/api/src/main/java/io/serverlessworkflow/api/serializers/CallbackStateSerializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/serializers/CallbackStateSerializer.java
@@ -15,14 +15,14 @@
  */
 package io.serverlessworkflow.api.serializers;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.BeanSerializerFactory;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.serverlessworkflow.api.states.CallbackState;
 import io.serverlessworkflow.api.states.DefaultState;
-import java.io.IOException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.BeanSerializerFactory;
+import tools.jackson.databind.ser.std.StdSerializer;
 
 public class CallbackStateSerializer extends StdSerializer<CallbackState> {
 
@@ -35,16 +35,17 @@ public class CallbackStateSerializer extends StdSerializer<CallbackState> {
   }
 
   @Override
-  public void serialize(CallbackState callbackState, JsonGenerator gen, SerializerProvider provider)
-      throws IOException {
+  public void serialize(
+      CallbackState callbackState, JsonGenerator gen, SerializationContext provider) {
 
     // set defaults for callback state
     callbackState.setType(DefaultState.Type.CALLBACK);
 
     // serialize after setting default bean values...
+    JavaType type = provider.constructType(CallbackState.class);
     BeanSerializerFactory.instance
         .createSerializer(
-            provider, TypeFactory.defaultInstance().constructType(CallbackState.class))
+            provider, type, provider.lazyIntrospectBeanDescription(type), JsonFormat.Value.empty())
         .serialize(callbackState, gen, provider);
   }
 }

--- a/api/src/main/java/io/serverlessworkflow/api/serializers/ContinueAsSerializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/serializers/ContinueAsSerializer.java
@@ -15,11 +15,10 @@
  */
 package io.serverlessworkflow.api.serializers;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import io.serverlessworkflow.api.end.ContinueAs;
-import java.io.IOException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.std.StdSerializer;
 
 public class ContinueAsSerializer extends StdSerializer<ContinueAs> {
 
@@ -32,8 +31,7 @@ public class ContinueAsSerializer extends StdSerializer<ContinueAs> {
   }
 
   @Override
-  public void serialize(ContinueAs continueAs, JsonGenerator gen, SerializerProvider provider)
-      throws IOException {
+  public void serialize(ContinueAs continueAs, JsonGenerator gen, SerializationContext provider) {
 
     if (continueAs != null) {
       if ((continueAs.getWorkflowId() != null && !continueAs.getWorkflowId().isEmpty())
@@ -45,19 +43,19 @@ public class ContinueAsSerializer extends StdSerializer<ContinueAs> {
         gen.writeStartObject();
 
         if (continueAs.getWorkflowId() != null && continueAs.getWorkflowId().length() > 0) {
-          gen.writeStringField("workflowId", continueAs.getWorkflowId());
+          gen.writeStringProperty("workflowId", continueAs.getWorkflowId());
         }
 
         if (continueAs.getVersion() != null && continueAs.getVersion().length() > 0) {
-          gen.writeStringField("version", continueAs.getVersion());
+          gen.writeStringProperty("version", continueAs.getVersion());
         }
 
         if (continueAs.getData() != null && continueAs.getData().length() > 0) {
-          gen.writeStringField("data", continueAs.getData());
+          gen.writeStringProperty("data", continueAs.getData());
         }
 
         if (continueAs.getWorkflowExecTimeout() != null) {
-          gen.writeObjectField("workflowExecTimeout", continueAs.getWorkflowExecTimeout());
+          gen.writePOJOProperty("workflowExecTimeout", continueAs.getWorkflowExecTimeout());
         }
 
         gen.writeEndObject();

--- a/api/src/main/java/io/serverlessworkflow/api/serializers/CronSerializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/serializers/CronSerializer.java
@@ -15,11 +15,10 @@
  */
 package io.serverlessworkflow.api.serializers;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import io.serverlessworkflow.api.cron.Cron;
-import java.io.IOException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.std.StdSerializer;
 
 public class CronSerializer extends StdSerializer<Cron> {
 
@@ -32,8 +31,7 @@ public class CronSerializer extends StdSerializer<Cron> {
   }
 
   @Override
-  public void serialize(Cron cron, JsonGenerator gen, SerializerProvider provider)
-      throws IOException {
+  public void serialize(Cron cron, JsonGenerator gen, SerializationContext provider) {
 
     if (cron != null) {
       if ((cron.getValidUntil() == null || cron.getValidUntil().isEmpty())
@@ -44,11 +42,11 @@ public class CronSerializer extends StdSerializer<Cron> {
         gen.writeStartObject();
 
         if (cron.getExpression() != null && cron.getExpression().length() > 0) {
-          gen.writeStringField("expression", cron.getExpression());
+          gen.writeStringProperty("expression", cron.getExpression());
         }
 
         if (cron.getValidUntil() != null && cron.getValidUntil().length() > 0) {
-          gen.writeStringField("validUntil", cron.getValidUntil());
+          gen.writeStringProperty("validUntil", cron.getValidUntil());
         }
 
         gen.writeEndObject();

--- a/api/src/main/java/io/serverlessworkflow/api/serializers/EndDefinitionSerializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/serializers/EndDefinitionSerializer.java
@@ -15,12 +15,11 @@
  */
 package io.serverlessworkflow.api.serializers;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import io.serverlessworkflow.api.end.End;
 import io.serverlessworkflow.api.produce.ProduceEvent;
-import java.io.IOException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.std.StdSerializer;
 
 public class EndDefinitionSerializer extends StdSerializer<End> {
 
@@ -33,8 +32,7 @@ public class EndDefinitionSerializer extends StdSerializer<End> {
   }
 
   @Override
-  public void serialize(End end, JsonGenerator gen, SerializerProvider provider)
-      throws IOException {
+  public void serialize(End end, JsonGenerator gen, SerializationContext provider) {
 
     if (end != null) {
       if ((end.getProduceEvents() == null || end.getProduceEvents().size() < 1)
@@ -46,23 +44,23 @@ public class EndDefinitionSerializer extends StdSerializer<End> {
         gen.writeStartObject();
 
         if (end.isTerminate()) {
-          gen.writeBooleanField("terminate", true);
+          gen.writeBooleanProperty("terminate", true);
         }
 
         if (end.getProduceEvents() != null && !end.getProduceEvents().isEmpty()) {
-          gen.writeArrayFieldStart("produceEvents");
+          gen.writeArrayPropertyStart("produceEvents");
           for (ProduceEvent produceEvent : end.getProduceEvents()) {
-            gen.writeObject(produceEvent);
+            gen.writePOJO(produceEvent);
           }
           gen.writeEndArray();
         }
 
         if (end.isCompensate()) {
-          gen.writeBooleanField("compensate", true);
+          gen.writeBooleanProperty("compensate", true);
         }
 
         if (end.getContinueAs() != null) {
-          gen.writeObjectField("continueAs", end.getContinueAs());
+          gen.writePOJOProperty("continueAs", end.getContinueAs());
         }
 
         gen.writeEndObject();

--- a/api/src/main/java/io/serverlessworkflow/api/serializers/EventDefinitionSerializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/serializers/EventDefinitionSerializer.java
@@ -15,13 +15,13 @@
  */
 package io.serverlessworkflow.api.serializers;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.BeanSerializerFactory;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.serverlessworkflow.api.events.EventDefinition;
-import java.io.IOException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.BeanSerializerFactory;
+import tools.jackson.databind.ser.std.StdSerializer;
 
 public class EventDefinitionSerializer extends StdSerializer<EventDefinition> {
 
@@ -35,13 +35,13 @@ public class EventDefinitionSerializer extends StdSerializer<EventDefinition> {
 
   @Override
   public void serialize(
-      EventDefinition triggerEvent, JsonGenerator gen, SerializerProvider provider)
-      throws IOException {
+      EventDefinition triggerEvent, JsonGenerator gen, SerializationContext provider) {
 
     // serialize after setting default bean values...
+    JavaType type = provider.constructType(EventDefinition.class);
     BeanSerializerFactory.instance
         .createSerializer(
-            provider, TypeFactory.defaultInstance().constructType(EventDefinition.class))
+            provider, type, provider.lazyIntrospectBeanDescription(type), JsonFormat.Value.empty())
         .serialize(triggerEvent, gen, provider);
   }
 }

--- a/api/src/main/java/io/serverlessworkflow/api/serializers/EventStateSerializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/serializers/EventStateSerializer.java
@@ -15,14 +15,14 @@
  */
 package io.serverlessworkflow.api.serializers;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.BeanSerializerFactory;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.serverlessworkflow.api.states.DefaultState;
 import io.serverlessworkflow.api.states.EventState;
-import java.io.IOException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.BeanSerializerFactory;
+import tools.jackson.databind.ser.std.StdSerializer;
 
 public class EventStateSerializer extends StdSerializer<EventState> {
 
@@ -35,15 +35,16 @@ public class EventStateSerializer extends StdSerializer<EventState> {
   }
 
   @Override
-  public void serialize(EventState eventState, JsonGenerator gen, SerializerProvider provider)
-      throws IOException {
+  public void serialize(EventState eventState, JsonGenerator gen, SerializationContext provider) {
 
     // set defaults for end state
     eventState.setType(DefaultState.Type.EVENT);
 
     // serialize after setting default bean values...
+    JavaType type = provider.constructType(EventState.class);
     BeanSerializerFactory.instance
-        .createSerializer(provider, TypeFactory.defaultInstance().constructType(EventState.class))
+        .createSerializer(
+            provider, type, provider.lazyIntrospectBeanDescription(type), JsonFormat.Value.empty())
         .serialize(eventState, gen, provider);
   }
 }

--- a/api/src/main/java/io/serverlessworkflow/api/serializers/ExtensionSerializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/serializers/ExtensionSerializer.java
@@ -15,15 +15,15 @@
  */
 package io.serverlessworkflow.api.serializers;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.BeanSerializerFactory;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.serverlessworkflow.api.interfaces.Extension;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.BeanSerializerFactory;
+import tools.jackson.databind.ser.std.StdSerializer;
 
 public class ExtensionSerializer extends StdSerializer<Extension> {
 
@@ -42,16 +42,19 @@ public class ExtensionSerializer extends StdSerializer<Extension> {
   }
 
   @Override
-  public void serialize(Extension extension, JsonGenerator gen, SerializerProvider provider)
-      throws IOException {
+  public void serialize(Extension extension, JsonGenerator gen, SerializationContext provider) {
 
     String extensionId = extension.getExtensionId();
 
     if (extensionsMap.containsKey(extensionId)) {
       // serialize after setting default bean values...
+      JavaType type = provider.constructType(extensionsMap.get(extensionId));
       BeanSerializerFactory.instance
           .createSerializer(
-              provider, TypeFactory.defaultInstance().constructType(extensionsMap.get(extensionId)))
+              provider,
+              type,
+              provider.lazyIntrospectBeanDescription(type),
+              JsonFormat.Value.empty())
           .serialize(extension, gen, provider);
     } else {
       throw new IllegalArgumentException("Extension handler not registered for: " + extensionId);

--- a/api/src/main/java/io/serverlessworkflow/api/serializers/ForEachStateSerializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/serializers/ForEachStateSerializer.java
@@ -15,14 +15,14 @@
  */
 package io.serverlessworkflow.api.serializers;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.BeanSerializerFactory;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.serverlessworkflow.api.states.DefaultState;
 import io.serverlessworkflow.api.states.ForEachState;
-import java.io.IOException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.BeanSerializerFactory;
+import tools.jackson.databind.ser.std.StdSerializer;
 
 public class ForEachStateSerializer extends StdSerializer<ForEachState> {
 
@@ -35,15 +35,17 @@ public class ForEachStateSerializer extends StdSerializer<ForEachState> {
   }
 
   @Override
-  public void serialize(ForEachState forEachState, JsonGenerator gen, SerializerProvider provider)
-      throws IOException {
+  public void serialize(
+      ForEachState forEachState, JsonGenerator gen, SerializationContext provider) {
 
     // set defaults for foreach state
     forEachState.setType(DefaultState.Type.FOREACH);
 
     // serialize after setting default bean values...
+    JavaType type = provider.constructType(ForEachState.class);
     BeanSerializerFactory.instance
-        .createSerializer(provider, TypeFactory.defaultInstance().constructType(ForEachState.class))
+        .createSerializer(
+            provider, type, provider.lazyIntrospectBeanDescription(type), JsonFormat.Value.empty())
         .serialize(forEachState, gen, provider);
   }
 }

--- a/api/src/main/java/io/serverlessworkflow/api/serializers/FunctionRefSerializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/serializers/FunctionRefSerializer.java
@@ -15,11 +15,10 @@
  */
 package io.serverlessworkflow.api.serializers;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import io.serverlessworkflow.api.functions.FunctionRef;
-import java.io.IOException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.std.StdSerializer;
 
 public class FunctionRefSerializer extends StdSerializer<FunctionRef> {
 
@@ -32,8 +31,7 @@ public class FunctionRefSerializer extends StdSerializer<FunctionRef> {
   }
 
   @Override
-  public void serialize(FunctionRef functionRef, JsonGenerator gen, SerializerProvider provider)
-      throws IOException {
+  public void serialize(FunctionRef functionRef, JsonGenerator gen, SerializationContext provider) {
 
     if (functionRef != null) {
       if ((functionRef.getArguments() == null || functionRef.getArguments().isEmpty())
@@ -47,19 +45,19 @@ public class FunctionRefSerializer extends StdSerializer<FunctionRef> {
         gen.writeStartObject();
 
         if (functionRef.getRefName() != null && functionRef.getRefName().length() > 0) {
-          gen.writeStringField("refName", functionRef.getRefName());
+          gen.writeStringProperty("refName", functionRef.getRefName());
         }
 
         if (functionRef.getArguments() != null && !functionRef.getArguments().isEmpty()) {
-          gen.writeObjectField("arguments", functionRef.getArguments());
+          gen.writePOJOProperty("arguments", functionRef.getArguments());
         }
 
         if (functionRef.getSelectionSet() != null && functionRef.getSelectionSet().length() > 0) {
-          gen.writeStringField("selectionSet", functionRef.getSelectionSet());
+          gen.writeStringProperty("selectionSet", functionRef.getSelectionSet());
         }
 
         if (functionRef.getInvoke() != null) {
-          gen.writeStringField("invoke", functionRef.getInvoke().value());
+          gen.writeStringProperty("invoke", functionRef.getInvoke().value());
         }
 
         gen.writeEndObject();

--- a/api/src/main/java/io/serverlessworkflow/api/serializers/InjectStateSerializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/serializers/InjectStateSerializer.java
@@ -15,14 +15,14 @@
  */
 package io.serverlessworkflow.api.serializers;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.BeanSerializerFactory;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.serverlessworkflow.api.states.DefaultState;
 import io.serverlessworkflow.api.states.InjectState;
-import java.io.IOException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.BeanSerializerFactory;
+import tools.jackson.databind.ser.std.StdSerializer;
 
 public class InjectStateSerializer extends StdSerializer<InjectState> {
 
@@ -35,15 +35,16 @@ public class InjectStateSerializer extends StdSerializer<InjectState> {
   }
 
   @Override
-  public void serialize(InjectState relayState, JsonGenerator gen, SerializerProvider provider)
-      throws IOException {
+  public void serialize(InjectState relayState, JsonGenerator gen, SerializationContext provider) {
 
     // set defaults for relay state
     relayState.setType(DefaultState.Type.INJECT);
 
     // serialize after setting default bean values...
+    JavaType type = provider.constructType(InjectState.class);
     BeanSerializerFactory.instance
-        .createSerializer(provider, TypeFactory.defaultInstance().constructType(InjectState.class))
+        .createSerializer(
+            provider, type, provider.lazyIntrospectBeanDescription(type), JsonFormat.Value.empty())
         .serialize(relayState, gen, provider);
   }
 }

--- a/api/src/main/java/io/serverlessworkflow/api/serializers/OperationStateSerializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/serializers/OperationStateSerializer.java
@@ -15,14 +15,14 @@
  */
 package io.serverlessworkflow.api.serializers;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.BeanSerializerFactory;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.serverlessworkflow.api.states.DefaultState;
 import io.serverlessworkflow.api.states.OperationState;
-import java.io.IOException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.BeanSerializerFactory;
+import tools.jackson.databind.ser.std.StdSerializer;
 
 public class OperationStateSerializer extends StdSerializer<OperationState> {
 
@@ -36,16 +36,16 @@ public class OperationStateSerializer extends StdSerializer<OperationState> {
 
   @Override
   public void serialize(
-      OperationState operationState, JsonGenerator gen, SerializerProvider provider)
-      throws IOException {
+      OperationState operationState, JsonGenerator gen, SerializationContext provider) {
 
     // set defaults for delay state
     operationState.setType(DefaultState.Type.OPERATION);
 
     // serialize after setting default bean values...
+    JavaType type = provider.constructType(OperationState.class);
     BeanSerializerFactory.instance
         .createSerializer(
-            provider, TypeFactory.defaultInstance().constructType(OperationState.class))
+            provider, type, provider.lazyIntrospectBeanDescription(type), JsonFormat.Value.empty())
         .serialize(operationState, gen, provider);
   }
 }

--- a/api/src/main/java/io/serverlessworkflow/api/serializers/ParallelStateSerializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/serializers/ParallelStateSerializer.java
@@ -15,14 +15,14 @@
  */
 package io.serverlessworkflow.api.serializers;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.BeanSerializerFactory;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.serverlessworkflow.api.states.DefaultState;
 import io.serverlessworkflow.api.states.ParallelState;
-import java.io.IOException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.BeanSerializerFactory;
+import tools.jackson.databind.ser.std.StdSerializer;
 
 public class ParallelStateSerializer extends StdSerializer<ParallelState> {
 
@@ -35,16 +35,17 @@ public class ParallelStateSerializer extends StdSerializer<ParallelState> {
   }
 
   @Override
-  public void serialize(ParallelState parallelState, JsonGenerator gen, SerializerProvider provider)
-      throws IOException {
+  public void serialize(
+      ParallelState parallelState, JsonGenerator gen, SerializationContext provider) {
 
     // set defaults for end state
     parallelState.setType(DefaultState.Type.PARALLEL);
 
     // serialize after setting default bean values...
+    JavaType type = provider.constructType(ParallelState.class);
     BeanSerializerFactory.instance
         .createSerializer(
-            provider, TypeFactory.defaultInstance().constructType(ParallelState.class))
+            provider, type, provider.lazyIntrospectBeanDescription(type), JsonFormat.Value.empty())
         .serialize(parallelState, gen, provider);
   }
 }

--- a/api/src/main/java/io/serverlessworkflow/api/serializers/ScheduleSerializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/serializers/ScheduleSerializer.java
@@ -15,11 +15,10 @@
  */
 package io.serverlessworkflow.api.serializers;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import io.serverlessworkflow.api.schedule.Schedule;
-import java.io.IOException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.std.StdSerializer;
 
 public class ScheduleSerializer extends StdSerializer<Schedule> {
 
@@ -32,8 +31,7 @@ public class ScheduleSerializer extends StdSerializer<Schedule> {
   }
 
   @Override
-  public void serialize(Schedule schedule, JsonGenerator gen, SerializerProvider provider)
-      throws IOException {
+  public void serialize(Schedule schedule, JsonGenerator gen, SerializationContext provider) {
 
     if (schedule != null) {
       if (schedule.getCron() == null
@@ -45,15 +43,15 @@ public class ScheduleSerializer extends StdSerializer<Schedule> {
         gen.writeStartObject();
 
         if (schedule.getInterval() != null && schedule.getInterval().length() > 0) {
-          gen.writeStringField("interval", schedule.getInterval());
+          gen.writeStringProperty("interval", schedule.getInterval());
         }
 
         if (schedule.getCron() != null) {
-          gen.writeObjectField("cron", schedule.getCron());
+          gen.writePOJOProperty("cron", schedule.getCron());
         }
 
         if (schedule.getTimezone() != null && schedule.getTimezone().length() > 0) {
-          gen.writeStringField("timezone", schedule.getTimezone());
+          gen.writeStringProperty("timezone", schedule.getTimezone());
         }
 
         gen.writeEndObject();

--- a/api/src/main/java/io/serverlessworkflow/api/serializers/SleepStateSerializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/serializers/SleepStateSerializer.java
@@ -15,14 +15,14 @@
  */
 package io.serverlessworkflow.api.serializers;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.BeanSerializerFactory;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.serverlessworkflow.api.states.DefaultState;
 import io.serverlessworkflow.api.states.SleepState;
-import java.io.IOException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.BeanSerializerFactory;
+import tools.jackson.databind.ser.std.StdSerializer;
 
 public class SleepStateSerializer extends StdSerializer<SleepState> {
 
@@ -35,15 +35,16 @@ public class SleepStateSerializer extends StdSerializer<SleepState> {
   }
 
   @Override
-  public void serialize(SleepState delayState, JsonGenerator gen, SerializerProvider provider)
-      throws IOException {
+  public void serialize(SleepState delayState, JsonGenerator gen, SerializationContext provider) {
 
     // set defaults for delay state
     delayState.setType(DefaultState.Type.SLEEP);
 
     // serialize after setting default bean values...
+    JavaType type = provider.constructType(SleepState.class);
     BeanSerializerFactory.instance
-        .createSerializer(provider, TypeFactory.defaultInstance().constructType(SleepState.class))
+        .createSerializer(
+            provider, type, provider.lazyIntrospectBeanDescription(type), JsonFormat.Value.empty())
         .serialize(delayState, gen, provider);
   }
 }

--- a/api/src/main/java/io/serverlessworkflow/api/serializers/StartDefinitionSerializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/serializers/StartDefinitionSerializer.java
@@ -15,11 +15,10 @@
  */
 package io.serverlessworkflow.api.serializers;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import io.serverlessworkflow.api.start.Start;
-import java.io.IOException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.std.StdSerializer;
 
 public class StartDefinitionSerializer extends StdSerializer<Start> {
 
@@ -32,8 +31,7 @@ public class StartDefinitionSerializer extends StdSerializer<Start> {
   }
 
   @Override
-  public void serialize(Start start, JsonGenerator gen, SerializerProvider provider)
-      throws IOException {
+  public void serialize(Start start, JsonGenerator gen, SerializationContext provider) {
 
     if (start != null) {
       if (start.getStateName() != null
@@ -44,11 +42,11 @@ public class StartDefinitionSerializer extends StdSerializer<Start> {
         gen.writeStartObject();
 
         if (start.getStateName() != null && start.getStateName().length() > 0) {
-          gen.writeStringField("stateName", start.getStateName());
+          gen.writeStringProperty("stateName", start.getStateName());
         }
 
         if (start.getSchedule() != null) {
-          gen.writeObjectField("schedule", start.getSchedule());
+          gen.writePOJOProperty("schedule", start.getSchedule());
         }
 
         gen.writeEndObject();

--- a/api/src/main/java/io/serverlessworkflow/api/serializers/StateExecTimeoutSerializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/serializers/StateExecTimeoutSerializer.java
@@ -15,11 +15,10 @@
  */
 package io.serverlessworkflow.api.serializers;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import io.serverlessworkflow.api.timeouts.StateExecTimeout;
-import java.io.IOException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.std.StdSerializer;
 
 public class StateExecTimeoutSerializer extends StdSerializer<StateExecTimeout> {
 
@@ -33,8 +32,7 @@ public class StateExecTimeoutSerializer extends StdSerializer<StateExecTimeout> 
 
   @Override
   public void serialize(
-      StateExecTimeout stateExecTimeout, JsonGenerator gen, SerializerProvider provider)
-      throws IOException {
+      StateExecTimeout stateExecTimeout, JsonGenerator gen, SerializationContext provider) {
 
     if (stateExecTimeout != null) {
       if ((stateExecTimeout.getTotal() != null && !stateExecTimeout.getTotal().isEmpty())
@@ -44,11 +42,11 @@ public class StateExecTimeoutSerializer extends StdSerializer<StateExecTimeout> 
         gen.writeStartObject();
 
         if (stateExecTimeout.getTotal() != null && stateExecTimeout.getTotal().length() > 0) {
-          gen.writeStringField("total", stateExecTimeout.getTotal());
+          gen.writeStringProperty("total", stateExecTimeout.getTotal());
         }
 
         if (stateExecTimeout.getSingle() != null && stateExecTimeout.getSingle().length() > 0) {
-          gen.writeStringField("single", stateExecTimeout.getSingle());
+          gen.writeStringProperty("single", stateExecTimeout.getSingle());
         }
 
         gen.writeEndObject();

--- a/api/src/main/java/io/serverlessworkflow/api/serializers/SubFlowRefSerializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/serializers/SubFlowRefSerializer.java
@@ -15,11 +15,10 @@
  */
 package io.serverlessworkflow.api.serializers;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import io.serverlessworkflow.api.functions.SubFlowRef;
-import java.io.IOException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.std.StdSerializer;
 
 public class SubFlowRefSerializer extends StdSerializer<SubFlowRef> {
 
@@ -32,8 +31,7 @@ public class SubFlowRefSerializer extends StdSerializer<SubFlowRef> {
   }
 
   @Override
-  public void serialize(SubFlowRef subflowRef, JsonGenerator gen, SerializerProvider provider)
-      throws IOException {
+  public void serialize(SubFlowRef subflowRef, JsonGenerator gen, SerializationContext provider) {
 
     if (subflowRef != null) {
       if ((subflowRef.getWorkflowId() == null || subflowRef.getWorkflowId().isEmpty())
@@ -45,19 +43,19 @@ public class SubFlowRefSerializer extends StdSerializer<SubFlowRef> {
         gen.writeStartObject();
 
         if (subflowRef.getWorkflowId() != null && subflowRef.getWorkflowId().length() > 0) {
-          gen.writeStringField("workflowId", subflowRef.getWorkflowId());
+          gen.writeStringProperty("workflowId", subflowRef.getWorkflowId());
         }
 
         if (subflowRef.getVersion() != null && subflowRef.getVersion().length() > 0) {
-          gen.writeStringField("version", subflowRef.getVersion());
+          gen.writeStringProperty("version", subflowRef.getVersion());
         }
 
         if (subflowRef.getOnParentComplete() != null) {
-          gen.writeStringField("onParentComplete", subflowRef.getOnParentComplete().value());
+          gen.writeStringProperty("onParentComplete", subflowRef.getOnParentComplete().value());
         }
 
         if (subflowRef.getInvoke() != null) {
-          gen.writeStringField("invoke", subflowRef.getInvoke().value());
+          gen.writeStringProperty("invoke", subflowRef.getInvoke().value());
         }
 
         gen.writeEndObject();

--- a/api/src/main/java/io/serverlessworkflow/api/serializers/SwitchStateSerializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/serializers/SwitchStateSerializer.java
@@ -15,14 +15,14 @@
  */
 package io.serverlessworkflow.api.serializers;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.BeanSerializerFactory;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.serverlessworkflow.api.states.DefaultState;
 import io.serverlessworkflow.api.states.SwitchState;
-import java.io.IOException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.BeanSerializerFactory;
+import tools.jackson.databind.ser.std.StdSerializer;
 
 public class SwitchStateSerializer extends StdSerializer<SwitchState> {
 
@@ -35,15 +35,16 @@ public class SwitchStateSerializer extends StdSerializer<SwitchState> {
   }
 
   @Override
-  public void serialize(SwitchState switchState, JsonGenerator gen, SerializerProvider provider)
-      throws IOException {
+  public void serialize(SwitchState switchState, JsonGenerator gen, SerializationContext provider) {
 
     // set defaults for end state
     switchState.setType(DefaultState.Type.SWITCH);
 
     // serialize after setting default bean values...
+    JavaType type = provider.constructType(SwitchState.class);
     BeanSerializerFactory.instance
-        .createSerializer(provider, TypeFactory.defaultInstance().constructType(SwitchState.class))
+        .createSerializer(
+            provider, type, provider.lazyIntrospectBeanDescription(type), JsonFormat.Value.empty())
         .serialize(switchState, gen, provider);
   }
 }

--- a/api/src/main/java/io/serverlessworkflow/api/serializers/TransitionSerializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/serializers/TransitionSerializer.java
@@ -15,12 +15,11 @@
  */
 package io.serverlessworkflow.api.serializers;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import io.serverlessworkflow.api.produce.ProduceEvent;
 import io.serverlessworkflow.api.transitions.Transition;
-import java.io.IOException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.std.StdSerializer;
 
 public class TransitionSerializer extends StdSerializer<Transition> {
 
@@ -33,8 +32,7 @@ public class TransitionSerializer extends StdSerializer<Transition> {
   }
 
   @Override
-  public void serialize(Transition transition, JsonGenerator gen, SerializerProvider provider)
-      throws IOException {
+  public void serialize(Transition transition, JsonGenerator gen, SerializationContext provider) {
 
     if (transition != null) {
       if ((transition.getProduceEvents() == null || transition.getProduceEvents().size() < 1)
@@ -46,19 +44,19 @@ public class TransitionSerializer extends StdSerializer<Transition> {
         gen.writeStartObject();
 
         if (transition.getProduceEvents() != null && !transition.getProduceEvents().isEmpty()) {
-          gen.writeArrayFieldStart("produceEvents");
+          gen.writeArrayPropertyStart("produceEvents");
           for (ProduceEvent produceEvent : transition.getProduceEvents()) {
-            gen.writeObject(produceEvent);
+            gen.writePOJO(produceEvent);
           }
           gen.writeEndArray();
         }
 
         if (transition.isCompensate()) {
-          gen.writeBooleanField("compensate", true);
+          gen.writeBooleanProperty("compensate", true);
         }
 
         if (transition.getNextState() != null && transition.getNextState().length() > 0) {
-          gen.writeStringField("nextState", transition.getNextState());
+          gen.writeStringProperty("nextState", transition.getNextState());
         }
 
         gen.writeEndObject();

--- a/api/src/main/java/io/serverlessworkflow/api/serializers/WorkflowSerializer.java
+++ b/api/src/main/java/io/serverlessworkflow/api/serializers/WorkflowSerializer.java
@@ -15,9 +15,6 @@
  */
 package io.serverlessworkflow.api.serializers;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import io.serverlessworkflow.api.Workflow;
 import io.serverlessworkflow.api.error.ErrorDefinition;
 import io.serverlessworkflow.api.events.EventDefinition;
@@ -25,9 +22,11 @@ import io.serverlessworkflow.api.functions.FunctionDefinition;
 import io.serverlessworkflow.api.interfaces.Extension;
 import io.serverlessworkflow.api.interfaces.State;
 import io.serverlessworkflow.api.retry.RetryDefinition;
-import java.io.IOException;
 import java.security.MessageDigest;
 import java.util.UUID;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.std.StdSerializer;
 
 public class WorkflowSerializer extends StdSerializer<Workflow> {
 
@@ -42,105 +41,104 @@ public class WorkflowSerializer extends StdSerializer<Workflow> {
   private static final char[] hexArray = "0123456789ABCDEF".toCharArray();
 
   @Override
-  public void serialize(Workflow workflow, JsonGenerator gen, SerializerProvider provider)
-      throws IOException {
+  public void serialize(Workflow workflow, JsonGenerator gen, SerializationContext provider) {
 
     gen.writeStartObject();
 
     if (workflow.getId() != null && !workflow.getId().isEmpty()) {
-      gen.writeStringField("id", workflow.getId());
+      gen.writeStringProperty("id", workflow.getId());
     } else {
-      gen.writeStringField("id", generateUniqueId());
+      gen.writeStringProperty("id", generateUniqueId());
     }
 
     if (workflow.getKey() != null) {
-      gen.writeStringField("key", workflow.getKey());
+      gen.writeStringProperty("key", workflow.getKey());
     }
-    gen.writeStringField("name", workflow.getName());
+    gen.writeStringProperty("name", workflow.getName());
 
     if (workflow.getDescription() != null && !workflow.getDescription().isEmpty()) {
-      gen.writeStringField("description", workflow.getDescription());
+      gen.writeStringProperty("description", workflow.getDescription());
     }
 
     if (workflow.getVersion() != null && !workflow.getVersion().isEmpty()) {
-      gen.writeStringField("version", workflow.getVersion());
+      gen.writeStringProperty("version", workflow.getVersion());
     }
 
     if (workflow.getAnnotations() != null && !workflow.getAnnotations().isEmpty()) {
-      gen.writeObjectField("annotations", workflow.getAnnotations());
+      gen.writePOJOProperty("annotations", workflow.getAnnotations());
     }
 
     if (workflow.getDataInputSchema() != null) {
       if (workflow.getDataInputSchema().getRefValue() != null
           && workflow.getDataInputSchema().getRefValue().length() > 0
           && workflow.getDataInputSchema().isFailOnValidationErrors()) {
-        gen.writeStringField("dataInputSchema", workflow.getDataInputSchema().getRefValue());
+        gen.writeStringProperty("dataInputSchema", workflow.getDataInputSchema().getRefValue());
 
       } else if (workflow.getDataInputSchema().getSchemaDef() != null
           && !workflow.getDataInputSchema().getSchemaDef().isEmpty()
           && !workflow.getDataInputSchema().isFailOnValidationErrors()) {
-        gen.writeObjectField("dataInputSchema", workflow.getDataInputSchema().getSchemaDef());
+        gen.writePOJOProperty("dataInputSchema", workflow.getDataInputSchema().getSchemaDef());
       }
     }
 
     if (workflow.getStart() != null) {
-      gen.writeObjectField("start", workflow.getStart());
+      gen.writePOJOProperty("start", workflow.getStart());
     }
 
     if (workflow.getSpecVersion() != null && !workflow.getSpecVersion().isEmpty()) {
-      gen.writeStringField("specVersion", workflow.getSpecVersion());
+      gen.writeStringProperty("specVersion", workflow.getSpecVersion());
     }
 
     if (workflow.getExtensions() != null && !workflow.getExpressionLang().isEmpty()) {
-      gen.writeStringField("expressionLang", workflow.getExpressionLang());
+      gen.writeStringProperty("expressionLang", workflow.getExpressionLang());
     }
 
     if (workflow.isKeepActive()) {
-      gen.writeBooleanField("keepActive", workflow.isKeepActive());
+      gen.writeBooleanProperty("keepActive", workflow.isKeepActive());
     }
 
     if (workflow.isAutoRetries()) {
-      gen.writeBooleanField("autoRetries", workflow.isAutoRetries());
+      gen.writeBooleanProperty("autoRetries", workflow.isAutoRetries());
     }
 
     if (workflow.getMetadata() != null && !workflow.getMetadata().isEmpty()) {
-      gen.writeObjectField("metadata", workflow.getMetadata());
+      gen.writePOJOProperty("metadata", workflow.getMetadata());
     }
 
     if (workflow.getEvents() != null && !workflow.getEvents().getEventDefs().isEmpty()) {
-      gen.writeArrayFieldStart("events");
+      gen.writeArrayPropertyStart("events");
       for (EventDefinition eventDefinition : workflow.getEvents().getEventDefs()) {
-        gen.writeObject(eventDefinition);
+        gen.writePOJO(eventDefinition);
       }
       gen.writeEndArray();
     }
 
     if (workflow.getFunctions() != null && !workflow.getFunctions().getFunctionDefs().isEmpty()) {
-      gen.writeArrayFieldStart("functions");
+      gen.writeArrayPropertyStart("functions");
       for (FunctionDefinition function : workflow.getFunctions().getFunctionDefs()) {
-        gen.writeObject(function);
+        gen.writePOJO(function);
       }
       gen.writeEndArray();
     }
 
     if (workflow.getRetries() != null && !workflow.getRetries().getRetryDefs().isEmpty()) {
-      gen.writeArrayFieldStart("retries");
+      gen.writeArrayPropertyStart("retries");
       for (RetryDefinition retry : workflow.getRetries().getRetryDefs()) {
-        gen.writeObject(retry);
+        gen.writePOJO(retry);
       }
       gen.writeEndArray();
     }
 
     if (workflow.getErrors() != null && !workflow.getErrors().getErrorDefs().isEmpty()) {
-      gen.writeArrayFieldStart("errors");
+      gen.writeArrayPropertyStart("errors");
       for (ErrorDefinition error : workflow.getErrors().getErrorDefs()) {
-        gen.writeObject(error);
+        gen.writePOJO(error);
       }
       gen.writeEndArray();
     }
 
     if (workflow.getSecrets() != null && !workflow.getSecrets().getSecretDefs().isEmpty()) {
-      gen.writeArrayFieldStart("secrets");
+      gen.writeArrayPropertyStart("secrets");
       for (String secretDef : workflow.getSecrets().getSecretDefs()) {
         gen.writeString(secretDef);
       }
@@ -150,32 +148,32 @@ public class WorkflowSerializer extends StdSerializer<Workflow> {
     if (workflow.getConstants() != null) {
       if (workflow.getConstants().getConstantsDef() != null
           && !workflow.getConstants().getConstantsDef().isEmpty()) {
-        gen.writeObjectField("constants", workflow.getConstants().getConstantsDef());
+        gen.writePOJOProperty("constants", workflow.getConstants().getConstantsDef());
       } else if (workflow.getConstants().getRefValue() != null) {
-        gen.writeStringField("constants", workflow.getConstants().getRefValue());
+        gen.writeStringProperty("constants", workflow.getConstants().getRefValue());
       }
     }
 
     if (workflow.getTimeouts() != null) {
-      gen.writeObjectField("timeouts", workflow.getTimeouts());
+      gen.writePOJOProperty("timeouts", workflow.getTimeouts());
     }
 
     if (workflow.getAuth() != null && !workflow.getAuth().getAuthDefs().isEmpty()) {
-      gen.writeObjectField("auth", workflow.getAuth().getAuthDefs());
+      gen.writePOJOProperty("auth", workflow.getAuth().getAuthDefs());
     }
 
     if (workflow.getStates() != null && !workflow.getStates().isEmpty()) {
-      gen.writeArrayFieldStart("states");
+      gen.writeArrayPropertyStart("states");
       for (State state : workflow.getStates()) {
-        gen.writeObject(state);
+        gen.writePOJO(state);
       }
       gen.writeEndArray();
     }
 
     if (workflow.getExtensions() != null && !workflow.getExtensions().isEmpty()) {
-      gen.writeArrayFieldStart("extensions");
+      gen.writeArrayPropertyStart("extensions");
       for (Extension extension : workflow.getExtensions()) {
-        gen.writeObject(extension);
+        gen.writePOJO(extension);
       }
       gen.writeEndArray();
     }

--- a/api/src/main/java/io/serverlessworkflow/api/utils/Utils.java
+++ b/api/src/main/java/io/serverlessworkflow/api/utils/Utils.java
@@ -15,21 +15,21 @@
  */
 package io.serverlessworkflow.api.utils;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.serverlessworkflow.api.mapper.JsonObjectMapperFactory;
 import io.serverlessworkflow.api.mapper.YamlObjectMapperFactory;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
 import java.util.stream.Collectors;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 public class Utils {
 
   @SuppressWarnings("DefaultCharset")
-  public static String getResourceFileAsString(String fileName) throws IOException {
+  public static String getResourceFileAsString(String fileName) {
     ClassLoader classLoader = ClassLoader.getSystemClassLoader();
     try (InputStream is = classLoader.getResourceAsStream(fileName)) {
       if (is == null) return null;
@@ -37,6 +37,8 @@ public class Utils {
           BufferedReader reader = new BufferedReader(isr)) {
         return reader.lines().collect(Collectors.joining(System.lineSeparator()));
       }
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
     }
   }
 
@@ -46,7 +48,7 @@ public class Utils {
         : JsonObjectMapperFactory.mapper();
   }
 
-  public static JsonNode getNode(String source) throws JsonProcessingException {
+  public static JsonNode getNode(String source) {
     return getObjectMapper(source).readTree(source);
   }
 }

--- a/api/src/main/java/io/serverlessworkflow/api/validation/WorkflowSchemaLoader.java
+++ b/api/src/main/java/io/serverlessworkflow/api/validation/WorkflowSchemaLoader.java
@@ -15,20 +15,14 @@
  */
 package io.serverlessworkflow.api.validation;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import java.io.UncheckedIOException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 public class WorkflowSchemaLoader {
 
   public static JsonNode getWorkflowSchema() {
-    try {
-      return ObjectMapperHolder.objectMapper.readTree(
-          WorkflowSchemaLoader.class.getResourceAsStream("/schema/workflow.json"));
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
+    return ObjectMapperHolder.objectMapper.readTree(
+        WorkflowSchemaLoader.class.getResourceAsStream("/schema/workflow.json"));
   }
 
   private static class ObjectMapperHolder {

--- a/api/src/main/java/io/serverlessworkflow/api/workflow/BaseWorkflow.java
+++ b/api/src/main/java/io/serverlessworkflow/api/workflow/BaseWorkflow.java
@@ -15,22 +15,23 @@
  */
 package io.serverlessworkflow.api.workflow;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.serverlessworkflow.api.Workflow;
 import io.serverlessworkflow.api.mapper.JsonObjectMapper;
 import io.serverlessworkflow.api.mapper.YamlObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.dataformat.yaml.YAMLFactory;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+import tools.jackson.dataformat.yaml.YAMLWriteFeature;
 
 /** Base Workflow provides some extra functionality for the Workflow types */
 public class BaseWorkflow {
 
-  private static JsonObjectMapper jsonObjectMapper = new JsonObjectMapper();
-  private static YamlObjectMapper yamlObjectMapper = new YamlObjectMapper();
+  private static ObjectMapper jsonObjectMapper = JsonObjectMapper.create();
+  private static ObjectMapper yamlObjectMapper = YamlObjectMapper.create();
 
   private static Logger logger = LoggerFactory.getLogger(BaseWorkflow.class);
 
@@ -52,7 +53,7 @@ public class BaseWorkflow {
   public static String toJson(Workflow workflow) {
     try {
       return jsonObjectMapper.writeValueAsString(workflow);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       logger.error("Error mapping to json: " + e.getMessage());
       return null;
     }
@@ -63,9 +64,10 @@ public class BaseWorkflow {
       String jsonString = jsonObjectMapper.writeValueAsString(workflow);
       JsonNode jsonNode = jsonObjectMapper.readTree(jsonString);
       YAMLFactory yamlFactory =
-          new YAMLFactory()
-              .disable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
-              .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
+          YAMLFactory.builder()
+              .disable(YAMLWriteFeature.MINIMIZE_QUOTES)
+              .disable(YAMLWriteFeature.WRITE_DOC_START_MARKER)
+              .build();
       return new YAMLMapper(yamlFactory).writeValueAsString(jsonNode);
     } catch (Exception e) {
       logger.error("Error mapping to yaml: " + e.getMessage());

--- a/api/src/main/java/io/serverlessworkflow/api/workflow/Constants.java
+++ b/api/src/main/java/io/serverlessworkflow/api/workflow/Constants.java
@@ -15,8 +15,8 @@
  */
 package io.serverlessworkflow.api.workflow;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import java.io.Serializable;
+import tools.jackson.databind.JsonNode;
 
 public class Constants implements Serializable {
   private String refValue;

--- a/api/src/main/java/io/serverlessworkflow/api/workflow/DataInputSchema.java
+++ b/api/src/main/java/io/serverlessworkflow/api/workflow/DataInputSchema.java
@@ -15,8 +15,8 @@
  */
 package io.serverlessworkflow.api.workflow;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import java.io.Serializable;
+import tools.jackson.databind.JsonNode;
 
 public class DataInputSchema implements Serializable {
   private String refValue;

--- a/api/src/main/resources/schema/events/eventref.json
+++ b/api/src/main/resources/schema/events/eventref.json
@@ -17,7 +17,7 @@
     },
     "data": {
       "type": "object",
-      "existingJavaType": "com.fasterxml.jackson.databind.JsonNode",
+      "existingJavaType": "tools.jackson.databind.JsonNode",
       "description": "Expression which selects parts of the states data output to become the data of the produced event."
     },
     "contextAttributes": {

--- a/api/src/main/resources/schema/functions/functionref.json
+++ b/api/src/main/resources/schema/functions/functionref.json
@@ -10,7 +10,7 @@
     "arguments": {
       "type": "object",
       "description": "Function arguments",
-      "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"
+      "existingJavaType": "tools.jackson.databind.JsonNode"
     },
     "selectionSet": {
       "type": "string",

--- a/api/src/main/resources/schema/produce/produceevent.json
+++ b/api/src/main/resources/schema/produce/produceevent.json
@@ -9,7 +9,7 @@
     },
     "data": {
       "type": "object",
-      "existingJavaType": "com.fasterxml.jackson.databind.JsonNode",
+      "existingJavaType": "tools.jackson.databind.JsonNode",
       "description": "Workflow expression which selects parts of the states data output to become the data of the produced event"
     },
     "contextAttributes": {

--- a/api/src/main/resources/schema/states/injectstate.json
+++ b/api/src/main/resources/schema/states/injectstate.json
@@ -12,7 +12,7 @@
     "data": {
       "type": "object",
       "description": "JSON object which can be set as states data input and can be manipulated via filters",
-      "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"
+      "existingJavaType": "tools.jackson.databind.JsonNode"
     },
     "usedForCompensation": {
       "type": "boolean",

--- a/api/src/test/java/io/serverlessworkflow/api/test/MarkupToWorkflowTest.java
+++ b/api/src/test/java/io/serverlessworkflow/api/test/MarkupToWorkflowTest.java
@@ -17,7 +17,6 @@ package io.serverlessworkflow.api.test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import io.serverlessworkflow.api.Workflow;
 import io.serverlessworkflow.api.actions.Action;
 import io.serverlessworkflow.api.auth.AuthDefinition;
@@ -31,7 +30,9 @@ import io.serverlessworkflow.api.functions.FunctionRef;
 import io.serverlessworkflow.api.functions.SubFlowRef;
 import io.serverlessworkflow.api.interfaces.State;
 import io.serverlessworkflow.api.retry.RetryDefinition;
+import io.serverlessworkflow.api.states.CallbackState;
 import io.serverlessworkflow.api.states.EventState;
+import io.serverlessworkflow.api.states.InjectState;
 import io.serverlessworkflow.api.states.OperationState;
 import io.serverlessworkflow.api.states.ParallelState;
 import io.serverlessworkflow.api.states.SwitchState;
@@ -41,8 +42,10 @@ import io.serverlessworkflow.api.timeouts.WorkflowExecTimeout;
 import io.serverlessworkflow.api.workflow.*;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import tools.jackson.databind.JsonNode;
 
 public class MarkupToWorkflowTest {
 
@@ -310,7 +313,7 @@ public class MarkupToWorkflowTest {
     FunctionRef functionRef2 = action2.getFunctionRef();
     assertEquals("sendRejectionEmailFunction", functionRef2.getRefName());
     assertEquals(1, functionRef2.getArguments().size());
-    assertEquals("${ .customer }", functionRef2.getArguments().get("applicant").asText());
+    assertEquals("${ .customer }", functionRef2.getArguments().get("applicant").asString());
   }
 
   @ParameterizedTest
@@ -359,10 +362,10 @@ public class MarkupToWorkflowTest {
     assertNotNull(params);
     assertEquals(4, params.size());
     assertEquals(123, params.get("id").intValue());
-    assertEquals("My Address, 123 MyCity, MyCountry", params.get("address").asText());
-    assertEquals("${ .owner.name }", params.get("owner").asText());
-    assertEquals("Pluto", params.get("body").get("name").asText());
-    assertEquals("${ .pet.tagnumber }", params.get("body").get("tag").asText());
+    assertEquals("My Address, 123 MyCity, MyCountry", params.get("address").asString());
+    assertEquals("${ .owner.name }", params.get("owner").asString());
+    assertEquals("Pluto", params.get("body").get("name").asString());
+    assertEquals("${ .pet.tagnumber }", params.get("body").get("tag").asString());
   }
 
   @ParameterizedTest
@@ -566,7 +569,7 @@ public class MarkupToWorkflowTest {
     assertNotNull(properties.get("firstName"));
     JsonNode typeNode = properties.get("firstName");
     JsonNode stringNode = typeNode.get("type");
-    assertEquals("string", stringNode.asText());
+    assertEquals("string", stringNode.asString());
     assertFalse(dataInputSchema.isFailOnValidationErrors());
   }
 
@@ -639,7 +642,7 @@ public class MarkupToWorkflowTest {
     assertNotNull(translationNode.get("Dog"));
     JsonNode translationDogNode = translationNode.get("Dog");
     JsonNode serbianTranslationNode = translationDogNode.get("Serbian");
-    assertEquals("pas", serbianTranslationNode.asText());
+    assertEquals("pas", serbianTranslationNode.asString());
   }
 
   @ParameterizedTest
@@ -804,7 +807,7 @@ public class MarkupToWorkflowTest {
     FunctionRef functionRef2 = action2.getFunctionRef();
     assertEquals("sendRejectionEmailFunction", functionRef2.getRefName());
     assertEquals(1, functionRef2.getArguments().size());
-    assertEquals("${ .customer }", functionRef2.getArguments().get("applicant").asText());
+    assertEquals("${ .customer }", functionRef2.getArguments().get("applicant").asString());
   }
 
   @ParameterizedTest

--- a/api/src/test/java/io/serverlessworkflow/api/test/utils/WorkflowTestUtils.java
+++ b/api/src/test/java/io/serverlessworkflow/api/test/utils/WorkflowTestUtils.java
@@ -21,10 +21,11 @@ import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import tools.jackson.databind.ObjectMapper;
 
 public class WorkflowTestUtils {
-  private static JsonObjectMapper jsonObjectMapper = new JsonObjectMapper();
-  private static YamlObjectMapper yamlObjectMapper = new YamlObjectMapper();
+  private static ObjectMapper jsonObjectMapper = JsonObjectMapper.create();
+  private static ObjectMapper yamlObjectMapper = YamlObjectMapper.create();
 
   public static final Path resourceDirectory = Paths.get("src", "test", "resources");
   public static final String absolutePath = resourceDirectory.toFile().getAbsolutePath();

--- a/diagram/src/test/java/io/serverlessworkflow/diagram/test/utils/DiagramTestUtils.java
+++ b/diagram/src/test/java/io/serverlessworkflow/diagram/test/utils/DiagramTestUtils.java
@@ -21,10 +21,11 @@ import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import tools.jackson.databind.ObjectMapper;
 
 public class DiagramTestUtils {
-  private static JsonObjectMapper jsonObjectMapper = new JsonObjectMapper();
-  private static YamlObjectMapper yamlObjectMapper = new YamlObjectMapper();
+  private static ObjectMapper jsonObjectMapper = JsonObjectMapper.create();
+  private static ObjectMapper yamlObjectMapper = YamlObjectMapper.create();
 
   public static final Path resourceDirectory = Paths.get("src", "test", "resources");
   public static final String absolutePath = resourceDirectory.toFile().getAbsolutePath();

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
     <version.maven>3.9.9</version.maven>
 
     <!-- Plugin versions -->
+    <version.antrun.plugin>3.1.0</version.antrun.plugin>
     <version.buildnumber.plugin>3.3.0</version.buildnumber.plugin>
     <version.checkstyle.plugin>3.6.0</version.checkstyle.plugin>
     <version.compiler.plugin>3.15.0</version.compiler.plugin>
@@ -63,7 +64,7 @@
     <version.gpg.plugin>3.2.8</version.gpg.plugin>
     <version.jar.plugin>3.5.1</version.jar.plugin>
     <version.jdk>${java.version}</version.jdk>
-    <version.jsonschema2pojo-maven-plugin>1.3.1</version.jsonschema2pojo-maven-plugin>
+    <version.jsonschema2pojo-maven-plugin>1.3.3</version.jsonschema2pojo-maven-plugin>
     <version.javadoc.plugin>3.12.0</version.javadoc.plugin>
     <version.release.plugin>3.3.1</version.release.plugin>
     <version.source.plugin>3.4.0</version.source.plugin>
@@ -71,8 +72,8 @@
 
     <!-- Dependency versions -->
     <version.ch.qos.logback>1.6.0</version.ch.qos.logback>
-    <version.com.fasterxml.jackson>2.22.1</version.com.fasterxml.jackson>
-    <version.com.networknt>1.5.9</version.com.networknt>
+    <version.com.fasterxml.jackson>3.2.1</version.com.fasterxml.jackson>
+    <version.com.networknt>3.0.6</version.com.networknt>
     <version.commons.lang>3.20.0</version.commons.lang>
     <version.graphviz>0.18.1</version.graphviz>
     <version.hamcrest>3.0</version.hamcrest>
@@ -123,12 +124,12 @@
         <version>${version.org.slf4j}</version>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
+        <groupId>tools.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
         <version>${version.com.fasterxml.jackson}</version>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
+        <groupId>tools.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
         <version>${version.com.fasterxml.jackson}</version>
       </dependency>
@@ -144,7 +145,7 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <groupId>tools.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-yaml</artifactId>
         <version>${version.com.fasterxml.jackson}</version>
       </dependency>
@@ -358,6 +359,11 @@
           <groupId>org.jsonschema2pojo</groupId>
           <artifactId>jsonschema2pojo-maven-plugin</artifactId>
           <version>${version.jsonschema2pojo-maven-plugin}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>${version.antrun.plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/utils/src/main/java/io/serverlessworkflow/utils/WorkflowUtils.java
+++ b/utils/src/main/java/io/serverlessworkflow/utils/WorkflowUtils.java
@@ -15,10 +15,6 @@
  */
 package io.serverlessworkflow.utils;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.serverlessworkflow.api.Workflow;
 import io.serverlessworkflow.api.actions.Action;
 import io.serverlessworkflow.api.branches.Branch;
@@ -34,6 +30,10 @@ import io.serverlessworkflow.api.switchconditions.DataCondition;
 import io.serverlessworkflow.api.switchconditions.EventCondition;
 import java.util.*;
 import java.util.stream.Collectors;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 /** Provides common utility methods to provide most often needed answers from a workflow */
 @SuppressWarnings("StreamToLoop")
@@ -571,11 +571,7 @@ public final class WorkflowUtils {
    * @return merged JsonNode
    */
   public static JsonNode mergeNodes(JsonNode mainNode, JsonNode updateNode) {
-
-    Iterator<String> fieldNames = updateNode.fieldNames();
-    while (fieldNames.hasNext()) {
-
-      String fieldName = fieldNames.next();
+    for (String fieldName : updateNode.propertyNames()) {
       JsonNode jsonNode = mainNode.get(fieldName);
       // if field exists and is an embedded object
       if (jsonNode != null && jsonNode.isObject()) {

--- a/utils/src/test/java/io/serverlessworkflow/util/JsonManipulationTest.java
+++ b/utils/src/test/java/io/serverlessworkflow/util/JsonManipulationTest.java
@@ -17,11 +17,11 @@ package io.serverlessworkflow.util;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.serverlessworkflow.utils.WorkflowUtils;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
 
 public class JsonManipulationTest {
   private static final ObjectMapper mapper = new ObjectMapper();
@@ -35,7 +35,7 @@ public class JsonManipulationTest {
     JsonNode added = WorkflowUtils.addFieldValue(mainNode, toAddString, "k3");
 
     assertNotNull(added);
-    assertEquals("v3", added.get("k3").asText());
+    assertEquals("v3", added.get("k3").asString());
   }
 
   @Test
@@ -48,7 +48,7 @@ public class JsonManipulationTest {
     JsonNode added = WorkflowUtils.addNode(mainNode, toAddNode, "newnode");
 
     assertNotNull(added);
-    assertEquals("v3", added.get("newnode").get("k3").asText());
+    assertEquals("v3", added.get("newnode").get("k3").asString());
   }
 
   @Test
@@ -63,8 +63,8 @@ public class JsonManipulationTest {
     assertNotNull(added);
     assertNotNull(added.get("newarray"));
     assertEquals(2, added.get("newarray").size());
-    assertEquals("a", added.get("newarray").get(0).asText());
-    assertEquals("b", added.get("newarray").get(1).asText());
+    assertEquals("a", added.get("newarray").get(0).asString());
+    assertEquals("b", added.get("newarray").get(1).asString());
   }
 
   @Test
@@ -77,8 +77,8 @@ public class JsonManipulationTest {
     JsonNode merged = WorkflowUtils.mergeNodes(mainNode, toMergeNode);
 
     assertNotNull(merged);
-    assertEquals("v3", merged.get("k3").asText());
-    assertEquals("v4", merged.get("k4").asText());
+    assertEquals("v3", merged.get("k3").asString());
+    assertEquals("v4", merged.get("k4").asString());
   }
 
   @Test
@@ -91,7 +91,7 @@ public class JsonManipulationTest {
     JsonNode merged = WorkflowUtils.mergeNodes(mainNode, toMergeNode);
 
     assertNotNull(merged);
-    assertEquals("v2new", merged.get("k2").asText());
-    assertEquals("v3", merged.get("k3").asText());
+    assertEquals("v2new", merged.get("k2").asString());
+    assertEquals("v3", merged.get("k3").asString());
   }
 }

--- a/validation/src/main/java/io/serverlessworkflow/validation/WorkflowValidatorImpl.java
+++ b/validation/src/main/java/io/serverlessworkflow/validation/WorkflowValidatorImpl.java
@@ -15,9 +15,10 @@
  */
 package io.serverlessworkflow.validation;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.networknt.schema.JsonSchemaFactory;
-import com.networknt.schema.SpecVersion.VersionFlag;
+import com.networknt.schema.Error;
+import com.networknt.schema.Schema;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.SpecificationVersion;
 import io.serverlessworkflow.api.Workflow;
 import io.serverlessworkflow.api.actions.Action;
 import io.serverlessworkflow.api.events.EventDefinition;
@@ -32,13 +33,15 @@ import io.serverlessworkflow.api.switchconditions.EventCondition;
 import io.serverlessworkflow.api.utils.Utils;
 import io.serverlessworkflow.api.validation.ValidationError;
 import io.serverlessworkflow.api.validation.WorkflowSchemaLoader;
-import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
 
 public class WorkflowValidatorImpl implements WorkflowValidator {
 
@@ -67,12 +70,15 @@ public class WorkflowValidatorImpl implements WorkflowValidator {
     if (workflow == null) {
       try {
         if (schemaValidationEnabled && source != null) {
-          JsonSchemaFactory.getInstance(VersionFlag.V7)
-              .getSchema(workflowSchema)
-              .validate(Utils.getNode(source))
-              .forEach(m -> addValidationError(m.getMessage(), ValidationError.SCHEMA_VALIDATION));
+          Schema schema =
+              SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_7)
+                  .getSchema(workflowSchema);
+          Collection<Error> errors = schema.validate(Utils.getNode(source));
+          errors.stream()
+              .filter(e -> !isOneOfTypeFalsePositive(e))
+              .forEach(e -> addValidationError(e.getMessage(), ValidationError.SCHEMA_VALIDATION));
         }
-      } catch (IOException e) {
+      } catch (JacksonException e) {
         logger.error("Unexpected error during validation", e);
       }
     }
@@ -394,18 +400,21 @@ public class WorkflowValidatorImpl implements WorkflowValidator {
         || !retries.stream().anyMatch(f -> f.getName() != null && f.getName().equals(retryName));
   }
 
-  private static final Set<String> skipMessages =
-      Set.of(
-          "$.start: string found, object expected",
-          "$.functions: array found, object expected",
-          "$.retries: array found, object expected",
-          "$.errors: array found, object expected",
-          "$.auth: array found, object expected");
+  // These top-level properties accept either a string (a reference/shorthand) or an object per
+  // the spec's oneOf schema. The schema validator reports a spurious "type" mismatch against the
+  // object branch even when the string branch matches, so those specific false positives are
+  // filtered by keyword + instance location rather than by message text (which is
+  // validator-version-dependent).
+  private static final Set<String> ONE_OF_STRING_OR_OBJECT_FIELDS =
+      Set.of("start", "functions", "retries", "errors", "auth");
+
+  private boolean isOneOfTypeFalsePositive(Error error) {
+    return "type".equals(error.getKeyword())
+        && error.getInstanceLocation().getNameCount() == 1
+        && ONE_OF_STRING_OR_OBJECT_FIELDS.contains(error.getInstanceLocation().getName(0));
+  }
 
   private void addValidationError(String message, String type) {
-    if (skipMessages.contains(message)) {
-      return;
-    }
     ValidationError mainError = new ValidationError();
     mainError.setMessage(message);
     mainError.setType(type);

--- a/validation/src/test/java/io/serverlessworkflow/validation/test/WorkflowValidationTest.java
+++ b/validation/src/test/java/io/serverlessworkflow/validation/test/WorkflowValidationTest.java
@@ -18,7 +18,6 @@ package io.serverlessworkflow.validation.test;
 import static io.serverlessworkflow.api.states.DefaultState.Type.OPERATION;
 import static io.serverlessworkflow.api.states.DefaultState.Type.SLEEP;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.serverlessworkflow.api.Workflow;
 import io.serverlessworkflow.api.actions.Action;
 import io.serverlessworkflow.api.end.End;
@@ -45,6 +44,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
 
 public class WorkflowValidationTest {
 
@@ -127,7 +127,7 @@ public class WorkflowValidationTest {
     Assertions.assertEquals(1, validationErrors.size());
 
     Assertions.assertEquals(
-        "$: required property 'id' not found", validationErrors.get(0).getMessage());
+        "required property 'id' not found", validationErrors.get(0).getMessage());
   }
 
   @Test
@@ -520,5 +520,103 @@ public class WorkflowValidationTest {
         new WorkflowValidatorImpl().setWorkflow(workflow).validate();
 
     Assertions.assertTrue(validationErrors.isEmpty());
+  }
+
+  @Test
+  public void testKuflowCallbackSwitchWorkflowSchemaValidation() {
+    String source =
+        """
+        {
+          "id" : "process-definition-id",
+          "name" : "process-definition-name",
+          "version" : "1.0",
+          "specVersion" : "0.8",
+          "start" : "dm-node-8ad9f542-4e61-42f8-af61-ff88f6b9ef96",
+          "states" : [ {
+            "id" : "dm-node-8ad9f542-4e61-42f8-af61-ff88f6b9ef96",
+            "name" : "dm-node-8ad9f542-4e61-42f8-af61-ff88f6b9ef96",
+            "type" : "inject",
+            "data" : {
+              "__kuflowDummy" : true
+            },
+            "transition" : "dm-node-0e7d2afd-1ecc-40a4-ba98-45c291e91177"
+          }, {
+            "id" : "dm-node-e0972733-0b72-4f0d-a6e5-372b90063fe2",
+            "name" : "dm-node-e0972733-0b72-4f0d-a6e5-372b90063fe2",
+            "type" : "inject",
+            "data" : {
+              "__kuflowDummy" : true
+            },
+            "end" : true
+          }, {
+            "id" : "dm-node-0e7d2afd-1ecc-40a4-ba98-45c291e91177",
+            "name" : "dm-node-0e7d2afd-1ecc-40a4-ba98-45c291e91177",
+            "type" : "callback",
+            "action" : {
+              "functionRef" : {
+                "refName" : "KuFlowCreateTask",
+                "arguments" : {
+                  "taskCode" : "TASK_001",
+                  "owner" : "${ \\"jrodped@kuflow.com\\" }",
+                  "elementValues" : { }
+                }
+              }
+            },
+            "eventRef" : "KuFlowCreateTaskResponseEvent",
+            "transition" : "dm-node-c4381d5e-69ff-462e-b77d-a98080918a0d"
+          }, {
+            "id" : "dm-node-c4381d5e-69ff-462e-b77d-a98080918a0d",
+            "name" : "dm-node-c4381d5e-69ff-462e-b77d-a98080918a0d",
+            "type" : "switch",
+            "dataConditions" : [ {
+              "condition" : "${ .tasks.TASK_001.data.ELEMENT_003 >= (now | todate) }",
+              "transition" : "dm-node-e0972733-0b72-4f0d-a6e5-372b90063fe2"
+            }, {
+              "condition" : "${ .tasks.TASK_001.data.ELEMENT_003 < (now | todate) }",
+              "transition" : "dm-node-4fe0124e-7614-45ac-a5fa-4ce39f6912bf"
+            } ],
+            "defaultCondition" : {
+              "transition" : "dm-node-e0972733-0b72-4f0d-a6e5-372b90063fe2"
+            }
+          }, {
+            "id" : "dm-node-4fe0124e-7614-45ac-a5fa-4ce39f6912bf",
+            "name" : "dm-node-4fe0124e-7614-45ac-a5fa-4ce39f6912bf",
+            "type" : "callback",
+            "action" : {
+              "functionRef" : {
+                "refName" : "KuFlowCreateTask",
+                "arguments" : {
+                  "taskCode" : "TASK_2",
+                  "elementValues" : { }
+                }
+              }
+            },
+            "eventRef" : "KuFlowCreateTaskResponseEvent",
+            "transition" : "dm-node-0e7d2afd-1ecc-40a4-ba98-45c291e91177"
+          } ],
+          "functions" : [ {
+            "name" : "KuFlowCreateTask",
+            "operation" : "https://api.kuflow.com/openapi/specs/api.kuflow.com/v1/openapi.yaml#operation/createTask"
+          } ],
+          "events" : [ {
+            "kind" : "consumed",
+            "name" : "KuFlowCreateTaskResponseEvent",
+            "type" : "com.kuflow.task",
+            "source" : "KuFlowSystem"
+          } ],
+          "metadata" : {
+            "diagram" : "irrelevant",
+            "diagramValid" : "true"
+          }
+        }
+        """;
+
+    List<ValidationError> validationErrors = new WorkflowValidatorImpl().setSource(source).validate();
+
+    Assertions.assertTrue(
+        validationErrors.isEmpty(),
+        () ->
+            "Expected no validation errors but got: "
+                + validationErrors.stream().map(ValidationError::toString).toList());
   }
 }


### PR DESCRIPTION
Upgrade com.fasterxml.jackson 2.22.1 to 3.2.1 (tools.jackson.* coordinates and packages), com.networknt:json-schema-validator 1.5.9 to 3.0.6, and jsonschema2pojo 1.3.1 to 1.3.3.

Jackson 3 no longer allows extending ObjectMapper, so BaseObjectMapper, JsonObjectMapper and YamlObjectMapper become factories built on top of MapperBuilder instead of subclasses. Serializers move from writeXField to writeXProperty and SerializerProvider to SerializationContext, deserializers read trees via JsonParser.readValueAsTree and DeserializationContext.readTreeAsValue, JsonNode.asText is replaced by asString, and IOException handling is dropped in favour of the unchecked JacksonException.

The generated POJOs are configured with annotationStyle jackson3 and the existingJavaType references in the schemas now point to tools.jackson.databind.JsonNode.

json-schema-validator 3 replaces JsonSchemaFactory and ValidationMessage with SchemaRegistry and Error, and no longer prefixes messages with the instance location. The oneOf false positives for start, functions, retries, errors and auth are therefore filtered by keyword and instance location instead of by message text, which is validator-version dependent.

Add a maven-antrun-plugin step to fix the invalid @Valid placement emitted by jsonschema2pojo on fully qualified generic type arguments, which javac rejects on Java 22 and later. See jsonschema2pojo issue 1586.

# Conflicts:
#	pom.xml

**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

**Special notes for reviewers**:

**Additional information (if needed):**